### PR TITLE
Feature/mlibz 1815 android n sq lite error

### DIFF
--- a/Kinvey-Xamarin-Android.nuspec
+++ b/Kinvey-Xamarin-Android.nuspec
@@ -21,6 +21,7 @@
       <dependency id="Newtonsoft.Json" version="8.0.2"/>
       <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
       <dependency id="SQLite.Net-PCL" version="3.1.1"/>
+      <dependency id="SQLite.Net.Platform.XamarinAndroidN" version="3.1.1"/>
       <dependency id="Xamarin.GooglePlayServices.Gcm" version="27.0.0.0"/>
       <dependency id="Kinvey" version="3.0.8"/>
     </dependencies>

--- a/Kinvey.Core.nuspec
+++ b/Kinvey.Core.nuspec
@@ -19,7 +19,7 @@
       <dependency id="Microsoft.Net.Http" version="2.2.29"/>
       <dependency id="modernhttpclient" version="2.4.2"/>
       <dependency id="Newtonsoft.Json" version="8.0.2"/>
-      <dependency id="PubnubPCL" version="3.8.5.0"/>
+      <dependency id="PubnubNetPlatform" version="3.8.7.0"/>
       <dependency id="Remotion.Linq" version="2.0.1"/>
       <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
       <dependency id="SQLite.Net-PCL" version="3.1.1"/>

--- a/Kinvey.Core/Kinvey.Core.csproj
+++ b/Kinvey.Core/Kinvey.Core.csproj
@@ -188,8 +188,8 @@
     <Reference Include="crypto">
       <HintPath>..\packages\Portable.BouncyCastle-Signed.1.7.0.2\lib\portable-net45+dnxcore50+wp80+win+wpa81+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10\crypto.dll</HintPath>
     </Reference>
-    <Reference Include="PubNub-Messaging">
-      <HintPath>..\packages\PubnubPCL.3.8.5.0\lib\portable-net40+sl50+win+wp80+MonoAndroid10+xamarinios10+MonoTouch10\PubNub-Messaging.dll</HintPath>
+    <Reference Include="PubnubNetPlatform">
+      <HintPath>..\packages\pubnubnetplatform.3.8.7\lib\portable45-net45+win8+wp8+wpa81\PubnubNetPlatform.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
#### Description
Android does not allow access to SQLite starting with API 24

#### Changes
Add a package dependency on a SQLite package that works around this limitation.

#### Tests
Manual test against a sample app.