### PR TITLE
Delta set fetch changes for performance

### DIFF
--- a/Kinvey-Xamarin/Model/Entity.cs
+++ b/Kinvey-Xamarin/Model/Entity.cs
@@ -46,6 +46,7 @@ namespace Kinvey
 		/// <value>The kmd.</value>
 		[JsonProperty("_kmd")]
 		[Preserve]
+		[Indexed]
 		[Column("_kmd")]
 		public KinveyMetaData KMD { get; set; }
 

--- a/Kinvey-Xamarin/Offline/ICache.cs
+++ b/Kinvey-Xamarin/Offline/ICache.cs
@@ -132,6 +132,8 @@ namespace Kinvey
 
 		List<GroupAggregationResults> GetAggregateResult(EnumReduceFunction reduceFunction, string groupField, string aggregateField, Expression query);
 
+		T LastModifiedEntity(Expression expr);
+
 		//Task<int> InsertEntityAsync (T entity);
 
 		//Task<T> UpsertEntityAsync(string id, string json);

--- a/Kinvey-Xamarin/Offline/ICacheManager.cs
+++ b/Kinvey-Xamarin/Offline/ICacheManager.cs
@@ -35,7 +35,7 @@ namespace Kinvey
 		/// </summary>
 		/// <returns>The cache.</returns>
 		/// <param name="collectionName">Collection name.</param>
-		ICache<T> GetCache <T>(string collectionName) where T:class;
+		ICache<T> GetCache <T>(string collectionName) where T:class, IPersistable;
 
 		ISyncQueue GetSyncQueue (string collectionName);
 

--- a/Kinvey-Xamarin/Offline/SQLiteCacheManager.cs
+++ b/Kinvey-Xamarin/Offline/SQLiteCacheManager.cs
@@ -140,7 +140,7 @@ namespace Kinvey
 //			return SQLiteHelper<T>.getInstance (platform, dbpath);
 //		}
 
-		public ICache<T> GetCache<T>(string collectionName) where T : class
+		public ICache<T> GetCache<T>(string collectionName) where T : class, IPersistable
 		{
 			if (!TableExists<CollectionTableMap>(DBConnectionSync))
 			{

--- a/Kinvey-Xamarin/Query/IQueryBuilder.cs
+++ b/Kinvey-Xamarin/Query/IQueryBuilder.cs
@@ -35,6 +35,9 @@ namespace Kinvey
 		/// <param name="value">Value to be appended to the modifier portion of the mongo-style query string.</param>
 		void AddModifier(object value);
 
+
+		void AddQueryExpression(object value);
+
 		/// <summary>
 		/// Gets the full mongo-style query string.
 		/// </summary>

--- a/Kinvey-Xamarin/Query/StringQueryBuilder.cs
+++ b/Kinvey-Xamarin/Query/StringQueryBuilder.cs
@@ -65,13 +65,24 @@ namespace Kinvey
 			modifierBuilder.Append(value);
 		}
 
+		public void AddQueryExpression(object value) 
+		{
+			if (queryBuilder.Length != 0) {
+				queryBuilder.Append(", ");
+			}
+			queryBuilder.Append(value);
+		}
 		/// <summary>
 		/// Gets the full string by combining the two StringBuilders.
 		/// </summary>
 		/// <returns>The full string.</returns>
 		public string BuildQueryString()
 		{
-			return queryBuilder + modifierBuilder.ToString();
+			var queryOutput = new StringBuilder();
+			queryOutput.Append("{");
+			queryOutput.Append(queryBuilder);
+			queryOutput.Append("}");
+			return queryOutput + modifierBuilder.ToString();
 		}
 	}
 }

--- a/Kinvey-Xamarin/Store/DataStore.cs
+++ b/Kinvey-Xamarin/Store/DataStore.cs
@@ -25,7 +25,7 @@ namespace Kinvey
 	/// Each DataStore in your application represents a collection on your backend. The DataStore class manages the access of data between the Kinvey backend and the app.
 	/// The DataStore provides simple CRUD operations on data, as well as powerful querying and synchronization APIs.
 	/// </summary>
-	public class DataStore<T> : KinveyQueryable<T>  where T:class
+	public class DataStore<T> : KinveyQueryable<T>  where T:class, IPersistable
 	{
 		#region Member variables
 

--- a/Kinvey-Xamarin/Store/ReadRequest.cs
+++ b/Kinvey-Xamarin/Store/ReadRequest.cs
@@ -50,6 +50,35 @@ namespace Kinvey
 			this.EntityIDs = entityIds;
 		}
 
+		protected string BuildMongoQueryForDelta() {
+			var lastEntity = Cache.LastModifiedEntity(Query?.Expression) as IPersistable;
+			if (lastEntity == null) {
+				return BuildMongoQuery();
+			}
+			string deltaQuery = "\"_kmd.lmt\": { \"$gt\": \"" + lastEntity.KMD.lastModifiedTime + "\"}";
+
+			if (Query != null)
+			{
+				StringQueryBuilder queryBuilder = new StringQueryBuilder();
+
+				KinveyQueryVisitor visitor = new KinveyQueryVisitor(queryBuilder, typeof(T));
+				QueryModel queryModel = (Query.Provider as KinveyQueryProvider)?.qm;
+
+				queryBuilder.Write("{");
+				queryModel?.Accept(visitor);
+				queryBuilder.Write(", " + deltaQuery);
+				queryBuilder.Write("}");
+
+				string mongoQuery = queryBuilder.BuildQueryString();
+
+				return mongoQuery;
+			}
+
+			return "{" + deltaQuery + "}";
+
+
+		}
+
 		/// <summary>
 		/// Builds the mongo-style query string to be run against the backend.
 		/// </summary>
@@ -73,99 +102,6 @@ namespace Kinvey
 			}
 
 			return default (string);
-		}
-
-
-		protected async Task<List<T>> RetrieveDeltaSet(List<T> cacheItems, List<DeltaSetFetchInfo> networkItems, string mongoQuery)
-		{
-			List<T> listDeltaSetResults = new List<T>();
-
-			#region DSF Step 2: Pull all entity IDs and LMTs of a collection in local storage
-
-			Dictionary<string, string> dictCachedEntities = new Dictionary<string, string>();
-
-			foreach (var cacheItem in cacheItems)
-			{
-				var item = cacheItem as IPersistable;
-				if (item.KMD?.lastModifiedTime != null) {  //if lmt doesn't exist for cache entity, avoid crashing
-					dictCachedEntities.Add(item.ID, item.KMD.lastModifiedTime);
-				}
-			}
-
-			List<string> listCachedEntitiesToRemove = new List<string>(dictCachedEntities.Keys);
-
-			#endregion
-
-			#region DSF Step 3: Compare backend and local entities to see what has been created, deleted and updated since the last fetch
-
-			List<string> listIDsToFetch = new List<string>();
-
-			foreach (var networkEntity in networkItems)
-			{
-				string ID = networkEntity.ID;
-				string LMT = networkEntity.KMD.lastModifiedTime;
-
-				if (!dictCachedEntities.ContainsKey(ID))
-				{
-					// Case where a new item exists in the backend, but not in the local cache
-					listIDsToFetch.Add(ID);
-				}
-				else if (HelperMethods.IsDateMoreRecent(LMT, dictCachedEntities[ID]))
-				{
-					// Case where the backend has a more up-to-date version of the entity than the local cache
-					listIDsToFetch.Add(ID);
-				}
-
-				// Case where the backend has deleted an item that has not been removed from local storage.
-				//
-				// To begin with, this list has all the IDs currently present in local storage.  If an ID
-				// has been found in the set of backend IDs, we will remove it from this list.  What will
-				// remain in this list are all the IDs that are currently in local storage that
-				// are not present in the backend, and therefore have to be deleted from local storage.
-				listCachedEntitiesToRemove.Remove(ID);
-
-				// NO-OPS: Should never hit these cases, because a Push() has to happen prior to a pull
-				// 		Case where a new item exists in the local cache, but not in the backend
-				// 		Case where the local cache has a more up-to-date version of the entity than the backend
-				// 		Case where the local cache has deleted an item that has not been removed from the backend
-			}
-
-			#endregion
-
-			#region DSF Step 4: Remove items from local storage that are no longer in the backend
-
-			Cache.DeleteByIDs(listCachedEntitiesToRemove);
-
-			#endregion
-
-			#region DSF Step 5: Fetch selected IDs from backend to update local storage
-
-			// Then, with this set of IDs from the previous step, make a query to the
-			// backend, to get full records for each ID that has changed since last fetch.
-			int numIDs = listIDsToFetch.Count;
-
-			if (numIDs == networkItems.Count) {
-				//Special case where delta set is the same size as the network result.
-				//This will occur either when all entities are new/updated, or in error cases such as missing lmts
-				return await RetrieveNetworkResults(mongoQuery);
-			}
-
-			int start = 0;
-			int batchSize = 200;
-
-			while (start < numIDs)
-			{
-				int count = Math.Min((numIDs - start), batchSize);
-				string queryIDs = BuildIDsQuery(listIDsToFetch.GetRange(start, count));
-				List<T> listBatchResults = await Client.NetworkFactory.buildGetRequest<T>(Collection, queryIDs).ExecuteAsync();
-
-				start += listBatchResults.Count();
-				listDeltaSetResults.AddRange(listBatchResults);
-			}
-
-			#endregion
-
-			return listDeltaSetResults;
 		}
 
 		protected List<T> PerformLocalFind(KinveyDelegate<List<T>> localDelegate = null)
@@ -210,33 +146,23 @@ namespace Kinvey
 			try
 			{
 				string mongoQuery = this.BuildMongoQuery();
-
 				if (DeltaSetFetchingEnabled && !Cache.IsCacheEmpty())
 				{
-					var localResults = PerformLocalFind();
 
-					if (localResults?.Count > 0)
-					{
-						#region DSF Step 1: Pull all entity IDs and LMTs of a collection in the backend
-						if (String.IsNullOrEmpty(mongoQuery))
-						{
-							mongoQuery = "{}";
-						}
+					var query = BuildMongoQueryForDelta();
 
-						var fieldsQuery = mongoQuery + "&fields=_id,_kmd.lmt";
-
-						List<DeltaSetFetchInfo> networkMetadata = await Client.NetworkFactory.buildGetRequest<DeltaSetFetchInfo>(Collection, fieldsQuery).ExecuteAsync();
-
-						#endregion
-
-						var delta = await RetrieveDeltaSet(localResults, networkMetadata, mongoQuery);
-						if (delta.Count > 0)
-						{
-							Cache.RefreshCache(delta);
-						}
-
-						return new NetworkReadResponse<T>(delta, networkMetadata.Count, true);
+					var delta = await Client.NetworkFactory.buildGetRequest<T>(Collection, query).ExecuteAsync();
+					if (delta.Count > 0) {
+						Cache.RefreshCache(delta);
 					}
+
+					var deletedItems = await Client.NetworkFactory.buildGetRequest<Entity>(Collection + "-deleted").ExecuteAsync();
+					if (deletedItems.Count > 0) { 
+						Cache.DeleteByIDs(deletedItems.Select(x => x.ID).ToList());
+					}
+
+					//TODO: total count should be returned in this response
+					return new NetworkReadResponse<T>(delta, 0, true);
 				}
 
 				var results = await RetrieveNetworkResults(mongoQuery);


### PR DESCRIPTION
#### Description
Changes the implementation of DSF to calculate deltas on the server instead of the client.

#### Changes
- The SDK calculates delta by constructing a query with the `lmt` that it's aware of. 
- Deletes are tracked by the server in a separate collection.

#### Tests
Tested manually with large datasets. Requires automated tests (pending).