### PR TITLE
Feature/mlibz 1839 query with boolean values not working

### DIFF
--- a/Kinvey.Core/Query/KinveyQueryVisitor.cs
+++ b/Kinvey.Core/Query/KinveyQueryVisitor.cs
@@ -197,8 +197,6 @@ namespace Kinvey
 					argument = argument.Replace("\"", "\\\"");
 					builderMongoQuery.Write(argument);
 					builderMongoQuery.Write("\"}");
-					argument = argument.ToLower();
-					builderMongoQuery.Write(argument);
 				}
 				else if (b.Method.Name.Equals("Equals"))
 				{

--- a/Kinvey.Core/Query/KinveyQueryVisitor.cs
+++ b/Kinvey.Core/Query/KinveyQueryVisitor.cs
@@ -112,31 +112,65 @@ namespace Kinvey
 			{
 				BinaryExpression equality = whereClause.Predicate as BinaryExpression;
 				var member = equality.Left as MemberExpression;
+				var argument = equality.Right.ToString();
 
-				builderMongoQuery.Write ("\"" + mapPropertyToName[member.Member.Name] + "\"");
-				builderMongoQuery.Write (":");
-				builderMongoQuery.Write (equality.Right);
+				builderMongoQuery.Write("\"" + mapPropertyToName[member.Member.Name] + "\"");
+				builderMongoQuery.Write(":");
+
+				if (equality.Right.Type.Name.Equals("Boolean"))
+				{
+					// case where boolean value is explicitly checked with double equal sign (example below)
+					// 		var query = from e in todoStore
+					//					where e.BoolVal == true
+					//					select e;
+					argument = equality.Right.ToString().ToLower();
+				}
+
+				builderMongoQuery.Write(argument);
 			}
 			else if (whereClause.Predicate.NodeType.ToString().Equals("AndAlso"))
 			{
 				BinaryExpression and = whereClause.Predicate as BinaryExpression;
 				VisitWhereClause(new WhereClause(and.Right), queryModel, index);
-				builderMongoQuery.Write (",");
+				builderMongoQuery.Write(",");
 				VisitWhereClause(new WhereClause(and.Left), queryModel, index);
 			}
 			else if (whereClause.Predicate.NodeType.ToString().Equals("OrElse"))
 			{
 				BinaryExpression or = whereClause.Predicate as BinaryExpression;
 
-				builderMongoQuery.Write ("\"$or\":");
+				builderMongoQuery.Write("\"$or\":");
 				builderMongoQuery.Write("[");
-				builderMongoQuery.Write ("{");
-				VisitWhereClause (new WhereClause(or.Left), queryModel, index);
-				builderMongoQuery.Write ("},");
-				builderMongoQuery.Write ("{");
-				VisitWhereClause (new WhereClause(or.Right), queryModel, index);
-				builderMongoQuery.Write ("}");
-				builderMongoQuery.Write ("]");
+				builderMongoQuery.Write("{");
+				VisitWhereClause(new WhereClause(or.Left), queryModel, index);
+				builderMongoQuery.Write("},");
+				builderMongoQuery.Write("{");
+				VisitWhereClause(new WhereClause(or.Right), queryModel, index);
+				builderMongoQuery.Write("}");
+				builderMongoQuery.Write("]");
+			}
+			else if (whereClause.Predicate.NodeType == ExpressionType.MemberAccess &&
+					 whereClause.Predicate.Type == typeof(System.Boolean))
+			{
+				// Case where query is against boolean value, where value is not specified (example below)
+				// 		var query = from e in todoStore
+				//					where e.BoolVal
+				//					select e;
+
+				MemberExpression ma = whereClause.Predicate as MemberExpression;
+
+				string name = ma.Member.Name;
+				string propertyName = mapPropertyToName[name];
+
+				if (index > 0)
+				{
+					// multiple where clauses present, so separate with comma
+					builderMongoQuery.Write(",");
+				}
+
+				builderMongoQuery.Write("\"" + propertyName + "\"");
+				builderMongoQuery.Write(":");
+				builderMongoQuery.Write("true");
 			}
 			else if (whereClause.Predicate.NodeType == ExpressionType.Call)
 			{
@@ -163,6 +197,8 @@ namespace Kinvey
 					argument = argument.Replace("\"", "\\\"");
 					builderMongoQuery.Write(argument);
 					builderMongoQuery.Write("\"}");
+					argument = argument.ToLower();
+					builderMongoQuery.Write(argument);
 				}
 				else if (b.Method.Name.Equals("Equals"))
 				{
@@ -178,6 +214,12 @@ namespace Kinvey
 					{
 						argument = argument.Replace("\"", "\\\"");
 						argument = "\"" + argument + "\"";
+					}
+					else if (argType.Name.Equals("Boolean"))
+					{
+						// Case where query is against boolean value, using the "Equals" expression (example below)
+						// 		var query = todoStore.Where(x => x.BoolVal.Equals(true));
+						argument = argument.ToLower();
 					}
 					builderMongoQuery.Write(argument);
 				}

--- a/TestFramework/TestSupportFiles/ToDo.cs
+++ b/TestFramework/TestSupportFiles/ToDo.cs
@@ -17,6 +17,9 @@ namespace TestFramework
 
 		[JsonProperty("value")]
 		public int Value { get; set; }
+
+		[JsonProperty("bool_value")]
+		public bool BoolVal { get; set; }
 	}
 }
 

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -352,6 +352,147 @@ namespace TestFramework
 		}
 
 		[Test]
+		public async Task TestNetworkStoreFindByQueryBoolValueImplicit()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.BoolVal = true;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			var query = from e in todoStore
+						where e.BoolVal
+						select e;
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryBoolValueExplicit()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.BoolVal = true;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			var query = from e in todoStore
+						where e.Name == "another todo" || e.BoolVal == true
+						select e;
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+
+			//var query = todoStore.Where(x => x.BoolVal.Equals(true));
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryBoolValueExplicitEqualsExpression()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.BoolVal = true;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+
+			var query = todoStore.Where(x => x.BoolVal.Equals(true));
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
 		public async Task TestNetworkStoreFindByQueryNotSupported()
 		{
 			// Setup

--- a/testiosapp2/ToDo.cs
+++ b/testiosapp2/ToDo.cs
@@ -1,0 +1,25 @@
+﻿using Newtonsoft.Json;
+using Kinvey;
+
+namespace testiosapp2
+{
+	[JsonObject(MemberSerialization.OptIn)]
+	public class ToDo : Entity
+	{
+		[JsonProperty("name")]
+		public string Name { get; set; }
+
+		[JsonProperty("details")]
+		public string Details { get; set; }
+
+		[JsonProperty("due_date")]
+		public string DueDate { get; set; }
+
+		[JsonProperty("value")]
+		public int Value { get; set; }
+
+		[JsonProperty("bool_value")]
+		public bool BoolVal { get; set; }
+	}
+}
+

--- a/testiosapp2/testiosapp2.csproj
+++ b/testiosapp2/testiosapp2.csproj
@@ -121,6 +121,7 @@
       <DependentUpon>ViewController.cs</DependentUpon>
     </Compile>
     <Compile Include="Book.cs" />
+    <Compile Include="ToDo.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Kinvey-Utils\Kinvey-Utils.csproj">


### PR DESCRIPTION
#### Description
Boolean values were not being processed properly in translating LINQ queries into Mongo query strings.

#### Changes
Properly translate queries with boolean values into the appropriate Mongo query, for the 3 different ways that boolean queries can present themselves in LINQ.

#### Tests
3 integration tests added to cover the different ways to express boolean queries in where clauses.
