### PR TITLE
MLIBZ-1539 Initial commit of code and packages to retrieve device info

### DIFF
--- a/Kinvey-Xamarin-Android.nuspec
+++ b/Kinvey-Xamarin-Android.nuspec
@@ -23,6 +23,7 @@
       <dependency id="SQLite.Net-PCL" version="3.1.1"/>
       <dependency id="Xamarin.GooglePlayServices.Gcm" version="27.0.0.0"/>
       <dependency id="Kinvey" version="3.0.2"/>
+      <dependency id="Xam.Plugin.DeviceInfo" version="2.1.2"/>
     </dependencies>
   </metadata>
   <files>

--- a/Kinvey-Xamarin-Android/Kinvey-Xamarin-Android.csproj
+++ b/Kinvey-Xamarin-Android/Kinvey-Xamarin-Android.csproj
@@ -14,6 +14,7 @@
     <AndroidUseLatestPlatformSdk>false</AndroidUseLatestPlatformSdk>
     <AssemblyName>Kinvey-Xamarin-Android</AssemblyName>
     <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
+    <AndroidTlsProvider></AndroidTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,6 +57,15 @@
     <Reference Include="Xamarin.Android.Support.v4">
       <HintPath>..\packages\Xamarin.Android.Support.v4.23.1.1.0\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
     </Reference>
+    <Reference Include="Plugin.CurrentActivity">
+      <HintPath>..\packages\Plugin.CurrentActivity.1.0.1\lib\MonoAndroid10\Plugin.CurrentActivity.dll</HintPath>
+    </Reference>
+    <Reference Include="Plugin.DeviceInfo.Abstractions">
+      <HintPath>..\packages\Xam.Plugin.DeviceInfo.2.1.2\lib\MonoAndroid10\Plugin.DeviceInfo.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Plugin.DeviceInfo">
+      <HintPath>..\packages\Xam.Plugin.DeviceInfo.2.1.2\lib\MonoAndroid10\Plugin.DeviceInfo.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Push\KinveyGCMService.cs" />
@@ -64,6 +74,7 @@
     <Compile Include="Auth\AndroidNativeCredentialStore.cs" />
     <Compile Include="Auth\KinveyAccountService.cs" />
     <Compile Include="Auth\UserExtension.cs" />
+    <Compile Include="MainApplication.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Kinvey-Xamarin-Android/MainApplication.cs
+++ b/Kinvey-Xamarin-Android/MainApplication.cs
@@ -1,0 +1,63 @@
+using System;
+
+using Android.App;
+using Android.OS;
+using Android.Runtime;
+using Plugin.CurrentActivity;
+
+namespace KinveyXamarinAndroid
+{
+	//You can specify additional application information in this attribute
+    [Application]
+    public class MainApplication : Application, Application.IActivityLifecycleCallbacks
+    {
+        public MainApplication(IntPtr handle, JniHandleOwnership transer)
+          :base(handle, transer)
+        {
+        }
+
+        public override void OnCreate()
+        {
+            base.OnCreate();
+            RegisterActivityLifecycleCallbacks(this);
+            //A great place to initialize Xamarin.Insights and Dependency Services!
+        }
+
+        public override void OnTerminate()
+        {
+            base.OnTerminate();
+            UnregisterActivityLifecycleCallbacks(this);
+        }
+
+        public void OnActivityCreated(Activity activity, Bundle savedInstanceState)
+        {
+            CrossCurrentActivity.Current.Activity = activity;
+        }
+
+        public void OnActivityDestroyed(Activity activity)
+        {
+        }
+
+        public void OnActivityPaused(Activity activity)
+        {
+        }
+
+        public void OnActivityResumed(Activity activity)
+        {
+            CrossCurrentActivity.Current.Activity = activity;
+        }
+
+        public void OnActivitySaveInstanceState(Activity activity, Bundle outState)
+        {
+        }
+
+        public void OnActivityStarted(Activity activity)
+        {
+            CrossCurrentActivity.Current.Activity = activity;
+        }
+
+        public void OnActivityStopped(Activity activity)
+        {
+        }
+    }
+}

--- a/Kinvey-Xamarin-Android/packages.config
+++ b/Kinvey-Xamarin-Android/packages.config
@@ -2,6 +2,8 @@
 <packages>
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="MonoAndroid50" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="MonoAndroid50" />
+  <package id="Plugin.CurrentActivity" version="1.0.1" targetFramework="monoandroid70" />
+  <package id="Xam.Plugin.DeviceInfo" version="2.1.2" targetFramework="monoandroid70" />
   <package id="Xamarin.Android.Support.v4" version="23.1.1.0" targetFramework="MonoAndroid50" />
   <package id="Xamarin.GooglePlayServices.Base" version="27.0.0.0" targetFramework="MonoAndroid50" />
   <package id="Xamarin.GooglePlayServices.Basement" version="27.0.0.0" targetFramework="MonoAndroid50" />

--- a/Kinvey-Xamarin-iOS.nuspec
+++ b/Kinvey-Xamarin-iOS.nuspec
@@ -22,6 +22,7 @@
       <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
       <dependency id="SQLite.Net-PCL" version="3.1.1"/>
       <dependency id="Kinvey" version="3.0.2"/>
+      <dependency id="Xam.Plugin.DeviceInfo" version="2.1.2"/>
     </dependencies>
   </metadata>
   <files>

--- a/Kinvey-Xamarin-iOS/Kinvey-Xamarin-iOS.csproj
+++ b/Kinvey-Xamarin-iOS/Kinvey-Xamarin-iOS.csproj
@@ -44,6 +44,12 @@
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\portable-net40+sl5+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System.Json" />
+    <Reference Include="Plugin.DeviceInfo.Abstractions">
+      <HintPath>..\packages\Xam.Plugin.DeviceInfo.2.1.2\lib\Xamarin.iOS10\Plugin.DeviceInfo.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Plugin.DeviceInfo">
+      <HintPath>..\packages\Xam.Plugin.DeviceInfo.2.1.2\lib\Xamarin.iOS10\Plugin.DeviceInfo.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/Kinvey-Xamarin-iOS/packages.config
+++ b/Kinvey-Xamarin-iOS/packages.config
@@ -4,4 +4,5 @@
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="xamarinios10" />
   <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="xamarinios10" />
   <package id="Newtonsoft.Json" version="8.0.2" targetFramework="xamarinios10" />
+  <package id="Xam.Plugin.DeviceInfo" version="2.1.2" targetFramework="xamarinios10" />
 </packages>

--- a/Kinvey-Xamarin.nuspec
+++ b/Kinvey-Xamarin.nuspec
@@ -22,6 +22,7 @@
       <dependency id="Remotion.Linq" version="2.0.1"/>
       <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
       <dependency id="SQLite.Net-PCL" version="3.1.1"/>
+      <dependency id="Xam.Plugin.DeviceInfo" version="2.1.2"/>
     </dependencies>
   </metadata>
   <files>

--- a/Kinvey-Xamarin/Core/KinveyHeaders.cs
+++ b/Kinvey-Xamarin/Core/KinveyHeaders.cs
@@ -13,9 +13,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using RestSharp;
 
 namespace Kinvey
@@ -26,36 +23,52 @@ namespace Kinvey
     public class KinveyHeaders : List<HttpHeader>
     {
 		/// <summary>
-		/// The version of the library.
+		/// The version of the SDK.
 		/// </summary>
 		public static string VERSION = "3.0.2";
 
-		/// <summary>
-		/// The kinvey API version key.
-		/// </summary>
-        private static string kinveyApiVersionKey = "X-Kinvey-API-Version";
-		/// <summary>
-		/// The kinvey API version.
-		/// </summary>
-        private static string kinveyApiVersion = "3";
+		// The kinvey API version.
+        static string kinveyApiVersionKey = "X-Kinvey-API-Version";
+        static string kinveyApiVersion = "3";
+
+		// The user agent.
+        static string userAgentKey = "user-agent";
+		string userAgent = "xamarin-kinvey-http/" + VERSION;
+
+		// The device info, which includes the OS and OS version, as well as the device model.
+		static string kinveyDeviceInfoKey = "X-Kinvey-Device-Info";
+		static string _kinveyDeviceInfo = null;
+
+		static string KinveyDeviceInfo
+		{
+			get
+			{
+				if (_kinveyDeviceInfo == null)
+				{
+					try
+					{
+						_kinveyDeviceInfo = Plugin.DeviceInfo.CrossDeviceInfo.Current?.Platform + " " +
+											Plugin.DeviceInfo.CrossDeviceInfo.Current?.Version + " " +
+											Plugin.DeviceInfo.CrossDeviceInfo.Current?.Model;
+					}
+					catch (Exception e)
+					{
+						_kinveyDeviceInfo = String.Empty;
+					}
+				}
+
+				return _kinveyDeviceInfo;
+			}
+		}
 
 		/// <summary>
-		/// The user agent key.
+		/// Initializes a new instance of the <see cref="KinveyHeaders"/> class.
 		/// </summary>
-        private static string userAgentKey = "user-agent";
-		/// <summary>
-		/// The user agent.
-		/// </summary>
-		private string userAgent = "xamarin-kinvey-http/" + VERSION;
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="KinveyXamarin.KinveyHeaders"/> class.
-		/// </summary>
-        public KinveyHeaders() : base()
+        public KinveyHeaders()
         {
-			this.Add(new HttpHeader() {Name = userAgentKey, Value = new List<string>(){userAgent}});
-			this.Add(new HttpHeader() {Name = kinveyApiVersionKey, Value = new List<string>(){kinveyApiVersion}});
+			Add(new HttpHeader { Name = userAgentKey, Value = new List<string> { userAgent } });
+			Add(new HttpHeader { Name = kinveyApiVersionKey, Value = new List<string> { kinveyApiVersion } });
+			Add(new HttpHeader { Name = kinveyDeviceInfoKey, Value = new List<string> { KinveyDeviceInfo } });
         }
-
     }
 }

--- a/Kinvey-Xamarin/Kinvey-Xamarin.csproj
+++ b/Kinvey-Xamarin/Kinvey-Xamarin.csproj
@@ -175,6 +175,12 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\packages\Newtonsoft.Json.8.0.2\lib\portable-net45+wp80+win8+wpa81+dnxcore50\Newtonsoft.Json.dll</HintPath>
     </Reference>
+    <Reference Include="Plugin.DeviceInfo.Abstractions">
+      <HintPath>..\packages\Xam.Plugin.DeviceInfo.2.1.2\lib\portable-net45+wp80+win8+wpa81\Plugin.DeviceInfo.Abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="Plugin.DeviceInfo">
+      <HintPath>..\packages\Xam.Plugin.DeviceInfo.2.1.2\lib\portable-net45+wp80+win8+wpa81\Plugin.DeviceInfo.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kinvey-Utils\Kinvey-Utils.csproj">

--- a/Kinvey-Xamarin/packages.config
+++ b/Kinvey-Xamarin/packages.config
@@ -11,4 +11,5 @@
   <package id="SQLite.Net.Core-PCL" version="3.1.1" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
   <package id="SQLite.Net-PCL" version="3.1.1" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
   <package id="System.Data.SQLite" version="1.0.103" targetFramework="portable45-net45+win8+wp8" />
+  <package id="Xam.Plugin.DeviceInfo" version="2.1.2" targetFramework="portable45-net45+win8+wp8" />
 </packages>


### PR DESCRIPTION
#### Description
This PR is for adding device info in request headers.  This is done in the `X-Kinvey-Device-Info` header.  This information includes OS, OS version, and basic device model.

Example iOS output:  `X-Kinvey-Device-Info -> iOS 10.2 iPhone`
Example Android output: `X-Kinvey-Device-Info -> Android 4.4.2 GT-P5210`

#### Changes
The `Xam.Plugin.DeviceInfo` package was added as a dependency for our PCL as well as our platform packages.  In addition to this, a new header was added to our requests.

#### Tests
No new tests are added here, because the device info package does not support getting information from a Mac OS.  The test that this is working as intended is the fact that all current tests pass as normal, despite not being able to retrieve device info on the Mac.