### PR TITLE
MLIBZ-1896 Change method signature of FindByID to return an entity

### DIFF
--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -290,7 +290,7 @@ namespace Kinvey
 			FindRequest<T> findByQueryRequest = new FindRequest<T>(client, collectionName, cache, storeType.ReadPolicy, DeltaSetFetchingEnabled, cacheDelegate, null, listIDs);
 			ct.ThrowIfCancellationRequested();
 			var results = await findByQueryRequest.ExecuteAsync();
-			return results.FirstOrDefault();
+			return results?.FirstOrDefault();
 		}
 
 		#region Grouping/Aggregate Functions

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -268,7 +268,7 @@ namespace Kinvey
 		/// network results being returned.  This is only valid if the <see cref="KinveyXamarin.DataStoreType"/> is 
 		/// <see cref="KinveyXamarin.DataStoreType.CACHE"/></param>
 		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		public async Task<List<T>> FindByIDAsync(string entityID, KinveyDelegate<List<T>> cacheResults = null, CancellationToken ct = default(CancellationToken))
+		public async Task<T> FindByIDAsync(string entityID, KinveyDelegate<T> cacheResult = null, CancellationToken ct = default(CancellationToken))
 		{
 			List<string> listIDs = new List<string>();
 
@@ -277,9 +277,20 @@ namespace Kinvey
 				listIDs.Add(entityID);
 			}
 
-			FindRequest<T> findByQueryRequest = new FindRequest<T>(client, collectionName, cache, storeType.ReadPolicy, DeltaSetFetchingEnabled, cacheResults, null, listIDs);
+			var cacheDelegate = new KinveyDelegate<List<T>>
+			{
+				onSuccess = (listCacheResults) => {
+					cacheResult.onSuccess(listCacheResults.FirstOrDefault());
+				},
+				onError = (error) => {
+					cacheResult.onError(error);
+				}
+			};
+
+			FindRequest<T> findByQueryRequest = new FindRequest<T>(client, collectionName, cache, storeType.ReadPolicy, DeltaSetFetchingEnabled, cacheDelegate, null, listIDs);
 			ct.ThrowIfCancellationRequested();
-			return await findByQueryRequest.ExecuteAsync();
+			var results = await findByQueryRequest.ExecuteAsync();
+			return results.FirstOrDefault();
 		}
 
 		#region Grouping/Aggregate Functions

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -201,7 +201,7 @@ namespace TestFramework
 
 			// Act
 			ToDo entity = null;
-			entity = (await todoStore.FindByIDAsync(t.ID)).First();
+			entity = await todoStore.FindByIDAsync(t.ID);
 
 			// Assert
 			Assert.NotNull(entity);

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -180,7 +180,7 @@ namespace TestFramework
 
 			// Act
 			ToDo entity = null;
-			entity = (await todoStore.FindByIDAsync(t.ID)).First();
+			entity = await todoStore.FindByIDAsync(t.ID);
 
 			// Assert
 			Assert.NotNull(entity);


### PR DESCRIPTION
#### Description
Currently, for consistency, the SDK returns a `List<T>` for `FindByID()`.  It should return just `T`.

#### Changes
Changed the method signature to return only `T`, rather than a list.

#### Tests
Tests added for all `DataStore` types. 
