### PR TITLE
MLIBZ-1916 Clean up SQLiteCacheManager state during logout

### DIFF
--- a/Kinvey.Core/Offline/SQLiteCacheManager.cs
+++ b/Kinvey.Core/Offline/SQLiteCacheManager.cs
@@ -124,6 +124,7 @@ namespace Kinvey
 						string dropQuery = $"DROP TABLE IF EXISTS {collection.TableName}";
 						DBConnectionSync.Execute(dropQuery);
 						GetSyncQueue(collection.CollectionName).RemoveAll();
+						mapCollectionToCache.Remove(collection.CollectionName);
 					}
 
 					DBConnectionSync.DeleteAll<CollectionTableMap>();

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -390,6 +390,14 @@ namespace TestFramework
 			// Assert
 			Assert.Null(kinveyClient.ActiveUser);
 			Assert.IsEmpty(kinveyClient.CacheManager.GetSyncQueue(collectionName).GetFirstN(1, 0));
+
+			// Check that all state is cleared out properly in logout by verifying that re-login works correctly
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+			DataStore<ToDo> todoStoreRelogin = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC, kinveyClient);
+			Assert.DoesNotThrowAsync(async () => await todoStoreRelogin.FindAsync());
+
+			// Teardown
+			kinveyClient.ActiveUser.Logout();
 		}
 
 		[Test]


### PR DESCRIPTION
#### Description
Issues with clearing state during logout of app. Results in an exception being thrown when logging back in and accessing the offline DB.

#### Changes
Clear state in the `SQLiteCacheManager` which holds mappings to cached tables.

#### Tests
Manual tests, since this manifests itself in an app lifecycle.
