### PR TITLE
Added apis to clear cache and purge the sync queue

### DIFF
--- a/Kinvey-Xamarin/Model/KinveyDeleteResponse.cs
+++ b/Kinvey-Xamarin/Model/KinveyDeleteResponse.cs
@@ -12,6 +12,7 @@
 // contents is a violation of applicable laws.
 
 using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 
 namespace Kinvey
@@ -26,13 +27,21 @@ namespace Kinvey
 		/// Initializes a new instance of the <see cref="KinveyXamarin.KinveyDeleteResponse"/> class.
 		/// </summary>
 		public KinveyDeleteResponse ()
-		{}
+		{
+		}
 		/// <summary>
 		/// Gets or sets the count of entities deleted.
 		/// </summary>
 		/// <value>The count.</value>
 		[JsonProperty]
 		public int count{get; set;}
+
+		/// <summary>
+		/// Represents the IDs of the entities deleted, when available.
+		/// For internal use only.
+		/// </summary>
+		/// <value>List of IDs for deleted entities</value>
+		internal List<string> IDs { get; set;}
 	}
 }
 

--- a/Kinvey-Xamarin/Offline/ICache.cs
+++ b/Kinvey-Xamarin/Offline/ICache.cs
@@ -112,7 +112,7 @@ namespace Kinvey
 		/// </summary>
 		/// <returns>A KinveyDeleteResponse object.</returns>
 		/// <param name="expr">Expression derived from QueryModel object.</param>
-		KinveyDeleteResponse Clear(Expression expr);
+		KinveyDeleteResponse Clear(Expression expr = null);
 
 		/// <summary>
 		/// Deletes the cached item by ID.

--- a/Kinvey-Xamarin/Offline/ISyncQueue.cs
+++ b/Kinvey-Xamarin/Offline/ISyncQueue.cs
@@ -31,6 +31,7 @@ namespace Kinvey
 		PendingWriteAction GetByID(string entityId);
 
 		int Remove (string entityId);
+		int Remove(List<string> entityIDs);
 		int RemoveAll ();
 	}
 }

--- a/Kinvey-Xamarin/Offline/SQLiteSyncQueue.cs
+++ b/Kinvey-Xamarin/Offline/SQLiteSyncQueue.cs
@@ -127,6 +127,19 @@ namespace Kinvey
 			return dbConnection.Delete(item);
 		}
 
+		public int Remove(List<string> entityIDs) {
+			if (entityIDs == null) 
+			{
+				return RemoveAll();
+			}
+
+			int ret = 0;
+			foreach (var id in entityIDs) {
+				ret += this.Remove(id);
+			}
+			return ret;
+		}
+
 		public int RemoveAll () {
 			return  dbConnection.DeleteAll <PendingWriteAction> ();
 		}

--- a/Kinvey-Xamarin/Store/DataStore.cs
+++ b/Kinvey-Xamarin/Store/DataStore.cs
@@ -368,6 +368,33 @@ namespace Kinvey
 			return syncQueue.Count(allCollections);
 		}
 
+		/// <summary>
+		/// Removes data from local storage. This does not affect the backend.
+		/// </summary>
+		/// <returns>Details of the clear operation, including the number of entities that were cleared.</returns>
+		/// <param name="query">Optional Query parameter.</param>
+		public KinveyDeleteResponse ClearCache(IQueryable<T> query = null)
+		{
+			var ret = cache.Clear(query?.Expression);
+			if (ret?.IDs != null)
+			{
+				syncQueue.Remove(ret.IDs);
+			}
+			else {
+				syncQueue.RemoveAll();
+			}
+			return ret;
+		}
+
+		/// <summary>
+		/// Removes pending write operations from local storage. This prevents changes made on the client from being persisted on the backend.
+		/// </summary>
+		/// <returns>The number of pending operations that were purged.</returns>
+		public int Purge()
+		{
+			return syncQueue.RemoveAll();
+		}
+
 		#endregion
 
 		#region Requests

--- a/Kinvey-Xamarin/Store/DataStore.cs
+++ b/Kinvey-Xamarin/Store/DataStore.cs
@@ -390,8 +390,19 @@ namespace Kinvey
 		/// Removes pending write operations from local storage. This prevents changes made on the client from being persisted on the backend.
 		/// </summary>
 		/// <returns>The number of pending operations that were purged.</returns>
-		public int Purge()
+		/// <param name="query">Optional Query parameter.</param>
+		public int Purge(IQueryable<T> query = null)
 		{
+			if (query!=null) 
+			{
+				var ids = new List<string>();
+				var entities = cache.FindByQuery(query.Expression);
+				foreach (var entity in entities) {					
+					ids.Add((entity as IPersistable).ID);
+				}
+				return syncQueue.Remove(ids);
+			}
+
 			return syncQueue.RemoveAll();
 		}
 

--- a/Kinvey-Xamarin/Store/ReadRequest.cs
+++ b/Kinvey-Xamarin/Store/ReadRequest.cs
@@ -86,7 +86,7 @@ namespace Kinvey
 
 			foreach (var cacheItem in cacheItems)
 			{
-				Entity item = cacheItem as Entity;
+				var item = cacheItem as IPersistable;
 				if (item.KMD?.lastModifiedTime != null) {  //if lmt doesn't exist for cache entity, avoid crashing
 					dictCachedEntities.Add(item.ID, item.KMD.lastModifiedTime);
 				}

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -1031,6 +1031,38 @@ namespace TestFramework
 		}
 
 		[Test]
+		public async Task TestPurgeByQuery()
+		{
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			var store = DataStore<Person>.Collection("Person", DataStoreType.SYNC);
+			var person1 = new Person();
+			person1.FirstName = "james";
+			await store.SaveAsync(person1);
+
+			var person2 = new Person();
+			person2.FirstName = "bond";
+			await store.SaveAsync(person2);
+
+			ICache<Person> cache = kinveyClient.CacheManager.GetCache<Person>("Person");
+			Assert.AreEqual(cache.CountAll(), 2);
+			Assert.AreEqual(store.GetSyncCount(), 2);
+
+			var query = store.Where(x => x.FirstName.Equals(person2.FirstName));
+			var result = store.Purge(query);
+			Assert.AreEqual(result, 1);
+			Assert.AreEqual(cache.CountAll(), 2);
+			Assert.AreEqual(store.GetSyncCount(), 1);
+
+			kinveyClient.ActiveUser.Logout();
+		}
+
+		[Test]
 		public async Task TestClear() { 
 			if (kinveyClient.ActiveUser != null)
 			{

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -1009,6 +1009,82 @@ namespace TestFramework
 			kinveyClient.ActiveUser.Logout();
 		}
 
+		[Test]
+		public async Task TestPurge() { 
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			var store = DataStore<Person>.Collection("Person", DataStoreType.SYNC);
+			await store.SaveAsync(new Person());
+			Assert.AreEqual(store.GetSyncCount(), 1);
+
+			store.Purge();
+			Assert.AreEqual(store.GetSyncCount(), 0);
+			ICache<Person> cache = kinveyClient.CacheManager.GetCache<Person>("Person");
+			Assert.AreEqual(cache.CountAll(), 1);
+
+			kinveyClient.ActiveUser.Logout();
+		}
+
+		[Test]
+		public async Task TestClear() { 
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			var store = DataStore<Person>.Collection("Person", DataStoreType.SYNC);
+			await store.SaveAsync(new Person());
+
+			ICache<Person> cache = kinveyClient.CacheManager.GetCache<Person>("Person");
+			Assert.AreEqual(cache.CountAll(), 1);
+			Assert.AreEqual(store.GetSyncCount(), 1);
+
+			var result = store.ClearCache();
+			Assert.AreEqual(result.count, 1);
+			Assert.AreEqual(cache.CountAll(), 0);
+			Assert.AreEqual(store.GetSyncCount(), 0);
+
+			kinveyClient.ActiveUser.Logout();
+		}
+
+		[Test]
+		public async Task TestClearByQuery()
+		{
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			var store = DataStore<Person>.Collection("Person", DataStoreType.SYNC);
+			var person1 = new Person();
+			person1.FirstName = "james";
+			await store.SaveAsync(person1);
+
+			var person2 = new Person();
+			person2.FirstName = "bond";
+			await store.SaveAsync(person2);
+
+			ICache<Person> cache = kinveyClient.CacheManager.GetCache<Person>("Person");
+			Assert.AreEqual(cache.CountAll(), 2);
+			Assert.AreEqual(store.GetSyncCount(), 2);
+
+			var query = store.Where(x => x.FirstName.Equals(person2.FirstName));
+			var result = store.ClearCache(query);
+			Assert.AreEqual(result.count, 1);
+			Assert.AreEqual(cache.CountAll(), 1);
+			Assert.AreEqual(store.GetSyncCount(), 1);
+
+			kinveyClient.ActiveUser.Logout();
+		}
 		#endregion
 	}
 }


### PR DESCRIPTION
#### Description
New `DataStore` APIs - `ClearCache()` and `Purge()`

#### Changes
- Minor changes to the `ICache` and `ISyncQueue` interfaces (backwards compatible)
- New tests to cover the new APIs

#### Tests
Added new tests to cover the new APIs
