### PR TITLE
Reinstate default storetype constructor for datastore

### DIFF
--- a/Kinvey-Xamarin/Store/DataStore.cs
+++ b/Kinvey-Xamarin/Store/DataStore.cs
@@ -39,7 +39,7 @@ namespace Kinvey
 
 		private ISyncQueue syncQueue = null;
 
-		private DataStoreType storeType = DataStoreType.SYNC;
+		private DataStoreType storeType = DataStoreType.CACHE;
 
 		private JObject customRequestProperties = new JObject();
 
@@ -61,8 +61,19 @@ namespace Kinvey
 		}
 
 		/// <summary>
+		/// Gets the type of the store. 
+		/// <seealso cref="Client"/>
+		/// </summary>
+		/// <value>The type of the store.</value>
+		public DataStoreType StoreType
+		{
+			get { return this.storeType; }
+
+		}
+
+		/// <summary>
 		/// Gets or sets the Kinvey client that is used for making data requests. 
-		/// <seealso cref="KinveyXamarin.Client"/>
+		/// <seealso cref="DataStoreType"/>
 		/// </summary>
 		/// <value>The Kinvey client.</value>
 		public AbstractClient KinveyClient
@@ -126,6 +137,16 @@ namespace Kinvey
 		}
 
 		#region Public interface
+		/// <summary>
+		/// Gets an instance of the <see cref="KinveyXamarin.DataStore{T}"/>.
+		/// </summary>
+		/// <returns>The DataStore instance.</returns>
+		/// <param name="collectionName">Collection name of the Kinvey collection backing this DataStore</param>
+		/// <param name="client">Kinvey Client used by this DataStore (optional). If the client is not specified, the <see cref="KinveyXamarin.Client.SharedClient"/> is used.</param>
+		public static DataStore<T> Collection(string collectionName, AbstractClient client = null)
+		{
+			return new DataStore<T>(DataStoreType.CACHE, collectionName, client);
+		}
 
 		/// <summary>
 		/// Gets an instance of the <see cref="KinveyXamarin.DataStore{T}"/>.

--- a/Kinvey-Xamarin/Store/DataStore.cs
+++ b/Kinvey-Xamarin/Store/DataStore.cs
@@ -62,7 +62,7 @@ namespace Kinvey
 
 		/// <summary>
 		/// Gets the type of the store. 
-		/// <seealso cref="Client"/>
+		/// <seealso cref="DataStoreType"/>
 		/// </summary>
 		/// <value>The type of the store.</value>
 		public DataStoreType StoreType
@@ -73,7 +73,7 @@ namespace Kinvey
 
 		/// <summary>
 		/// Gets or sets the Kinvey client that is used for making data requests. 
-		/// <seealso cref="DataStoreType"/>
+		/// <seealso cref="Client"/>
 		/// </summary>
 		/// <value>The Kinvey client.</value>
 		public AbstractClient KinveyClient

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -54,11 +54,27 @@ namespace TestFramework
 			// Arrange
 
 			// Act
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName);
+
+			// Assert
+			Assert.NotNull(todoStore);
+			Assert.AreEqual(todoStore.CollectionName, collectionName);
+			Assert.AreEqual(todoStore.StoreType, DataStoreType.CACHE);
+		}
+
+		[Test]
+		public async Task TestCollectionStoreType()
+		{
+			// Arrange
+
+			// Act
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 
 			// Assert
 			Assert.NotNull(todoStore);
-			Assert.True(string.Equals(todoStore.CollectionName, collectionName));
+			Assert.AreEqual(todoStore.CollectionName, collectionName);
+			Assert.AreEqual(todoStore.StoreType, DataStoreType.NETWORK);
+
 		}
 
 		[Test]


### PR DESCRIPTION
#### Description
Adds a new overloaded `collection` method to `DataStore` with a default `StoreType`.

#### Changes
- New method in `DataStore`.
- Change the default storetype to `CACHE`, which is what we mention on devcenter.
- New tests.

#### Tests
- New test to cover the new API
- Existing tests pass.
