### PR TITLE
MLIBZ-1783 Correctly throw exceptions in MIC automated auth flow

### DIFF
--- a/Kinvey-Xamarin/Auth/User.cs
+++ b/Kinvey-Xamarin/Auth/User.cs
@@ -536,7 +536,7 @@ namespace Kinvey
 			{
 				ct.ThrowIfCancellationRequested();
 
-				GetMICTempURLRequest  MICTempURLRequest = User.BuildMICTempURLRequest(uc);
+				GetMICTempURLRequest MICTempURLRequest = User.BuildMICTempURLRequest(uc);
 				ct.ThrowIfCancellationRequested();
 				JObject tempResult = await MICTempURLRequest.ExecuteAsync();
 
@@ -562,9 +562,15 @@ namespace Kinvey
 				currentCred.RedirectUri = uc.MICRedirectURI;
 				uc.Store.Store(u.Id, uc.SSOGroupKey, currentCred);
 			}
+			catch (KinveyException ke)
+			{
+				throw ke;
+			}
 			catch(Exception e)
 			{
 				Logger.Log("Error in LoginWithAuthorizationCodeAPI: " + e.StackTrace);
+				var kinveyException = new KinveyException(EnumErrorCategory.ERROR_USER, EnumErrorCode.ERROR_GENERAL, "Unexpected error in MIC Automated Auth Flow", e);
+				throw kinveyException;
 			}
 		}
 

--- a/TestFramework/Tests.Unit/Tests.Unit.csproj
+++ b/TestFramework/Tests.Unit/Tests.Unit.csproj
@@ -52,6 +52,7 @@
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.5.10\lib\net45\Moq.dll</HintPath>
     </Reference>
+    <Reference Include="System.Net" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Tests\ClientUnitTests.cs" />


### PR DESCRIPTION
#### Description
Fixes for both [MLIBZ-1783](https://kinvey.atlassian.net/browse/MLIBZ-1783) and [MLIBZ-1774](https://kinvey.atlassian.net/browse/MLIBZ-1774).  Addresses a bug with MIC automated authorization flow where any exceptions thrown during this process were not properly propagated up to the user.  The exceptions were being trapped by the SDK, which is incorrect behavior.

#### Changes
Correctly throw any `KinveyException` caught during MIC automated auth flow.
Create new `KinveyException` for any unexpected general exception.

#### Tests
Add unit test to check behavior against mock 504 response.
