### PR TITLE
Automatic pagination on DataStore.pull()

### DIFF
--- a/Kinvey.Core/Core/NetworkFactory.cs
+++ b/Kinvey.Core/Core/NetworkFactory.cs
@@ -115,8 +115,9 @@ namespace Kinvey
 
 			if (!string.IsNullOrEmpty (queryString)) { 
 				REST_PATH = "appdata/{appKey}/{collectionName}/_count?query={querystring}";
-				urlParameters.Add ("querystring", queryString);
-			}
+				Dictionary<string, string> modifiers = ParseQueryForModifiers(queryString, ref REST_PATH, ref urlParameters);
+
+			} 
 
 			NetworkRequest<T> getCountQuery = new NetworkRequest<T>(client, "GET", REST_PATH, null, urlParameters);
 			client.InitializeRequest(getCountQuery);

--- a/Kinvey.Core/Kinvey.Core.csproj
+++ b/Kinvey.Core/Kinvey.Core.csproj
@@ -134,6 +134,7 @@
     <Compile Include="Realtime\RealtimeMessage.cs" />
     <Compile Include="Store\KinveyDataStoreDelegate.cs" />
     <Compile Include="Realtime\KinveyStreamDelegate.cs" />
+    <Compile Include="Store\PagedPullRequest.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />

--- a/Kinvey.Core/Offline/SQLiteCache.cs
+++ b/Kinvey.Core/Offline/SQLiteCache.cs
@@ -146,8 +146,16 @@ namespace Kinvey
 //			{
 //				return items;
 //			}
+			try
+			{
+				dbConnectionSync.InsertAll(items);
+			}
+			catch (SQLiteException e)
+			{
+				throw new KinveyException(EnumErrorCategory.ERROR_DATASTORE_CACHE, EnumErrorCode.ERROR_DATASTORE_CACHE_SAVE_INSERT_ENTITY, "", e);
+			}
 
-			return default(List<T>);
+			return items;
 		}
 
 		public T UpdateCacheSave(T item, string tempID)

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -51,6 +51,7 @@ namespace Kinvey
 		/// <value><c>true</c> if delta set fetching enabled; otherwise, <c>false</c>.</value>
 		public bool DeltaSetFetchingEnabled { get; set; }
 
+		public bool AutoPagination { get; set; }
 		/// <summary>
 		/// Represents the name of the collection.
 		/// </summary>
@@ -136,6 +137,7 @@ namespace Kinvey
 			this.customRequestProperties = this.client.GetCustomRequestProperties();
 			this.networkFactory = new NetworkFactory(this.client);
 			this.DeltaSetFetchingEnabled = false;
+			this.AutoPagination = false;
 		}
 
 		#region Public interface
@@ -361,8 +363,15 @@ namespace Kinvey
 				throw new KinveyException(EnumErrorCategory.ERROR_DATASTORE_NETWORK, EnumErrorCode.ERROR_DATASTORE_PULL_ONLY_ON_CLEAN_SYNC_QUEUE, "");
 			}
 
-			//TODO query
-			PullRequest<T> pullRequest = new PullRequest<T> (client, CollectionName, cache, DeltaSetFetchingEnabled, query);
+			if (AutoPagination)
+			{
+				var pagedPullRequest = new PagedPullRequest<T>(client, CollectionName, cache, DeltaSetFetchingEnabled, query);
+				ct.ThrowIfCancellationRequested();
+				return await pagedPullRequest.ExecuteAsync();
+
+			}
+
+			var	pullRequest = new PullRequest<T> (client, CollectionName, cache, DeltaSetFetchingEnabled, query);	
 			ct.ThrowIfCancellationRequested();
 			return await pullRequest.ExecuteAsync();
 		}

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -351,7 +351,7 @@ namespace Kinvey
 		/// <returns>Entities that were pulled from the backend.</returns>
 		/// <param name="query">Optional Query parameter.</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		public async Task<PullDataStoreResponse<T>> PullAsync(IQueryable<T> query = null, CancellationToken ct = default(CancellationToken))
+		public async Task<PullDataStoreResponse<T>> PullAsync(IQueryable<T> query = null, int count = -1, bool isInitial = false, CancellationToken ct = default(CancellationToken))
 		{
 			if (this.storeType == DataStoreType.NETWORK)
 			{
@@ -365,7 +365,7 @@ namespace Kinvey
 
 			if (AutoPagination)
 			{
-				var pagedPullRequest = new PagedPullRequest<T>(client, CollectionName, cache, DeltaSetFetchingEnabled, query);
+				var pagedPullRequest = new PagedPullRequest<T>(client, CollectionName, cache, DeltaSetFetchingEnabled, query, count, isInitial);
 				ct.ThrowIfCancellationRequested();
 				return await pagedPullRequest.ExecuteAsync();
 

--- a/Kinvey.Core/Store/PagedPullRequest.cs
+++ b/Kinvey.Core/Store/PagedPullRequest.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) 2016, Kinvey, Inc. All rights reserved.
+//
+// This software is licensed to you under the Kinvey terms of service located at
+// http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+// software, you hereby accept such terms of service  (and any agreement referenced
+// therein) and agree that you have read, understand and agree to be bound by such
+// terms of service and are of legal age to agree to such terms with Kinvey.
+//
+// This software contains valuable confidential and proprietary information of
+// KINVEY, INC and is subject to applicable licensing agreements.
+// Unauthorized reproduction, transmission or distribution of this file and its
+// contents is a violation of applicable laws.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.Linq;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+
+namespace Kinvey
+{
+	public class PagedPullRequest<T> : ReadRequest<T, PullDataStoreResponse<T>>
+	{
+		BlockingCollection<List<T>> workQueue = new BlockingCollection<List<T>>(10);
+
+		public PagedPullRequest(AbstractClient client, string collection, ICache<T> cache, bool deltaSetFetchingEnabled, IQueryable<object> query)
+			: base(client, collection, cache, query, ReadPolicy.FORCE_NETWORK, deltaSetFetchingEnabled)
+		{
+
+		}
+
+		public override async Task<PullDataStoreResponse<T>> ExecuteAsync()
+		{
+			int skipCount = 0, pageSize = 10000;
+
+			var count = await new GetCountRequest<T>(this.Client, this.Collection, this.Cache, ReadPolicy.FORCE_NETWORK, false, null, this.Query).ExecuteAsync();
+
+			Task consumer = Task.Run(() => FlushWorkQueue());
+
+			var pageQueue = new List<Task<List<T>>>();
+			do
+			{
+				var skipTakeQuery = this.Query.Skip(skipCount).Take(pageSize);
+				pageQueue.Add(new FindRequest<T>(Client, Collection, Cache, ReadPolicy.FORCE_NETWORK, false, null, skipTakeQuery, null).ExecuteAsync());
+				skipCount += pageSize;
+			} while (skipCount < count);
+
+
+			while (pageQueue.Count > 0) {
+				Debug.WriteLine("Pagequeue size: " + pageQueue.Count);
+				var page = await Task.WhenAny(pageQueue);
+				pageQueue.Remove(page);
+				try
+				{
+					workQueue.Add(await page);
+				}
+				catch (OperationCanceledException e)
+				{
+					//log 
+				}
+				catch (Exception e) 
+				{ 
+					//return all exceptions once done
+				}
+			}
+			workQueue.CompleteAdding();
+			await consumer;
+			return new PullDataStoreResponse<T>();
+		}
+
+		private void FlushWorkQueue()
+		{
+
+			while (true)
+			{
+				try
+				{
+					List<T> items = workQueue.Take();
+					Cache.RefreshCache(items);
+					Debug.WriteLine(string.Format("Processing {0} items, workQueue size = {1}", items.Count, workQueue.Count));
+				}
+				catch (InvalidOperationException e)
+				{
+					Debug.WriteLine(string.Format("Work queue has been closed."));
+					break;
+				}
+			}
+		}
+
+		public override Task<bool> Cancel()
+		{
+			throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_METHOD_NOT_IMPLEMENTED, "Cancel method on PullRequest not implemented.");
+		}
+	}
+}


### PR DESCRIPTION
#### Description
New feature - add automatic paging to `dataStore.pull()`. This allows a large collection to be pulled to the app without the developer having to write pagination logic using `skip` and `limit`.

This PR also adds pipelining to the page-by-page pull.  A multithreaded producer dumps pages into a queue from which a single consumer writes them to cache.

#### Changes
- New request to implement auto-paging (`PagedPullRequest`)
- New setting in DataStore (`AutoPagination`, defaults to `false`)

#### Tests
TBD
