### PR TITLE
Mlibz 1709 unregister push

### DIFF
--- a/Kinvey-Xamarin/AbstractPush.cs
+++ b/Kinvey-Xamarin/AbstractPush.cs
@@ -81,10 +81,6 @@ namespace KinveyXamarin
 			[JsonProperty]
 			private String deviceId {get; set;}
 
-			public PushPayload(string platform) {
-				this.platform = platform;
-			}
-
 			public PushPayload(string platform, string deviceId) {
 				this.platform = platform;
 				this.deviceId = deviceId;

--- a/Kinvey-Xamarin/AbstractPush.cs
+++ b/Kinvey-Xamarin/AbstractPush.cs
@@ -43,7 +43,7 @@ namespace KinveyXamarin
 			var urlParameters = new Dictionary<string, string>();
 			urlParameters.Add("appKey", ((KinveyClientRequestInitializer)client.RequestInitializer).AppKey);
 
-			PushPayload input = new PushPayload (platform);
+			PushPayload input = new PushPayload (platform, deviceId);
 
 			RemovePush disable = new RemovePush (client, input, urlParameters);
 


### PR DESCRIPTION
#### Description
Fixes the problem with unregistering push device tokens.

#### Changes
- Add the device token parameter to the unregister request. 
- Remove the constructor for `PushPayload` that takes a single parameter, since it should never be used.

#### Tests
- Tested locally to confirm that the push payload in the request is correct.
- Tested the backend against REST API to confirm that the correct payload results in unregistering the token.