### PR TITLE
MLIBZ-1836 Add clientID to MIC methods

### DIFF
--- a/Kinvey.Core/Auth/Credential.cs
+++ b/Kinvey.Core/Auth/Credential.cs
@@ -82,6 +82,13 @@ namespace Kinvey
 		public string DeviceID { get; set; }
 
 		/// <summary>
+		/// Gets or sets the MIC Client identifier.
+		/// </summary>
+		/// <value>The MICC lient identifier.</value>
+		[DataMember]
+		public string MICClientID { get; set; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="KinveyXamarin.Credential"/> class.
 		/// </summary>
 		[Preserve]
@@ -109,7 +116,8 @@ namespace Kinvey
 		                  KinveyUserMetaData kmd,
 		                  string refreshToken,
 		                  string redirectURI,
-		                  string deviceID)
+		                  string deviceID,
+		                  string micClientID)
 		{
 			this.userId = userId;
 			this.AccessToken = accessToken;
@@ -121,6 +129,7 @@ namespace Kinvey
 			this.RefreshToken = refreshToken;
 			this.RedirectUri = redirectURI;
 			this.DeviceID = deviceID;
+			this.MICClientID = micClientID;
 		}
 		/// <summary>
 		/// Gets or sets the user _id.
@@ -188,7 +197,7 @@ namespace Kinvey
 		/// <param name="response">The response of a Kinvey login/create request.</param>
 		public static Credential From(KinveyAuthResponse response)
 		{
-			return new Credential(response.UserId, response.AccessToken, response.AuthSocialIdentity, response.AuthToken, response.username, response.Attributes, response.UserMetaData, null, null, null);
+			return new Credential(response.UserId, response.AccessToken, response.AuthSocialIdentity, response.AuthToken, response.username, response.Attributes, response.UserMetaData, null, null, null, null);
 		}
 
 		/// <summary>
@@ -197,7 +206,7 @@ namespace Kinvey
 		/// <param name="user">User.</param>
 		public static Credential From(User user)
 		{
-			return new Credential(user.Id, user.AccessToken, user.AuthSocialID, user.AuthToken, user.UserName, user.Attributes, user.Metadata, null, null, user.KinveyClient.DeviceID);
+			return new Credential(user.Id, user.AccessToken, user.AuthSocialID, user.AuthToken, user.UserName, user.Attributes, user.Metadata, null, null, user.KinveyClient.DeviceID, null);
 		}
 
 		public static Credential From(NativeCredential nc)
@@ -211,6 +220,7 @@ namespace Kinvey
 			                      JsonConvert.DeserializeObject<KinveyUserMetaData>(nc.Properties[Constants.STR_USER_KMD]),
 			                      nc.Properties[Constants.STR_REFRESH_TOKEN],
 			                      nc.Properties[Constants.STR_REDIRECT_URI],
+			                      null,
 			                      null);
 		}
 
@@ -219,7 +229,7 @@ namespace Kinvey
 			Dictionary<string, JToken> attributes = JsonConvert.DeserializeObject<Dictionary<string, JToken>>(sqlcred.Attributes);
 			KinveyUserMetaData userKMD = JsonConvert.DeserializeObject<KinveyUserMetaData>(sqlcred.UserKMD);
 			KinveyAuthSocialID socialIdentity = JsonConvert.DeserializeObject<KinveyAuthSocialID>(sqlcred.AuthSocialID);
-			return new Credential(sqlcred.UserID, sqlcred.AccessToken, socialIdentity, sqlcred.AuthToken, sqlcred.UserName, attributes, userKMD, sqlcred.RefreshToken, sqlcred.RedirectUri, sqlcred.DeviceID);
+			return new Credential(sqlcred.UserID, sqlcred.AccessToken, socialIdentity, sqlcred.AuthToken, sqlcred.UserName, attributes, userKMD, sqlcred.RefreshToken, sqlcred.RedirectUri, sqlcred.DeviceID, sqlcred.MICClientID);
 		}
 	}
 }

--- a/Kinvey.Core/Auth/InMemoryCredentialStore.cs
+++ b/Kinvey.Core/Auth/InMemoryCredentialStore.cs
@@ -55,7 +55,7 @@ namespace Kinvey
         {
             if (userId != null)
             {
-				Credential cred = new Credential(userId, credential.AccessToken, credential.AuthSocialID, credential.AuthToken, credential.UserName, credential.Attributes, credential.UserKMD, credential.RefreshToken, credential.RedirectUri, credential.DeviceID);
+				Credential cred = new Credential(userId, credential.AccessToken, credential.AuthSocialID, credential.AuthToken, credential.UserName, credential.Attributes, credential.UserKMD, credential.RefreshToken, credential.RedirectUri, credential.DeviceID, credential.MICClientID);
                 store.Add(userId, cred);
             }
         }

--- a/Kinvey.Core/Auth/SQLCredential.cs
+++ b/Kinvey.Core/Auth/SQLCredential.cs
@@ -78,4 +78,10 @@ public class SQLCredential
 	/// </summary>
 	/// <value>The attributes dictionary</value>
 	public string DeviceID { get; set; }
+
+	/// <summary>
+	/// Gets or sets the MIC ID associated with the auth service used.
+	/// </summary>
+	/// <value>The attributes dictionary</value>
+	public string MICClientID { get; set; }
 }

--- a/Kinvey.Core/Auth/SQLiteCredentialStore.cs
+++ b/Kinvey.Core/Auth/SQLiteCredentialStore.cs
@@ -123,7 +123,7 @@ namespace Kinvey
 					socialIdentity = JsonConvert.DeserializeObject<KinveyAuthSocialID>(sqlcred.AuthSocialID);
 				}
 
-				cred =  new Credential (sqlcred.UserID, sqlcred.AccessToken, socialIdentity, sqlcred.AuthToken, sqlcred.UserName, attributes, kmd, sqlcred.RefreshToken, sqlcred.RedirectUri, sqlcred.DeviceID);
+				cred =  new Credential (sqlcred.UserID, sqlcred.AccessToken, socialIdentity, sqlcred.AuthToken, sqlcred.UserName, attributes, kmd, sqlcred.RefreshToken, sqlcred.RedirectUri, sqlcred.DeviceID, sqlcred.MICClientID);
 			}
 
 			return cred;

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -153,6 +153,8 @@ namespace Kinvey
             get { return this.client; }
         }
 
+		internal string MICClientID { get; set; }
+
 		/// <summary>
 		/// the auth request builder.
 		/// </summary>
@@ -242,6 +244,7 @@ namespace Kinvey
 			u.Id = credential.UserId;
 			u.metadata = credential.UserKMD;
 			u.UserName = credential.UserName;
+			u.MICClientID = credential.MICClientID;
 			return u;
 		}
 
@@ -507,23 +510,46 @@ namespace Kinvey
 		/// <param name="MICDelegate">MIC Delegate, which has a callback to pass back the URL to render for login, as well as success and error callbacks.</param>
 		/// <param name="userClient">[optional] Client that the user is logged in for, defaulted to SharedClient.</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+		[Obsolete("This method has been deprecated.  Please use LoginWithMIC() instead.")]
 		static public void LoginWithAuthorizationCodeLoginPage(string redirectURI, KinveyMICDelegate<User> MICDelegate, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
+		{
+			LoginWithMIC(redirectURI, MICDelegate, null, userClient, ct);
+		}
+
+		/// <summary>
+		/// Performs MIC Login authorization through a login page.
+		/// </summary>
+		/// <param name="redirectURI">The redirect URI to be used for parsing the grant code</param>
+		/// <param name="MICDelegate">MIC Delegate, which has a callback to pass back the URL to render for login, as well as success and error callbacks.</param>
+		/// <param name="clientID">[optional] Client ID configured during auth provider configuration, which is to be used during authentication.  Defaults to app key.</param>
+		/// <param name="userClient">[optional] Client that the user is logged in for, defaulted to SharedClient.</param>
+		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+		static public void LoginWithMIC(string redirectURI, KinveyMICDelegate<User> MICDelegate, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
 			//return URL for login page
 			//https://auth.kinvey.com/oauth/auth?client_id=<your_app_id>&redirect_uri=<redirect_uri>&response_type=code
 
 			AbstractClient uc = userClient ?? Client.SharedClient;
 
-			string appkey = ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey;
+			string appKey = ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey;
 			string hostname = uc.MICHostName;
 			if (uc.MICApiVersion != null && uc.MICApiVersion.Length > 0)
 			{
 				hostname += uc.MICApiVersion + "/";
 			}
 
+			string clientID = appKey;
+
+			// Check if a client ID for MIC authentication has been provided
+			//
+			if (!string.IsNullOrEmpty(micID))
+			{
+				clientID += ":" + micID;
+			}
+
 			ct.ThrowIfCancellationRequested();
 
-			string myURLToRender = hostname + "oauth/auth?client_id=" + appkey + "&redirect_uri=" + redirectURI + "&response_type=code";
+			string myURLToRender = hostname + "oauth/auth?client_id=" + clientID + "&redirect_uri=" + redirectURI + "&response_type=code";
 
 			//keep a reference to the redirect uri for later
 			uc.MICRedirectURI = redirectURI;
@@ -543,7 +569,20 @@ namespace Kinvey
 		/// <param name="password">Password for authentication</param>
 		/// <param name="redirectURI">The redirect URI to be used for parsing the grant code</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+		[Obsolete("This method has been deprecated.  Please use LoginWithMIC() instead.")]
 		static public async Task LoginWithAuthorizationCodeAPIAsync(string username, string password, string redirectURI, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
+		{
+			await LoginWithMIC(username, password, redirectURI, null, userClient, ct);
+		}
+
+		/// <summary>
+		/// Performs MIC Login authorization through an API.
+		/// </summary>
+		/// <param name="username">Username for authentication</param>
+		/// <param name="password">Password for authentication</param>
+		/// <param name="redirectURI">The redirect URI to be used for parsing the grant code</param>
+		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+		static public async Task LoginWithMIC(string username, string password, string redirectURI, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
 			AbstractClient uc = userClient ?? Client.SharedClient;
 			uc.MICRedirectURI = redirectURI;
@@ -552,13 +591,28 @@ namespace Kinvey
 			{
 				ct.ThrowIfCancellationRequested();
 
-				GetMICTempURLRequest MICTempURLRequest = User.BuildMICTempURLRequest(uc);
+				string appKey = ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey;
+
+				string clientID = appKey;
+
+				// Check if a client ID for MIC authentication has been provided
+				//
+				if (!string.IsNullOrEmpty(micID))
+				{
+					clientID += ":" + micID;
+				}
+
+				// Initiate grant reqeust
+				//
+				GetMICTempURLRequest MICTempURLRequest = User.BuildMICTempURLRequest(uc, clientID);
 				ct.ThrowIfCancellationRequested();
 				JObject tempResult = await MICTempURLRequest.ExecuteAsync();
 
 				string tempURL = tempResult["temp_login_uri"].ToString();
 
-				LoginToTempURLRequest MICLoginToTempURL = User.BuildMICLoginToTempURL(uc, username, password, tempURL);
+				// Initiate token request
+				//
+				LoginToTempURLRequest MICLoginToTempURL = User.BuildMICLoginToTempURL(uc, username, password, tempURL, clientID);
 				ct.ThrowIfCancellationRequested();
 				JObject accessResult = await MICLoginToTempURL.ExecuteAsync();
 
@@ -567,15 +621,20 @@ namespace Kinvey
 				string accessToken = accessResult["access_token"].ToString();
 
 				ct.ThrowIfCancellationRequested();
+
+				// Log into Kinvey
+				//
 				User u = await User.LoginMICWithAccessTokenAsync(accessToken);
 
 				ct.ThrowIfCancellationRequested();
 
-				//store the new refresh token
+				// Store the new access token and refresh token
+				//
 				Credential currentCred = uc.Store.Load(u.Id, uc.SSOGroupKey);
 				currentCred.AccessToken = accessResult["access_token"].ToString();
 				currentCred.RefreshToken = accessResult["refresh_token"].ToString();
 				currentCred.RedirectUri = uc.MICRedirectURI;
+				currentCred.MICClientID = clientID;
 				uc.Store.Store(u.Id, uc.SSOGroupKey, currentCred);
 			}
 			catch (KinveyException ke)
@@ -595,14 +654,25 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="token">Grant token passed back from MIC grant request</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		static public async Task GetMICAccessTokenAsync(String token, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
+		static public async Task GetMICAccessTokenAsync(String token, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
 			AbstractClient uc = userClient ?? Client.SharedClient;
 
 			try
 			{
+				string appKey = ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey;
+
+				string clientID = appKey;
+
+				// Check if a client ID for MIC authentication has been provided
+				//
+				if (!string.IsNullOrEmpty(micID))
+				{
+					clientID += ":" + micID;
+				}
+
 				ct.ThrowIfCancellationRequested();
-				JObject result = await User.GetMICToken(uc, token).ExecuteAsync();
+				JObject result = await User.GetMICToken(uc, token, clientID).ExecuteAsync();
 				string accessToken = result["access_token"].ToString();
 
 				ct.ThrowIfCancellationRequested();
@@ -974,7 +1044,7 @@ namespace Kinvey
 		#region User class blocking private classes - used to build up requests
 
 		// Generates a request to exchange the OAuth2.0 authorization code for a MIC user token
-		static private RetrieveMICAccessTokenRequest GetMICToken(AbstractClient cli, String code)
+		static private RetrieveMICAccessTokenRequest GetMICToken(AbstractClient cli, String code, string clientID)
 		{
 			//        grant_type: "authorization_code" - this is always set to this value
 			//        code: use the ‘code’ returned in the callback 
@@ -987,7 +1057,7 @@ namespace Kinvey
 			data.Add("grant_type", "authorization_code");
 			data.Add("code", code);
 			data.Add("redirect_uri", cli.MICRedirectURI);
-			data.Add("client_id", app_id);
+			data.Add("client_id", clientID);
 
 			var urlParameters = new Dictionary<string, string>();
 			urlParameters.Add("appKey", app_id);
@@ -999,7 +1069,7 @@ namespace Kinvey
 		}
 
 		// Generates a request that uses the refresh token to retrieve a new MIC user token
-		internal RetrieveMICAccessTokenRequest UseRefreshToken(String refreshToken, string redirectUri)
+		internal RetrieveMICAccessTokenRequest UseRefreshToken(String refreshToken, string redirectUri, string clientID)
 		{
 			//        grant_type: "refresh_token" - this is always set to this value  - note the difference
 			//        refresh_token: use the refresh token 
@@ -1010,7 +1080,7 @@ namespace Kinvey
 			data.Add("grant_type", "refresh_token");
 			data.Add("refresh_token", refreshToken);
 			data.Add("redirect_uri", redirectUri);
-			data.Add("client_id", ((KinveyClientRequestInitializer) client.RequestInitializer).AppKey);
+			data.Add("client_id", clientID);
 
 			var urlParameters = new Dictionary<string, string>();
 			urlParameters.Add("appKey", ((KinveyClientRequestInitializer)client.RequestInitializer).AppKey);
@@ -1022,7 +1092,7 @@ namespace Kinvey
 		}
 
 		// Generates a request to get a temporary MIC URL (automated authorization grant flow)
-		static private GetMICTempURLRequest BuildMICTempURLRequest(AbstractClient cli)
+		static private GetMICTempURLRequest BuildMICTempURLRequest(AbstractClient cli, string clientID)
 		{
 			//    	client_id:  this is the app’s appKey (the KID)
 			//    	redirect_uri:  the uri that the grant will redirect to on authentication, as set in the console. Note, this must exactly match one of the redirect URIs configured in the console.
@@ -1033,11 +1103,12 @@ namespace Kinvey
 			data.Add("redirect_uri", Client.SharedClient.MICRedirectURI);//this.KinveyClient.MICRedirectURI);
 			data.Add("scope", "openid");
 
-			string app_id = ((KinveyClientRequestInitializer)cli.RequestInitializer).AppKey;
-			data.Add("client_id", app_id);
+			string appKey = ((KinveyClientRequestInitializer)cli.RequestInitializer).AppKey;
+
+			data.Add("client_id", clientID);
 
 			var urlParameters = new Dictionary<string, string>();
-			urlParameters.Add("appKey", app_id);
+			urlParameters.Add("appKey", appKey);
 
 			if (cli.MICApiVersion != null && cli.MICApiVersion.Length > 0)
 			{
@@ -1052,25 +1123,25 @@ namespace Kinvey
 		}
 
 		// Generates a request to login a user to the temporary MIC URL (automated authorization grant flow)
-		static private LoginToTempURLRequest BuildMICLoginToTempURL(AbstractClient cli, String username, String password, String tempURL)
+		static private LoginToTempURLRequest BuildMICLoginToTempURL(AbstractClient cli, String username, String password, String tempURL, string clientID)
 		{
-			//    	client_id:  this is the app’s appKey (the KID)
+			//    	client_id:  provided by the developer when configuring authlink (defaults to the app’s appKey (the KID))
 			//    	redirect_uri:  the uri that the grant will redirect to on authentication, as set in the console. Note, this much exactly match one of the redirect URIs configured in the console.
 			//    	response_type:  this is always set to “code”
 			//    	username
 			//    	password
 
-			string app_id = ((KinveyClientRequestInitializer)cli.RequestInitializer).AppKey;
+			string appKey = ((KinveyClientRequestInitializer)cli.RequestInitializer).AppKey;
 
 			Dictionary<string, string> data = new Dictionary<string, string>();
-			data.Add("client_id", app_id);
+			data.Add("client_id", clientID);
 			data.Add("redirect_uri", cli.MICRedirectURI);
 			data.Add("response_type", "code");
 			data.Add("username", username);
 			data.Add("password", password);
 
 			var urlParameters = new Dictionary<string, string>();
-			urlParameters.Add("appKey", app_id);
+			urlParameters.Add("appKey", appKey);
 
 			LoginToTempURLRequest loginTemp = new LoginToTempURLRequest(cli, tempURL, data, urlParameters);
 			loginTemp.RequireAppCredentials = true;
@@ -1247,6 +1318,7 @@ namespace Kinvey
 		private class LoginToTempURLRequest : AbstractKinveyClientRequest<JObject>
 		{
 			AbstractClient cli;
+			string clientID = null;
 
 			internal LoginToTempURLRequest(AbstractClient client, string tempURL, Object httpContent, Dictionary<string, string> urlProperties):
 				base(client, tempURL, "POST", "", httpContent, urlProperties)
@@ -1254,6 +1326,7 @@ namespace Kinvey
 				this.PayloadType = new URLEncodedPayload();
 				this.OverrideRedirect = true;
 				this.cli = client;
+				clientID = (httpContent as Dictionary<string, string>)["client_id"];
 			}
 
 			public override async Task<JObject> onRedirectAsync (string newLocation)
@@ -1265,7 +1338,7 @@ namespace Kinvey
 				}
 
 				String accesstoken = newLocation.Substring (codeIndex + 5); // TODO change "String" to "string" - use alias everywhere
-				return await User.GetMICToken(cli, accesstoken).ExecuteAsync();
+				return await User.GetMICToken(cli, accesstoken, clientID).ExecuteAsync();
 			}
 		}
 

--- a/Kinvey.Core/Auth/UserRequestFactory.cs
+++ b/Kinvey.Core/Auth/UserRequestFactory.cs
@@ -83,7 +83,7 @@ namespace Kinvey
 
 		internal LoginRequest BuildLoginRequestWithKinveyAuthToken(string userID, string authToken)
 		{
-			return BuildLoginRequest(new Credential(userID, null, null, authToken, null, null, null, null, null, Client.DeviceID));
+			return BuildLoginRequest(new Credential(userID, null, null, authToken, null, null, null, null, null, Client.DeviceID, null));
 		}
 
 		#endregion

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -455,7 +455,7 @@ namespace Kinvey
 						if (refreshToken != null)
 						{
 							//use the refresh token for a new access token
-							JObject result = await Client.ActiveUser.UseRefreshToken(refreshToken, redirectUri).ExecuteAsync();
+							JObject result = await Client.ActiveUser.UseRefreshToken(refreshToken, redirectUri, Client.ActiveUser.MICClientID).ExecuteAsync();
 
 							// log out the current user without removing the user record from the credential store
 							Client.ActiveUser.LogoutSoft();

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -324,7 +324,7 @@ namespace TestFramework
 		// MIC LOGIN TESTS
 		//
 		[Test]
-		public async Task TestMIC_LoginWithAuthorizationCodeLoginPage()
+		public void TestMIC_LoginWithMIC_NormalFlow()
 		{
 			// Arrange
 			string redirectURI = "http://test.redirect";
@@ -332,7 +332,7 @@ namespace TestFramework
 
 			// Act
 			string renderURL = null;
-			User.LoginWithAuthorizationCodeLoginPage(redirectURI, new KinveyMICDelegate<User>
+			User.LoginWithMIC(redirectURI, new KinveyMICDelegate<User>
 			{
 				onSuccess = (user) => { loggedInUser = user; },
 				onError = (e) => { Console.WriteLine("TEST MIC ERROR"); },
@@ -342,12 +342,38 @@ namespace TestFramework
 			// Assert
 			Assert.IsNotNull(renderURL);
 			Assert.IsNotEmpty(renderURL);
-			Assert.True(renderURL.StartsWith(kinveyClient.MICHostName + "oauth/auth?client_id"));
+			Assert.True(renderURL.StartsWith(kinveyClient.MICHostName + "oauth/auth?client_id=" + TestSetup.app_key, StringComparison.Ordinal));
+		}
+
+		[Test]
+		public void TestMIC_LoginWithMIC_NormalFlow_ClientID()
+		{
+			// Arrange
+			string redirectURI = "http://test.redirect";
+			User loggedInUser = null;
+
+			// Act
+			string renderURL = null;
+			string micID = "12345";
+
+			User.LoginWithMIC(redirectURI, new KinveyMICDelegate<User>
+			{
+				onSuccess = (user) => { loggedInUser = user; },
+				onError = (e) => { Console.WriteLine("TEST MIC ERROR"); },
+				onReadyToRender = (url) => { renderURL = url; }
+			}, micID);
+
+			System.Diagnostics.Debug.WriteLine("\tClientID: " + micID);
+
+			// Assert
+			Assert.IsNotNull(renderURL);
+			Assert.IsNotEmpty(renderURL);
+			Assert.True(renderURL.StartsWith(kinveyClient.MICHostName + "oauth/auth?client_id=" + TestSetup.app_key + ":" + micID, StringComparison.Ordinal));
 		}
 
 		[Test]
 		[Ignore("Placeholder - Need configured backend to run test")]
-		public async Task TestMIC_LoginWithAuthorizationCodeAPI()
+		public async Task TestMIC_LoginWithMIC_HeadlessFlow()
 		{
 			// Arrange
 			string username = "testuser";
@@ -360,7 +386,32 @@ namespace TestFramework
 			localClient.MICApiVersion = "v2";
 
 			// Act
-			await User.LoginWithAuthorizationCodeAPIAsync(username, password, redirectURI);
+			await User.LoginWithMIC(username, password, redirectURI);
+
+			// Assert
+			Assert.NotNull(localClient.ActiveUser);
+
+			// Teardown
+			localClient.ActiveUser.Logout();
+		}
+
+		[Test]
+		[Ignore("Placeholder - Need configured backend to run test")]
+		public async Task TestMIC_LoginWithMIC_HeadlessFlow_ClientID()
+		{
+			// Arrange
+			string username = "testuser";
+			string password = "testpass";
+			string redirectURI = "kinveyAuthDemo://";
+			string saml_app_key = "kid_ZkPDb_34T";
+			string saml_app_secret = "c3752d5079f34353ab89d07229efaf63";
+			Client.Builder localBuilder = new Client.Builder(saml_app_key, saml_app_secret);
+			Client localClient = localBuilder.Build();
+			localClient.MICApiVersion = "v2";
+
+			// Act
+			string micID = "12345";
+			await User.LoginWithMIC(username, password, redirectURI, micID);
 
 			// Assert
 			Assert.NotNull(localClient.ActiveUser);


### PR DESCRIPTION
#### Description
As part of MLIBZ-1803, this PR adds support for a custom MIC ID to be passed into MIC login methods.

#### Changes
The previous method names have been deprecated, in favor of `LoginWithMIC()`.  And `micID` has been added as an optional parameter, defaulting to `appKey`, as was the case before.

#### Tests
Tests added for normal MIC flow
