### PR TITLE
MLIBZ-1964 Add attribute dictionary to _socialIdentity and kinveyAuth objects to capture custom fields.

### DIFF
--- a/Kinvey.Core/Model/KinveyAuthMetaData.cs
+++ b/Kinvey.Core/Model/KinveyAuthMetaData.cs
@@ -11,7 +11,7 @@
 // Unauthorized reproduction, transmission or distribution of this file and its
 // contents is a violation of applicable laws.
 
-using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -41,6 +41,13 @@ namespace Kinvey
 		[Preserve]
 		[JsonProperty("audience")]
 		public string AuthAudience { get; set; }
+
+		/// <summary>
+		/// A name-value dictionary of custom attributes of the kinveyAuth object
+		/// </summary>
+		[Preserve]
+		[JsonExtensionData]
+		public Dictionary<string, JToken> Attributes;
 
 		/// <summary>
 		/// Serialize this instance of <see cref="KinveyAuthMetaData"/> in the local cache.

--- a/Kinvey.Core/Model/KinveyAuthSocialID.cs
+++ b/Kinvey.Core/Model/KinveyAuthSocialID.cs
@@ -11,7 +11,7 @@
 // Unauthorized reproduction, transmission or distribution of this file and its
 // contents is a violation of applicable laws.
 
-using System;
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -34,5 +34,12 @@ namespace Kinvey
 		[Preserve]
 		[JsonProperty("kinveyAuth")]
 		public KinveyAuthMetaData AuthMetaData { get; set; }
+
+		/// <summary>
+		/// A name-value dictionary of custom attributes of the _socialIdentity object
+		/// </summary>
+		[Preserve]
+		[JsonExtensionData]
+		public Dictionary<string, JToken> Attributes;
 	}
 }


### PR DESCRIPTION
#### Description
Custom fields can be added to the `_socialIdentity` object, but the SDK does not have a way to access them.

#### Changes
Add `Attributes` dictionary to both the `_socialIdentity` and `kinveyAuth` objects.

#### Tests
Manual testing via MIC.
