### PR TITLE
Renamed file methods to follow naming conventions

### DIFF
--- a/Kinvey-Xamarin/File/File.cs
+++ b/Kinvey-Xamarin/File/File.cs
@@ -123,7 +123,7 @@ namespace Kinvey
 		/// <param name="metadata">Metadata associated with the file; supports arbitrary key/value pairs.</param>
 		/// <param name="content">The actual bytes of the file to upload.</param>
 		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> uploadAsync(FileMetaData metadata, byte[] content, CancellationToken ct = default(CancellationToken))
+		public async Task<FileMetaData> UploadAsync(FileMetaData metadata, byte[] content, CancellationToken ct = default(CancellationToken))
 		{
 			UploadFileWithMetaDataRequest uploadRequest = buildUploadFileRequest(metadata);
 			ct.ThrowIfCancellationRequested();
@@ -139,7 +139,7 @@ namespace Kinvey
 		/// <param name="metadata">Metadata associated with the file; supports arbitrary key/value pairs.</param>
 		/// <param name="content">The stream of file content to upload.</param>
 		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> uploadAsync(FileMetaData metadata, Stream content, CancellationToken ct = default(CancellationToken))
+		public async Task<FileMetaData> UploadAsync(FileMetaData metadata, Stream content, CancellationToken ct = default(CancellationToken))
 		{
 			UploadFileWithMetaDataRequest uploadRequest = buildUploadFileRequest(metadata);
 			ct.ThrowIfCancellationRequested();
@@ -154,7 +154,7 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="metadata">The updated FileMetaData to upload to Kinvey.</param>
 		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> uploadMetadataAsync(FileMetaData metadata, CancellationToken ct = default(CancellationToken))
+		public async Task<FileMetaData> UploadMetadataAsync(FileMetaData metadata, CancellationToken ct = default(CancellationToken))
 		{
 			UploadMetaDataRequest uploadMetaDataRequest = buildUploadMetaDataRequest(metadata);
 			ct.ThrowIfCancellationRequested();
@@ -172,7 +172,7 @@ namespace Kinvey
 		/// <param name="metadata">The FileMetaData representing the file to download.  This must contain an id.</param>
 		/// <param name="content">Content.</param>
 		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> downloadAsync(FileMetaData metadata, byte[] content, CancellationToken ct = default(CancellationToken))
+		public async Task<FileMetaData> DownloadAsync(FileMetaData metadata, byte[] content, CancellationToken ct = default(CancellationToken))
 		{
 			DownloadFileWithMetaDataRequest downloadRequest = buildDownloadFileRequest(metadata);
 			ct.ThrowIfCancellationRequested();
@@ -188,7 +188,7 @@ namespace Kinvey
 		/// <param name="metadata">The FileMetaData representing the file to download.  This must contain an id.</param>
 		/// <param name="content">Where the contents of the file will be streamed.</param>
 		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> downloadAsync(FileMetaData metadata, Stream content, CancellationToken ct = default(CancellationToken))
+		public async Task<FileMetaData> DownloadAsync(FileMetaData metadata, Stream content, CancellationToken ct = default(CancellationToken))
 		{
 			DownloadFileWithMetaDataRequest downloadRequest = buildDownloadFileRequest(metadata);
 			ct.ThrowIfCancellationRequested();
@@ -203,7 +203,7 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="fileId">The _id of the file's metadata to download. </param>
 		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> downloadMetadataAsync(string fileId, CancellationToken ct = default(CancellationToken))
+		public async Task<FileMetaData> DownloadMetadataAsync(string fileId, CancellationToken ct = default(CancellationToken))
 		{
 			DownloadMetaDataRequest downloadMetadataRequest = buildDownloadMetaDataRequest(fileId);
 			ct.ThrowIfCancellationRequested();
@@ -220,7 +220,7 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="fileId">The _id of the file to delete.</param>
 		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<KinveyDeleteResponse> delete(string fileId, CancellationToken ct = default(CancellationToken))
+		public async Task<KinveyDeleteResponse> Delete(string fileId, CancellationToken ct = default(CancellationToken))
 		{
 			DeleteFileAndMetaDataRequest request = buildDeleteFileRequest(fileId);
 			ct.ThrowIfCancellationRequested();

--- a/TestFramework/Tests.Integration/Tests/FileIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/FileIntegrationTests.cs
@@ -63,7 +63,7 @@ namespace TestFramework
 			fileMetaData.size = contentSize;
 
 			// Act
-			FileMetaData fmd = await kinveyClient.File().uploadAsync(fileMetaData, content);
+			FileMetaData fmd = await kinveyClient.File().UploadAsync(fileMetaData, content);
 
 			// Assert
 			Assert.NotNull(fmd);
@@ -91,7 +91,7 @@ namespace TestFramework
 			fileMetaData.size = contentSize;
 
 			// Act
-			FileMetaData fmd = await Client.SharedClient.File().uploadAsync(fileMetaData, content);
+			FileMetaData fmd = await Client.SharedClient.File().UploadAsync(fileMetaData, content);
 
 			// Assert
 			Assert.NotNull(fmd);
@@ -121,7 +121,7 @@ namespace TestFramework
 			MemoryStream streamContent = new MemoryStream(content);
 
 			// Act
-			FileMetaData fmd = await kinveyClient.File().uploadAsync(fileMetaData, streamContent);
+			FileMetaData fmd = await kinveyClient.File().UploadAsync(fileMetaData, streamContent);
 
 			// Assert
 			Assert.NotNull(fmd);
@@ -147,7 +147,7 @@ namespace TestFramework
 			// Assert
 			Assert.CatchAsync(async delegate ()
 			{
-				await kinveyClient.File().uploadAsync(fileMetaData, content);
+				await kinveyClient.File().UploadAsync(fileMetaData, content);
 			});
 
 			// Teardown
@@ -169,13 +169,13 @@ namespace TestFramework
 			int contentSize = (content.Length) * sizeof(byte);
 			fileMetaData.size = contentSize;
 
-			FileMetaData fmd = await kinveyClient.File().uploadAsync(fileMetaData, content);
+			FileMetaData fmd = await kinveyClient.File().UploadAsync(fileMetaData, content);
 
 			fmd._public = !publicAccess;
 			fmd.fileName = "test.png";
 
 			// Act
-			FileMetaData fmdUpdate = await kinveyClient.File().uploadMetadataAsync(fmd);
+			FileMetaData fmdUpdate = await kinveyClient.File().UploadMetadataAsync(fmd);
 
 			// Assert
 			Assert.NotNull(fmdUpdate);
@@ -200,7 +200,7 @@ namespace TestFramework
 			// Assert
 			Assert.CatchAsync(async delegate ()
 			{
-				await kinveyClient.File().uploadMetadataAsync(fileMetaData);
+				await kinveyClient.File().UploadMetadataAsync(fileMetaData);
 			});
 
 			// Teardown
@@ -221,15 +221,15 @@ namespace TestFramework
 			byte[] content = System.IO.File.ReadAllBytes(image_path);
 			int contentSize = (content.Length) * sizeof(byte);
 			uploadMetaData.size = contentSize;
-			FileMetaData uploadFMD = await kinveyClient.File().uploadAsync(uploadMetaData, content);
+			FileMetaData uploadFMD = await kinveyClient.File().UploadAsync(uploadMetaData, content);
 
 			FileMetaData downloadMetaData = new FileMetaData();
-			downloadMetaData = await kinveyClient.File().downloadMetadataAsync(uploadFMD.id);
+			downloadMetaData = await kinveyClient.File().DownloadMetadataAsync(uploadFMD.id);
 			downloadMetaData.id = uploadFMD.id;
 			byte[] downloadContent = new byte[downloadMetaData.size];
 
 			// Act
-			FileMetaData downloadFMD = await kinveyClient.File().downloadAsync(downloadMetaData, downloadContent);
+			FileMetaData downloadFMD = await kinveyClient.File().DownloadAsync(downloadMetaData, downloadContent);
 			System.IO.File.WriteAllBytes(downloadByteArrayFilePath, content);
 
 			// Assert
@@ -255,15 +255,15 @@ namespace TestFramework
 			int contentSize = (content.Length) * sizeof(byte);
 			uploadMetaData.size = contentSize;
 			MemoryStream uploadStreamContent = new MemoryStream(content);
-			FileMetaData uploadFMD = await kinveyClient.File().uploadAsync(uploadMetaData, uploadStreamContent);
+			FileMetaData uploadFMD = await kinveyClient.File().UploadAsync(uploadMetaData, uploadStreamContent);
 
 			FileMetaData downloadMetaData = new FileMetaData();
-			downloadMetaData = await kinveyClient.File().downloadMetadataAsync(uploadFMD.id);
+			downloadMetaData = await kinveyClient.File().DownloadMetadataAsync(uploadFMD.id);
 			downloadMetaData.id = uploadFMD.id;
 			MemoryStream downloadStreamContent = new MemoryStream();
 
 			// Act
-			FileMetaData downloadFMD = await kinveyClient.File().downloadAsync(downloadMetaData, downloadStreamContent);
+			FileMetaData downloadFMD = await kinveyClient.File().DownloadAsync(downloadMetaData, downloadStreamContent);
 			FileStream fs = new FileStream(downloadStreamFilePath, FileMode.Create);
 			downloadStreamContent.WriteTo(fs);
 			downloadStreamContent.Close();
@@ -291,7 +291,7 @@ namespace TestFramework
 			// Assert
 			Assert.CatchAsync(async delegate ()
 			{
-				await kinveyClient.File().downloadAsync(fileMetaData, content);
+				await kinveyClient.File().DownloadAsync(fileMetaData, content);
 			});
 
 			// Teardown
@@ -312,10 +312,10 @@ namespace TestFramework
 			byte[] content = System.IO.File.ReadAllBytes(image_path);
 			int contentSize = (content.Length) * sizeof(byte);
 			uploadMetaData.size = contentSize;
-			FileMetaData uploadFMD = await kinveyClient.File().uploadAsync(uploadMetaData, content);
+			FileMetaData uploadFMD = await kinveyClient.File().UploadAsync(uploadMetaData, content);
 
 			// Act
-			FileMetaData downloadMetaData = await kinveyClient.File().downloadMetadataAsync(uploadFMD.id);
+			FileMetaData downloadMetaData = await kinveyClient.File().DownloadMetadataAsync(uploadFMD.id);
 
 			// Assert
 			Assert.NotNull(downloadMetaData);
@@ -338,7 +338,7 @@ namespace TestFramework
 			// Assert
 			Assert.CatchAsync(async delegate ()
 			{
-				await kinveyClient.File().downloadMetadataAsync(fileID);
+				await kinveyClient.File().DownloadMetadataAsync(fileID);
 			});
 
 			// Teardown


### PR DESCRIPTION
#### Description
`File` APIs we using the wrong naming convention. This PR fixes the method names to start with uppercase chars.

#### Changes
Method names have changed. This will be a breaking change.

#### Tests
Compilation succeeds. No change in code other than method names.
