### PR TITLE
Feature/mlibz 1739 pushing deleted item failing

### DIFF
--- a/Kinvey-Xamarin/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey-Xamarin/Core/AbstractKinveyClientRequest.cs
@@ -560,6 +560,13 @@ namespace Kinvey
 				throw ke;
 			}
 
+			if (((int)response.StatusCode) < 200 || ((int)response.StatusCode) > 302)
+			{
+				KinveyException kinveyException = new KinveyException(EnumErrorCategory.ERROR_DATASTORE_NETWORK, EnumErrorCode.ERROR_JSON_RESPONSE, response);
+				kinveyException.RequestID = HelperMethods.getRequestID(response);
+				throw kinveyException;
+			}
+
 			try
 			{
 				return JsonConvert.DeserializeObject<T>(response.Content);

--- a/Kinvey-Xamarin/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey-Xamarin/Core/AbstractKinveyClientRequest.cs
@@ -562,7 +562,7 @@ namespace Kinvey
 
 			if (((int)response.StatusCode) < 200 || ((int)response.StatusCode) > 302)
 			{
-				KinveyException kinveyException = new KinveyException(EnumErrorCategory.ERROR_DATASTORE_NETWORK, EnumErrorCode.ERROR_JSON_RESPONSE, response);
+				KinveyException kinveyException = new KinveyException(EnumErrorCategory.ERROR_BACKEND, EnumErrorCode.ERROR_JSON_RESPONSE, response);
 				kinveyException.RequestID = HelperMethods.getRequestID(response);
 				throw kinveyException;
 			}

--- a/Kinvey-Xamarin/Offline/SQLiteSyncQueue.cs
+++ b/Kinvey-Xamarin/Offline/SQLiteSyncQueue.cs
@@ -54,7 +54,14 @@ namespace Kinvey
 				else if (pending.action == "DELETE")
 				{
 					// no matter what, favor the current deletion
-					this.Remove(existingSyncItem.entityId);
+					int countDeleted = this.Remove(existingSyncItem.entityId);
+
+					// If the existing item that is being deleted is something that only existed locally,
+					// do not insert the DELETE action into the queue, since it is local-only
+					if (existingSyncItem.entityId.StartsWith("temp_", StringComparison.OrdinalIgnoreCase))
+					{
+						return countDeleted;
+					}
 				}
 			}
 

--- a/Kinvey-Xamarin/Offline/SQLiteSyncQueue.cs
+++ b/Kinvey-Xamarin/Offline/SQLiteSyncQueue.cs
@@ -54,13 +54,13 @@ namespace Kinvey
 				else if (pending.action == "DELETE")
 				{
 					// no matter what, favor the current deletion
-					int countDeleted = this.Remove(existingSyncItem.entityId);
+					this.Remove(existingSyncItem.entityId);
 
 					// If the existing item that is being deleted is something that only existed locally,
 					// do not insert the DELETE action into the queue, since it is local-only
 					if (existingSyncItem.entityId.StartsWith("temp_", StringComparison.OrdinalIgnoreCase))
 					{
-						return countDeleted;
+						return 0;
 					}
 				}
 			}

--- a/Kinvey-Xamarin/Query/KinveyQueryVisitor.cs
+++ b/Kinvey-Xamarin/Query/KinveyQueryVisitor.cs
@@ -146,8 +146,9 @@ namespace Kinvey
 				string propertyName = mapPropertyToName[name];
 				//name = name.Replace("\"", "\\\"");
 
-				string argument = b.Arguments[0].ToString().Trim('"');
-				argument = argument.Replace("\"", "\\\"");
+				var arg = b.Arguments[0];
+				var argType = arg.Type;
+				string argument = arg.ToString().Trim('"');
 
 				if (b.Method.Name.Equals("StartsWith"))
 				{
@@ -159,6 +160,7 @@ namespace Kinvey
 
 					builderMongoQuery.Write("\"" + propertyName + "\"");
 					builderMongoQuery.Write(":{\"$regex\":\"^");
+					argument = argument.Replace("\"", "\\\"");
 					builderMongoQuery.Write(argument);
 					builderMongoQuery.Write("\"}");
 				}
@@ -172,7 +174,12 @@ namespace Kinvey
 
 					builderMongoQuery.Write("\"" + propertyName + "\"");
 					builderMongoQuery.Write(":");
-					builderMongoQuery.Write("\"" + argument + "\"");
+					if (argType.Name.Equals("String"))
+					{
+						argument = argument.Replace("\"", "\\\"");
+						argument = "\"" + argument + "\"";
+					}
+					builderMongoQuery.Write(argument);
 				}
 				else
 				{

--- a/Kinvey-Xamarin/Store/PushRequest.cs
+++ b/Kinvey-Xamarin/Store/PushRequest.cs
@@ -20,18 +20,22 @@ namespace Kinvey
 {
 	public class PushRequest <T> : WriteRequest<T, PushDataStoreResponse<T>>
 	{
+		int limit;
+		int offset;
+
+		PushDataStoreResponse<T> response;
+
 		public PushRequest(AbstractClient client, string collection, ICache<T> cache, ISyncQueue queue, WritePolicy policy)
 			: base (client, collection, cache, queue, policy)
 		{
+			limit = 3;
+			offset = 0;
+
+			response = new PushDataStoreResponse<T>();
 		}
 
 		public override async Task <PushDataStoreResponse<T>> ExecuteAsync()
 		{
-			PushDataStoreResponse<T> response = new PushDataStoreResponse<T>();
-
-			int limit = 3;
-			int offset = 0;
-
 			List<PendingWriteAction> pendingActions = SyncQueue.GetFirstN(limit, offset);
 
 			while (pendingActions != null && pendingActions.Count > 0)
@@ -39,8 +43,6 @@ namespace Kinvey
 				var tasks = new List<Task<T>>();
 				foreach (PendingWriteAction pwa in pendingActions)
 				{
-					try
-					{
 						if (String.Equals("POST", pwa.action))
 						{
 							tasks.Add(HandlePushPOST(pwa));
@@ -53,18 +55,19 @@ namespace Kinvey
 						{
 							tasks.Add(HandlePushDELETE(pwa));
 						}
-					}
-					catch (Exception e)
-					{
-						//Do nothing for now
-						response.AddKinveyException(new KinveyException(EnumErrorCategory.ERROR_DATASTORE_NETWORK,
-						                                                EnumErrorCode.ERROR_JSON_RESPONSE,
-						                                                "",
-						                                               e));  // TODO provide correct exception
-					}
 				}
-
-				await Task.WhenAll(tasks.ToArray());
+				try
+				{
+					await Task.WhenAll(tasks.ToArray());
+				}
+				catch (Exception e)
+				{
+					//Do nothing for now
+					response.AddKinveyException(new KinveyException(EnumErrorCategory.ERROR_DATASTORE_NETWORK,
+																	EnumErrorCode.ERROR_JSON_RESPONSE,
+																	"",
+																   e));  // TODO provide correct exception
+				}
 
 				List<T> resultEntities = new List<T>();
 				int resultCount = 0;
@@ -94,50 +97,93 @@ namespace Kinvey
 
 		private async Task<T> HandlePushPOST(PendingWriteAction pwa)
 		{
-			int result = 0;
+			T entity = default(T);
 
-			string tempID = pwa.entityId;
-			T entity = Cache.FindByID(pwa.entityId);
+			try
+			{
+				int result = 0;
 
-			JObject obj = JObject.FromObject(entity);
-			obj["_id"] = null;
-			entity = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(obj.ToString());
+				string tempID = pwa.entityId;
 
-			NetworkRequest<T> request = Client.NetworkFactory.buildCreateRequest<T>(pwa.collection, entity);
-			entity = await request.ExecuteAsync();
+				entity = Cache.FindByID(pwa.entityId);
 
-			Cache.UpdateCacheSave(entity, tempID);
+				JObject obj = JObject.FromObject(entity);
+				obj["_id"] = null;
+				entity = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(obj.ToString());
 
-			result = SyncQueue.Remove(tempID);
+				NetworkRequest<T> request = Client.NetworkFactory.buildCreateRequest<T>(pwa.collection, entity);
+				entity = await request.ExecuteAsync();
 
+				Cache.UpdateCacheSave(entity, tempID);
+
+				result = SyncQueue.Remove(tempID);
+
+				if (result == 0)
+				{
+					offset++;
+				}
+			}
+			catch (KinveyException ke)
+			{
+				response.AddKinveyException(ke);
+				offset++;
+			}
 			return entity;
 		}
 
 		private async Task<T> HandlePushPUT(PendingWriteAction pwa)
 		{
-			int result = 0;
+			T entity = default(T);
 
-			string tempID = pwa.entityId;
-			T entity = Cache.FindByID(pwa.entityId);
+			try
+			{
+				int result = 0;
 
-			NetworkRequest<T> request = Client.NetworkFactory.buildUpdateRequest<T>(pwa.collection, entity, pwa.entityId);
-			entity = await request.ExecuteAsync();
+				string tempID = pwa.entityId;
+				entity = Cache.FindByID(pwa.entityId);
 
-			result = SyncQueue.Remove(tempID);
+				NetworkRequest<T> request = Client.NetworkFactory.buildUpdateRequest<T>(pwa.collection, entity, pwa.entityId);
+				entity = await request.ExecuteAsync();
+
+				result = SyncQueue.Remove(tempID);
+
+				if (result == 0)
+				{
+					offset++;
+				}
+			}
+			catch (KinveyException ke)
+			{
+				response.AddKinveyException(ke);
+				offset++;
+			}
 
 			return entity;
 		}
 
 		private async Task<T> HandlePushDELETE(PendingWriteAction pwa)
 		{
-			int result = 0;
-
-			NetworkRequest<KinveyDeleteResponse> request = Client.NetworkFactory.buildDeleteRequest<KinveyDeleteResponse>(pwa.collection, pwa.entityId);
-			KinveyDeleteResponse kdr = await request.ExecuteAsync();
-
-			if (kdr.count == 1)
+			try
 			{
-				result = SyncQueue.Remove(pwa.entityId);
+				int result = 0;
+
+				NetworkRequest<KinveyDeleteResponse> request = Client.NetworkFactory.buildDeleteRequest<KinveyDeleteResponse>(pwa.collection, pwa.entityId);
+				KinveyDeleteResponse kdr = await request.ExecuteAsync();
+
+				if (kdr.count == 1)
+				{
+					result = SyncQueue.Remove(pwa.entityId);
+
+					if (result == 0)
+					{
+						offset++;
+					}
+				}
+			}
+			catch (KinveyException ke)
+			{
+				response.AddKinveyException(ke);
+				offset++;
 			}
 
 			return default(T);

--- a/TestFramework/TestSupportFiles/ToDo.cs
+++ b/TestFramework/TestSupportFiles/ToDo.cs
@@ -14,6 +14,9 @@ namespace TestFramework
 
 		[JsonProperty("due_date")]
 		public string DueDate { get; set; }
+
+		[JsonProperty("value")]
+		public int Value { get; set; }
 	}
 }
 

--- a/TestFramework/Tests.Integration/Tests/ClientIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/ClientIntegrationTests.cs
@@ -174,7 +174,7 @@ namespace TestFramework
 			// Assert
 			Assert.True(e.GetType() == typeof(KinveyException));
 			KinveyException ke = e as KinveyException;
-			Assert.True(ke.ErrorCategory == EnumErrorCategory.ERROR_DATASTORE_NETWORK);
+			Assert.True(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
 			Assert.True(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
 		}
 

--- a/TestFramework/Tests.Integration/Tests/ClientIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/ClientIntegrationTests.cs
@@ -166,12 +166,16 @@ namespace TestFramework
 			Client client = builder.Build();
 
 			// Act
-			PingResponse pr = await client.PingAsync();
+			Exception e = Assert.CatchAsync(async delegate
+			{
+				PingResponse pr = await client.PingAsync();
+			});
 
 			// Assert
-			Assert.IsNotNull(pr);
-			Assert.IsNull(pr.kinvey);
-			Assert.IsNull(pr.version);
+			Assert.True(e.GetType() == typeof(KinveyException));
+			KinveyException ke = e as KinveyException;
+			Assert.True(ke.ErrorCategory == EnumErrorCategory.ERROR_DATASTORE_NETWORK);
+			Assert.True(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
 		}
 
 		[Test]

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -128,7 +128,7 @@ namespace TestFramework
 
 			Assert.NotNull(er);
 			KinveyException ke = er as KinveyException;
-			Assert.AreEqual(EnumErrorCode.ERROR_JSON_PARSE, ke.ErrorCode);
+			Assert.AreEqual(EnumErrorCode.ERROR_GENERAL, ke.ErrorCode);
 
 			// Teardown
 			c.ActiveUser.Logout();

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -291,6 +291,51 @@ namespace TestFramework
 		}
 
 		[Test]
+		public async Task TestNetworkStoreFindByQueryIntValue()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 1;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+
+			var query = todoStore.Where(x => x.Value.Equals(1));
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
 		public async Task TestNetworkStoreFindByQueryNotSupported()
 		{
 			// Setup

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -650,16 +650,16 @@ namespace TestFramework
 			int syncQueueCount = kinveyClient.CacheManager.GetSyncQueue(collectionName).Count(true);
 
 			// Assert
-			Assert.NotNull(pwa);
-			Assert.IsNotNull(pwa.entityId);
-			Assert.IsNotEmpty(pwa.entityId);
-			Assert.True(String.Equals(collectionName, pwa.collection));
-			Assert.True(String.Equals("DELETE", pwa.action));
+			Assert.Null(pwa);
+			//Assert.IsNull(pwa.entityId);
+			//Assert.IsNotEmpty(pwa.entityId);
+			//Assert.True(String.Equals(collectionName, pwa.collection));
+			//Assert.True(String.Equals("DELETE", pwa.action));
 			Assert.NotNull(pushresp);
 			Assert.NotNull(pushresp.KinveyExceptions);
-			Assert.AreEqual(1, pushresp.KinveyExceptions.Count);
-			Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, pushresp.KinveyExceptions.First().ErrorCode);
-			Assert.AreEqual(1, syncQueueCount);
+			Assert.AreEqual(0, pushresp.KinveyExceptions.Count);
+			//Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, pushresp.KinveyExceptions.First().ErrorCode);
+			Assert.AreEqual(0, syncQueueCount);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem.ID);

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -631,6 +631,42 @@ namespace TestFramework
 		}
 
 		[Test]
+		public async Task TestSyncQueueAddThenDelete()
+		{
+			// Setup
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
+			ToDo newItem = new ToDo();
+			newItem.Name = "Task to save to SyncQ";
+			newItem.Details = "A sync add test";
+			newItem = await todoStore.SaveAsync(newItem);
+			var responseDelete = await todoStore.RemoveAsync(newItem.ID);
+
+			// Act
+			PendingWriteAction pwa = kinveyClient.CacheManager.GetSyncQueue(collectionName).Peek();
+			var pushresp = await todoStore.PushAsync();
+			int syncQueueCount = kinveyClient.CacheManager.GetSyncQueue(collectionName).Count(true);
+
+			// Assert
+			Assert.NotNull(pwa);
+			Assert.IsNotNull(pwa.entityId);
+			Assert.IsNotEmpty(pwa.entityId);
+			Assert.True(String.Equals(collectionName, pwa.collection));
+			Assert.True(String.Equals("DELETE", pwa.action));
+			Assert.NotNull(pushresp);
+			Assert.NotNull(pushresp.KinveyExceptions);
+			Assert.AreEqual(1, pushresp.KinveyExceptions.Count);
+			Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, pushresp.KinveyExceptions.First().ErrorCode);
+			Assert.AreEqual(1, syncQueueCount);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem.ID);
+			kinveyClient.ActiveUser.Logout();
+		}
+
+		[Test]
 		public async Task TestSyncQueuePush()
 		{
 			// Setup

--- a/TestFramework/Tests.Unit/Tests/ClientUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/ClientUnitTests.cs
@@ -174,7 +174,7 @@ namespace TestFramework
 			// Assert
 			Assert.True(e.GetType() == typeof(KinveyException));
 			KinveyException ke = e as KinveyException;
-			Assert.True(ke.ErrorCategory == EnumErrorCategory.ERROR_DATASTORE_NETWORK);
+			Assert.True(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
 			Assert.True(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
 		}
 

--- a/TestFramework/Tests.Unit/Tests/ClientUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/ClientUnitTests.cs
@@ -166,12 +166,16 @@ namespace TestFramework
 			Client client = builder.Build();
 
 			// Act
-			PingResponse pr = await client.PingAsync();
+			Exception e = Assert.CatchAsync(async delegate
+			{
+				PingResponse pr = await client.PingAsync();
+			});
 
 			// Assert
-			Assert.IsNotNull(pr);
-			Assert.IsNull(pr.kinvey);
-			Assert.IsNull(pr.version);
+			Assert.True(e.GetType() == typeof(KinveyException));
+			KinveyException ke = e as KinveyException;
+			Assert.True(ke.ErrorCategory == EnumErrorCategory.ERROR_DATASTORE_NETWORK);
+			Assert.True(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
 		}
 
 		[Test]


### PR DESCRIPTION
#### Description
This PR corrects the way we capture errors during a push operation.  In addition, it optimizes for the case where an entity was created locally and then deleted locally, without syncing with the backend system of record.

#### Changes
A change was made to catch 4xx/5xx errors in responses and throw a new `KinveyException`, which will be caught by the tasks in the `PushAsync` operation and used to populate the `PushDataStoreResponse` object.  Changes were also made to offset the items fetched from the sync queue, to make sure that queue items that triggered errors are left in place in the queue, and the queue is properly iterated.

#### Tests
A test was added to check the local add/delete use case.
