### PR TITLE
MLIBZ-1912 Support sort of DateTime objects in offline store.

### DIFF
--- a/Kinvey.Core/Offline/SQLiteCache.cs
+++ b/Kinvey.Core/Offline/SQLiteCache.cs
@@ -628,6 +628,11 @@ namespace Kinvey
 				var funcSort = exprSort as Expression<Func<T, uint>>;
 				query = sortAscending ? query.OrderBy(funcSort) : query.OrderByDescending(funcSort);
 			}
+			else if (retType == typeof(DateTime))
+			{
+				var funcSort = exprSort as Expression<Func<T, DateTime>>;
+				query = sortAscending? query.OrderBy(funcSort) : query.OrderByDescending(funcSort);
+			}
 		}
 
 		public KinveyDeleteResponse DeleteByID(string id)

--- a/TestFramework/TestSupportFiles/ToDo.cs
+++ b/TestFramework/TestSupportFiles/ToDo.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Kinvey;
 
 namespace TestFramework
@@ -14,6 +15,9 @@ namespace TestFramework
 
 		[JsonProperty("due_date")]
 		public string DueDate { get; set; }
+
+		[JsonProperty("new_date")]
+		public DateTime NewDate { get; set; }
 
 		[JsonProperty("value")]
 		public int Value { get; set; }

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -1028,6 +1028,134 @@ namespace TestFramework
 			kinveyClient.ActiveUser.Logout();
 		}
 
+		[Test]
+		public async Task TestSyncStoreFindByQueryWithSortAscending()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 22, 19, 56, 00);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2017, 4, 22, 19, 56, 00);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "z another todo";
+			newItem3.Details = "details for 3";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2016, 3, 22, 19, 56, 00);
+
+			ToDo newItem4 = new ToDo();
+			newItem4.Name = "c another todo";
+			newItem4.Details = "details for 4";
+			newItem4.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem4.NewDate = new DateTime(2016, 4, 21, 19, 56, 00);
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+			newItem4 = await todoStore.SaveAsync(newItem4);
+
+			// Act
+			var query = todoStore.Where(x => x.Details.StartsWith("det")).OrderBy(x => x.Name);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem4.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(4, listToDo.Count);
+			Assert.True(String.Compare(newItem2.Name, listToDo.First().Name) == 0);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryWithSortDescending()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 22, 19, 56, 00);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2017, 4, 22, 19, 56, 00);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "z another todo";
+			newItem3.Details = "details for 3";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2016, 3, 22, 19, 56, 00);
+
+			ToDo newItem4 = new ToDo();
+			newItem4.Name = "c another todo";
+			newItem4.Details = "details for 4";
+			newItem4.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem4.NewDate = new DateTime(2016, 4, 21, 19, 56, 00);
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+			newItem4 = await todoStore.SaveAsync(newItem4);
+
+			// Act
+			var query = todoStore.Where(x => x.Details.StartsWith("det")).OrderByDescending(x => x.NewDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem4.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(4, listToDo.Count);
+			Assert.True(String.Compare(newItem2.Name, listToDo.First().Name) == 0);
+		}
+
 
 		#region ORM Tests
 


### PR DESCRIPTION
#### Description
Sorting did not appear to work for sync store items in the offline DB.

#### Changes
The sorting issue was only for `DateTime` objects, which were not previously supported.  They are now supported for sorting in the offline case.

#### Tests
Integration tests added.
