### PR TITLE
Prevent exception during delta set fetch, when `lmt` is missing

### DIFF
--- a/Kinvey-Xamarin/Store/ReadRequest.cs
+++ b/Kinvey-Xamarin/Store/ReadRequest.cs
@@ -92,7 +92,9 @@ namespace Kinvey
 			foreach (var cacheItem in cacheItems)
 			{
 				Entity item = cacheItem as Entity;
-				dictCachedEntities.Add(item.ID, item.KMD.lastModifiedTime);
+				if (item.KMD?.lastModifiedTime != null) {  //if lmt doesn't exist for cache entity, avoid crashing
+					dictCachedEntities.Add(item.ID, item.KMD.lastModifiedTime);
+				}
 			}
 
 			List<string> listCachedEntitiesToRemove = new List<string>(dictCachedEntities.Keys);


### PR DESCRIPTION
#### Description
This PR adds safety checks to delta set fetch. In MLIBZ-1409, a crash was reported during delta fetch. While I was unable to reproduce the cache, the stack trace suggests a missing `lmt` from a third party data source could have caused it.

#### Changes
If `lmt` is missing, delta set caching will be ignored and the fetch will default to a network fetch.

#### Tests
All existing tests pass.