### PR TITLE
Mlibz 1709 register push

### DIFF
--- a/Kinvey-Xamarin-Android/Push/Push.cs
+++ b/Kinvey-Xamarin-Android/Push/Push.cs
@@ -23,21 +23,20 @@ namespace KinveyXamarinAndroid
 
 			string senders = base.client.senderID;
 
-			ISharedPreferences prefs = PreferenceManager.GetDefaultSharedPreferences (appContext);
-			string alreadyInitialized = prefs.GetString (GCM_ID, "");
-
-			if (alreadyInitialized.Length > 0) {
-				//this device has already registered for push
-				return;
-			}
-
 			ThreadPool.QueueUserWorkItem(o => {
 
 				Intent intent;
 
 				try{
-					var gcm = GoogleCloudMessaging.GetInstance(appContext);
-					var gcmID = gcm.Register(senders); 
+				
+					ISharedPreferences prefs = PreferenceManager.GetDefaultSharedPreferences(appContext);
+					string gcmID = prefs.GetString(GCM_ID, "");
+
+					if (gcmID.Length <= 0)
+					{
+						var gcm = GoogleCloudMessaging.GetInstance(appContext);
+						gcmID = gcm.Register(senders);
+					}
 
 					Logger.Log ("-------sender ID is: " + senders);
 					Logger.Log ("-------GCM ID is: " + gcmID);

--- a/Kinvey-Xamarin-Android/Push/Push.cs
+++ b/Kinvey-Xamarin-Android/Push/Push.cs
@@ -75,6 +75,10 @@ namespace KinveyXamarinAndroid
 
 			ThreadPool.QueueUserWorkItem (o => {
 				DisablePushViaRest("android", alreadyInitialized).Execute();
+
+				ISharedPreferencesEditor editor = prefs.Edit();
+				editor.Remove(GCM_ID);
+				editor.Apply();
 			});
 		}
 	}

--- a/Kinvey-Xamarin-Android/Push/Push.cs
+++ b/Kinvey-Xamarin-Android/Push/Push.cs
@@ -32,7 +32,7 @@ namespace KinveyXamarinAndroid
 					ISharedPreferences prefs = PreferenceManager.GetDefaultSharedPreferences(appContext);
 					string gcmID = prefs.GetString(GCM_ID, "");
 
-					if (gcmID.Length <= 0)
+					if (String.IsNullOrEmpty(gcmID))
 					{
 						var gcm = GoogleCloudMessaging.GetInstance(appContext);
 						gcmID = gcm.Register(senders);


### PR DESCRIPTION
#### Description
Fix for MLIBZ-1709: push re-registration error.

#### Changes
Fixed error where if a device ID was found, registration with the backend was not attempted.  Now, push registration with the backend is always attempted.

#### Tests
Tested on device.