### PR TITLE
MLIBZ-1816 Make the ResetPassword method static

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -911,7 +911,7 @@ namespace Kinvey
 		/// <param name="userID">The user ID of the user whose password is reset.  This can either be the 
 		/// ID of the user, or the email address of the user.</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		public async Task<User> ResetPasswordAsync(string userID, CancellationToken ct = default(CancellationToken))
+		static public async Task<User> ResetPasswordAsync(string userID, CancellationToken ct = default(CancellationToken))
 		{
 			ResetPasswordRequest resetPasswordRequest = buildResetPasswordRequest(userID);
 			ct.ThrowIfCancellationRequested();
@@ -1141,15 +1141,16 @@ namespace Kinvey
 			return update;
 		}
 
-		private ResetPasswordRequest buildResetPasswordRequest(string userID)
+		static private ResetPasswordRequest buildResetPasswordRequest(string userID, AbstractClient userClient = null)
 		{
+			AbstractClient uc = userClient ?? Client.SharedClient;
 			var urlParameters = new Dictionary<string, string>();
-			urlParameters.Add("appKey", ((KinveyClientRequestInitializer)client.RequestInitializer).AppKey);
+			urlParameters.Add("appKey", ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey);
 			urlParameters.Add("userID", userID);
 
-			ResetPasswordRequest reset = new ResetPasswordRequest (client, userID, urlParameters);
+			ResetPasswordRequest reset = new ResetPasswordRequest(uc, userID, urlParameters);
 
-			client.InitializeRequest(reset);
+			uc.InitializeRequest(reset);
 
 			return reset;
 		}

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -587,6 +587,20 @@ namespace TestFramework
 		}
 
 		[Test]
+		public void TestResetPassword()
+		{
+			// Arrange
+			string email = "vinay@kinvey.com";
+
+			// Act
+			// Assert
+			Assert.DoesNotThrowAsync(async delegate ()
+			{
+				await User.ResetPasswordAsync(email);
+			});
+		}
+
+		[Test]
 		[Ignore("Placeholder - No unit test yet")]
 		public async Task TestUpdateUserAsync()
 		{


### PR DESCRIPTION
#### Description
The `ResetPasswordAsync` method on the `User` class is an instance method, when it should be static.

#### Changes
Change method to be static on the `User` class, which is consistent with the other SDKs.

#### Tests
Added integration test.
