### PR TITLE
Feature/mlibz 1909 support inequality operators

### DIFF
--- a/Kinvey.Core/Query/KinveyQueryVisitor.cs
+++ b/Kinvey.Core/Query/KinveyQueryVisitor.cs
@@ -128,6 +128,78 @@ namespace Kinvey
 
 				builderMongoQuery.Write(argument);
 			}
+			else if (whereClause.Predicate.NodeType.ToString().Equals("GreaterThan"))
+			{
+				BinaryExpression equality = whereClause.Predicate as BinaryExpression;
+				var member = equality.Left as MemberExpression;
+				var argument = equality.Right.ToString();
+
+				builderMongoQuery.Write("\"" + mapPropertyToName[member.Member.Name] + "\"");
+
+				if (equality.Right.Type.Name.Equals("DateTime"))
+				{
+					DateTime dt = DateTime.Parse(equality.Right.ToString());
+					argument = Newtonsoft.Json.JsonConvert.SerializeObject(dt);
+				}
+
+				builderMongoQuery.Write(":{\"$gt\":");
+				builderMongoQuery.Write(argument);
+				builderMongoQuery.Write("}");
+			}
+			else if (whereClause.Predicate.NodeType.ToString().Equals("LessThan"))
+			{
+				BinaryExpression equality = whereClause.Predicate as BinaryExpression;
+				var member = equality.Left as MemberExpression;
+				var argument = equality.Right.ToString();
+
+				builderMongoQuery.Write("\"" + mapPropertyToName[member.Member.Name] + "\"");
+
+				if (equality.Right.Type.Name.Equals("DateTime"))
+				{
+					DateTime dt = DateTime.Parse(equality.Right.ToString());
+					argument = Newtonsoft.Json.JsonConvert.SerializeObject(dt);
+				}
+
+				builderMongoQuery.Write(":{\"$lt\":");
+				builderMongoQuery.Write(argument);
+				builderMongoQuery.Write("}");
+			}
+			else if (whereClause.Predicate.NodeType.ToString().Equals("LessThanOrEqual"))
+			{
+				BinaryExpression equality = whereClause.Predicate as BinaryExpression;
+				var member = equality.Left as MemberExpression;
+				var argument = equality.Right.ToString();
+
+				builderMongoQuery.Write("\"" + mapPropertyToName[member.Member.Name] + "\"");
+
+				if (equality.Right.Type.Name.Equals("DateTime"))
+				{
+					DateTime dt = DateTime.Parse(equality.Right.ToString());
+					argument = Newtonsoft.Json.JsonConvert.SerializeObject(dt);
+				}
+
+				builderMongoQuery.Write(":{\"$lte\":");
+				builderMongoQuery.Write(argument);
+				builderMongoQuery.Write("}");
+			}
+			else if (whereClause.Predicate.NodeType.ToString().Equals("GreaterThanOrEqual"))
+			{
+				BinaryExpression equality = whereClause.Predicate as BinaryExpression;
+				var member = equality.Left as MemberExpression;
+				var argument = equality.Right.ToString();
+
+				builderMongoQuery.Write("\"" + mapPropertyToName[member.Member.Name] + "\"");
+
+				if (equality.Right.Type.Name.Equals("DateTime"))
+				{
+					DateTime dt = DateTime.Parse(equality.Right.ToString());
+				argument = Newtonsoft.Json.JsonConvert.SerializeObject(dt);
+				}
+
+				builderMongoQuery.Write(":{\"$gte\":");
+				builderMongoQuery.Write(argument);
+				builderMongoQuery.Write("}");
+			}
 			else if (whereClause.Predicate.NodeType.ToString().Equals("AndAlso"))
 			{
 				BinaryExpression and = whereClause.Predicate as BinaryExpression;

--- a/TestFramework/TestSupportFiles/ToDo.cs
+++ b/TestFramework/TestSupportFiles/ToDo.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using Newtonsoft.Json;
 using Kinvey;
 
 namespace TestFramework
@@ -14,6 +15,9 @@ namespace TestFramework
 
 		[JsonProperty("due_date")]
 		public string DueDate { get; set; }
+
+		[JsonProperty("new_date")]
+		public DateTime NewDate { get; set; }
 
 		[JsonProperty("value")]
 		public int Value { get; set; }

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -493,6 +493,452 @@ namespace TestFramework
 		}
 
 		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityGreaterThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 2;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value > 1);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityGreaterThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 2;
+
+			//var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			//string end_date = "2016-04-22T19:56:00.963Z";
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value >= 2);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityLessThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 2;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value < 2);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityLessThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 3;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value <= 2);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectGreaterThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 4, 22, 19, 56, 0);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate > endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectGreaterThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 1, 1, 0, 0, 0);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate >= endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectLessThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 1, 1, 0, 0, 1);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate < endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectLessThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 1, 1, 0, 0, 0);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.NETWORK);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate <= endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(3, listToDo.Count);
+		}
+
+		[Test]
 		public async Task TestNetworkStoreFindByQueryNotSupported()
 		{
 			// Setup

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -279,6 +279,452 @@ namespace TestFramework
 		}
 
 		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityGreaterThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 2;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value > 1);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityGreaterThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 2;
+
+			//var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			//string end_date = "2016-04-22T19:56:00.963Z";
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value >= 2);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityLessThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 2;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value < 2);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityLessThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.Value = 1;
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.Value = 2;
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.Value = 3;
+
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.Value <= 2);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectGreaterThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 4, 22, 19, 56, 0);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate > endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectGreaterThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 1, 1, 0, 0, 0);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate >= endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(1, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectLessThan()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 1, 1, 0, 0, 1);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate < endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(2, listToDo.Count);
+		}
+
+		[Test]
+		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectLessThanOrEqual()
+		{
+			// Setup
+			if (kinveyClient.ActiveUser != null)
+			{
+				kinveyClient.ActiveUser.Logout();
+			}
+
+			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+			// Arrange
+			ToDo newItem1 = new ToDo();
+			newItem1.Name = "todo";
+			newItem1.Details = "details for 1";
+			newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem1.NewDate = new DateTime(2016, 4, 21, 19, 56, 0);
+
+			ToDo newItem2 = new ToDo();
+			newItem2.Name = "another todo";
+			newItem2.Details = "details for 2";
+			newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem2.NewDate = new DateTime(2016, 4, 22, 19, 56, 0);
+
+			ToDo newItem3 = new ToDo();
+			newItem3.Name = "another todo";
+			newItem3.Details = "details for 2";
+			newItem3.DueDate = "2016-04-22T19:56:00.963Z";
+			newItem3.NewDate = new DateTime(2017, 1, 1, 0, 0, 0);
+
+			var endDate = new DateTime(2017, 1, 1, 0, 0, 0);
+			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection("ToDos", DataStoreType.SYNC);
+
+			newItem1 = await todoStore.SaveAsync(newItem1);
+			newItem2 = await todoStore.SaveAsync(newItem2);
+			newItem3 = await todoStore.SaveAsync(newItem3);
+
+			// Act
+			var query = todoStore.Where(x => x.NewDate <= endDate);
+
+			List<ToDo> listToDo = new List<ToDo>();
+
+			listToDo = await todoStore.FindAsync(query);
+
+			// Teardown
+			await todoStore.RemoveAsync(newItem1.ID);
+			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem3.ID);
+			kinveyClient.ActiveUser.Logout();
+
+			// Assert
+			Assert.IsNotNull(listToDo);
+			Assert.IsNotEmpty(listToDo);
+			Assert.AreEqual(3, listToDo.Count);
+		}
+
+		[Test]
 		[Ignore("Placeholder - No unit test yet")]
 		public async Task TestGetAsyncBad()
 		{


### PR DESCRIPTION
#### Description
Inequality operators were previously not supported for LINQ querying.

#### Changes
Support has been added for `>`, `>=`, `<`, and `<=`.

#### Tests
Integration tests added for both `NETWORK` and `SYNC` stores.