### PR TITLE
MLIBZ-1850 Change database update to upsert for case where ID is provided in a entity created in SYNC store.

### DIFF
--- a/Kinvey.Core/Offline/SQLiteCache.cs
+++ b/Kinvey.Core/Offline/SQLiteCache.cs
@@ -128,7 +128,7 @@ namespace Kinvey
 		{
 			try
 			{
-				dbConnectionSync.Update(item);
+				dbConnectionSync.InsertOrReplace(item);
 			}
 			catch (SQLiteException e)
 			{


### PR DESCRIPTION
#### Description
It is permitted for an entity created on the client in a `SYNC` store to provide their own ID.  In this case, the operation is now identified as a `PUT` rather than a `POST`, but the item does not yet exist in the database.  In this case, it should not be assumed that the database entry exists, and we should insert if it does not.

#### Changes
Change the `Update` on the database to `InsertOrReplace`.

#### Tests
Unit test added.