### PR TITLE
fixed incorrect acl json schema

### DIFF
--- a/Kinvey-Xamarin/Model/AccessControlList.cs
+++ b/Kinvey-Xamarin/Model/AccessControlList.cs
@@ -47,7 +47,7 @@ namespace KinveyXamarin
 		public List<string> write {get; set;}
 
 		[JsonProperty("groups")]
-		public List<AclGroups> groups { get; set;}
+		public AclGroups groups { get; set;}
 
 		public AccessControlList(){}
 
@@ -55,10 +55,10 @@ namespace KinveyXamarin
 		public class AclGroups  {
 
 			[JsonProperty("r")]
-			public string read {get; set;}
+			public List<string> read {get; set;}
 
 			[JsonProperty("w")]
-			public string write {get; set;}
+			public List<string> write {get; set;}
 
 			public AclGroups(){}
 


### PR DESCRIPTION
Refers to MLIBZ-1346.

The JSON schema for groups was being parsed incorrectly. Refer to [this](http://devcenter.kinvey.com/rest/guides/security#entityanduserpermissions) for the backend schema for acl groups.
