### PR TITLE
Fixed push unregister bug on v3

### DIFF
--- a/Kinvey-Xamarin/Push/AbstractPush.cs
+++ b/Kinvey-Xamarin/Push/AbstractPush.cs
@@ -56,7 +56,7 @@ namespace Kinvey
 			var urlParameters = new Dictionary<string, string>();
 			urlParameters.Add("appKey", ((KinveyClientRequestInitializer)client.RequestInitializer).AppKey);
 
-			PushPayload input = new PushPayload (platform);
+			PushPayload input = new PushPayload (platform, deviceId);
 
 			RemovePush disable = new RemovePush (client, input, urlParameters);
 
@@ -93,10 +93,6 @@ namespace Kinvey
 
 			[JsonProperty]
 			private String deviceId {get; set;}
-
-			public PushPayload(string platform) {
-				this.platform = platform;
-			}
 
 			public PushPayload(string platform, string deviceId) {
 				this.platform = platform;


### PR DESCRIPTION
#### Description
Fixes the problem with unregistering push device tokens. (This PR corresponds to https://github.com/Kinvey/dotnet-sdk/pull/97 on v1)

#### Changes
- Add the device token parameter to the unregister request. 
- Remove the constructor for `PushPayload` that takes a single parameter, since it should never be used.

#### Tests
- Tested locally to confirm that the push payload in the request is correct.
- Tested the backend against REST API to confirm that the correct payload results in unregistering the token.