### PR TITLE
MLIBZ-1775 Fix logic around re-auth with refresh token.

### DIFF
--- a/Kinvey-Xamarin/Auth/SQLiteCredentialStore.cs
+++ b/Kinvey-Xamarin/Auth/SQLiteCredentialStore.cs
@@ -81,6 +81,7 @@ namespace Kinvey
 			cred.UserName = credential.UserName;
 			cred.Attributes = JsonConvert.SerializeObject(credential.Attributes);
 			cred.UserKMD = JsonConvert.SerializeObject(credential.UserKMD);
+			cred.AccessToken = credential.AccessToken;
 			cred.RefreshToken = credential.RefreshToken;
 			cred.RedirectUri = credential.RedirectUri;
 			_dbConnection.Insert(cred);

--- a/Kinvey-Xamarin/Auth/User.cs
+++ b/Kinvey-Xamarin/Auth/User.cs
@@ -1168,15 +1168,19 @@ namespace Kinvey
 
 			internal void Execute()
 			{
-				// delete cache and sync queue
-				ICacheManager cm = ((Client)memberUser.KinveyClient).CacheManager;
-				cm?.clearStorage();
-
-				CredentialManager manager = new CredentialManager(this.store);
-				var userId = memberUser.id;
-				if (userId != null && hardLogout)
+				if (hardLogout)
 				{
-					manager.RemoveCredential (userId, memberUser.KinveyClient.SSOGroupKey);
+					// delete cache and sync queue
+					ICacheManager cm = ((Client)memberUser.KinveyClient).CacheManager;
+					cm?.clearStorage();
+
+					CredentialManager manager = new CredentialManager(this.store);
+					var userId = memberUser.id;
+
+					if (userId != null)
+					{
+						manager.RemoveCredential(userId, memberUser.KinveyClient.SSOGroupKey);
+					}
 				}
 
 				((KinveyClientRequestInitializer)memberUser.KinveyClient.RequestInitializer).KinveyCredential = null;

--- a/Kinvey-Xamarin/Auth/User.cs
+++ b/Kinvey-Xamarin/Auth/User.cs
@@ -855,7 +855,8 @@ namespace Kinvey
 		static internal async Task LoginAsync(Credential cred, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
 			AbstractClient uc = userClient ?? Client.SharedClient;
-			if (!String.IsNullOrEmpty(cred.AccessToken))
+			if (!String.IsNullOrEmpty(cred.AccessToken) &&
+			    (0 != string.Compare(uc.SSOGroupKey, ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey, StringComparison.Ordinal)) )
 			{
 				User u = await User.LoginMICWithAccessTokenAsync(cred.AccessToken);
 				uc.ActiveUser = u;

--- a/Kinvey-Xamarin/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey-Xamarin/Core/AbstractKinveyClientRequest.cs
@@ -435,39 +435,52 @@ namespace Kinvey
 			}
 
 			//process refresh token needed
-			if ((int)response.StatusCode == 401 && !hasRetryed){
-
-				//get the refresh token
-				Credential cred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
-				String refreshToken = null;
-				string redirectUri = null;
-				if (cred != null){
-					refreshToken = cred.RefreshToken;
-					redirectUri = cred.RedirectUri;
-				}
-
-				if (refreshToken != null )
+			if ((int)response.StatusCode == 401)
+			{
+				if (!hasRetryed)
 				{
-					//logout the current user
-					Client.ActiveUser.Logout(); // TODO is this a potential deadlock?
+					// Attempt to get the refresh token
+					Credential cred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
+					string refreshToken = null;
+					string redirectUri = null;
 
-					//use the refresh token for a new access token
-					JObject result = await Client.ActiveUser.UseRefreshToken(refreshToken, redirectUri).ExecuteAsync();
+					if (cred != null)
+					{
+						refreshToken = cred.RefreshToken;
+						redirectUri = cred.RedirectUri;
+					}
 
-					//login with the access token
-					Provider provider = new Provider ();
-					provider.kinveyAuth = new MICCredential (result["access_token"].ToString());
-					User u = await User.LoginAsync(new ThirdPartyIdentity(provider), Client);
+					if (refreshToken != null)
+					{
+						//use the refresh token for a new access token
+						JObject result = await Client.ActiveUser.UseRefreshToken(refreshToken, redirectUri).ExecuteAsync();
 
-					//store the new refresh token
-					Credential currentCred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
-					currentCred.RefreshToken = result["refresh_token"].ToString();
-					currentCred.RedirectUri = redirectUri;
-					Client.Store.Store(Client.ActiveUser.Id, Client.SSOGroupKey, currentCred);
-					hasRetryed = true;
-					RequestAuth = new KinveyAuthenticator (currentCred.AuthToken);
-					var retryResponse = await ExecuteUnparsedAsync ();
-					return retryResponse;
+						// log out the current user without removing the user record from the credential store
+						Client.ActiveUser.LogoutSoft();
+
+						//login with the access token
+						Provider provider = new Provider();
+						provider.kinveyAuth = new MICCredential(result["access_token"].ToString());
+						User u = await User.LoginAsync(new ThirdPartyIdentity(provider), Client);
+
+						//store the new refresh token
+						Credential currentCred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
+						currentCred.AccessToken = result["access_token"].ToString();
+						currentCred.RefreshToken = result["refresh_token"].ToString();
+						currentCred.RedirectUri = redirectUri;
+						Client.Store.Store(Client.ActiveUser.Id, Client.SSOGroupKey, currentCred);
+
+						// Retry the original request
+						hasRetryed = true;
+						RequestAuth = new KinveyAuthenticator(currentCred.AuthToken);
+						var retryResponse = await ExecuteUnparsedAsync();
+						return retryResponse;
+					}
+					else
+					{
+						//logout the current user
+						Client.ActiveUser.Logout(); // TODO is this a potential deadlock?
+					}
 				}
 			}
 
@@ -534,7 +547,15 @@ namespace Kinvey
 						int i = response.Headers.IndexOf(param);
 						Parameter p = response.Headers[i];
 						var obj = p.Value as List<string>;
-						newLoc = obj.FirstOrDefault();
+						if (obj == null)
+						{
+							var obj2 = p.Value as string[];
+							newLoc = obj2.FirstOrDefault();
+						}
+						else
+						{
+							newLoc = obj.FirstOrDefault();
+						}
 						break;
 					}
 				}


### PR DESCRIPTION
#### Description
Fix logic around re-auth with refresh token.  Fix persistence of access token in SQLite.  Fix parsing of location in MIC flow to be more robust.

#### Changes
Changes made to the retry logic of requests failing with `401`, as well as to persistence of `access_token` in SQLite offline store.

#### Tests
Manual testing.