### PR TITLE
MLIBZ-1743: sync queue race condition

### DIFF
--- a/Kinvey.Core/Offline/ISyncQueue.cs
+++ b/Kinvey.Core/Offline/ISyncQueue.cs
@@ -30,8 +30,8 @@ namespace Kinvey
 		List<PendingWriteAction> GetFirstN(int limit, int offset);
 		PendingWriteAction GetByID(string entityId);
 
-		int Remove (string entityId);
-		int Remove(List<string> entityIDs);
+		int Remove(PendingWriteAction pending);
+        int Remove(IEnumerable<PendingWriteAction> pendings);
 		int RemoveAll ();
 	}
 }

--- a/Kinvey.Core/Offline/SQLiteSyncQueue.cs
+++ b/Kinvey.Core/Offline/SQLiteSyncQueue.cs
@@ -44,17 +44,17 @@ namespace Kinvey
 				else if (existingSyncItem.action == "PUT" && pending.action == "POST")
 				{
 					// highly unlikely, but favor the POST
-					this.Remove(existingSyncItem.entityId);
+					this.Remove(existingSyncItem);
 				}
 				else if (existingSyncItem.action == "DELETE" && (pending.action == "PUT" || pending.action == "POST"))
 				{
 					// odd case where an object has somehow been created/updated after a delete call, but favor the create/update
-					this.Remove(existingSyncItem.entityId);
+					this.Remove(existingSyncItem);
 				}
 				else if (pending.action == "DELETE")
 				{
 					// no matter what, favor the current deletion
-					this.Remove(existingSyncItem.entityId);
+					this.Remove(existingSyncItem);
 
 					// If the existing item that is being deleted is something that only existed locally,
 					// do not insert the DELETE action into the queue, since it is local-only
@@ -123,26 +123,20 @@ namespace Kinvey
 				               .Count();
 		}
 
-		public int Remove(string entityId)
+		public int Remove(PendingWriteAction pending)
 		{
-			PendingWriteAction item = GetByID(entityId);
-			if (item == null)
-			{
-				return 0;
-			}
-
-			return dbConnection.Delete(item);
+			return dbConnection.Delete(pending);
 		}
 
-		public int Remove(List<string> entityIDs) {
-			if (entityIDs == null) 
+		public int Remove(IEnumerable<PendingWriteAction> pendings) {
+			if (pendings == null) 
 			{
 				return RemoveAll();
 			}
 
 			int ret = 0;
-			foreach (var id in entityIDs) {
-				ret += this.Remove(id);
+			foreach (var pending in pendings) {
+				ret += this.Remove(pending);
 			}
 			return ret;
 		}

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -458,7 +458,8 @@ namespace Kinvey
 			var ret = cache.Clear(query?.Expression);
 			if (ret?.IDs != null)
 			{
-				syncQueue.Remove(ret.IDs);
+                var pendings = ret.IDs.Select(entityId => syncQueue.GetByID(entityId));
+                syncQueue.Remove(pendings);
 			}
 			else {
 				syncQueue.RemoveAll();
@@ -477,10 +478,9 @@ namespace Kinvey
 			{
 				var ids = new List<string>();
 				var entities = cache.FindByQuery(query.Expression);
-				foreach (var entity in entities) {					
-					ids.Add((entity as IPersistable).ID);
-				}
-				return syncQueue.Remove(ids);
+                var pendings = entities.Select(entity => entity as IPersistable)
+                                       .Select(persistable => syncQueue.GetByID(persistable.ID));
+				return syncQueue.Remove(pendings);
 			}
 
 			return syncQueue.RemoveAll();

--- a/Kinvey.Core/Store/PushRequest.cs
+++ b/Kinvey.Core/Store/PushRequest.cs
@@ -116,7 +116,7 @@ namespace Kinvey
 
 				Cache.UpdateCacheSave(entity, tempID);
 
-				result = SyncQueue.Remove(tempID);
+				result = SyncQueue.Remove(pwa);
 
 				if (result == 0)
 				{
@@ -145,7 +145,7 @@ namespace Kinvey
 				NetworkRequest<T> request = Client.NetworkFactory.buildUpdateRequest<T>(pwa.collection, entity, pwa.entityId);
 				entity = await request.ExecuteAsync();
 
-				result = SyncQueue.Remove(tempID);
+				result = SyncQueue.Remove(pwa);
 
 				if (result == 0)
 				{
@@ -172,7 +172,7 @@ namespace Kinvey
 
 				if (kdr.count == 1)
 				{
-					result = SyncQueue.Remove(pwa.entityId);
+					result = SyncQueue.Remove(pwa);
 
 					if (result == 0)
 					{

--- a/TestFramework/Tests.Unit/Tests.Unit.csproj
+++ b/TestFramework/Tests.Unit/Tests.Unit.csproj
@@ -81,6 +81,7 @@
     <Compile Include="..\TestSupportFiles\TestSetup.cs">
       <Link>TestSupportFiles\TestSupportFiles\TestSetup.cs</Link>
     </Compile>
+    <Compile Include="Tests\DataStoreUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Kinvey-Utils\Kinvey-Utils.csproj">

--- a/TestFramework/Tests.Unit/Tests/DataStoreUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/DataStoreUnitTests.cs
@@ -1,0 +1,98 @@
+﻿using NUnit.Framework;
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Kinvey;
+using System.Threading;
+using Newtonsoft.Json.Linq;
+
+namespace TestFramework
+{
+    [TestFixture]
+    public class DataStoreUnitTests
+    {
+        [Test]
+        public void TestSync()
+        {
+            Mock<RestSharp.IRestClient> moqRestClient = new Mock<RestSharp.IRestClient>();
+
+            Client.Builder clientBuilder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret)
+                .setFilePath(TestSetup.db_dir)
+                .setOfflinePlatform(new SQLite.Net.Platform.Generic.SQLitePlatformGeneric())
+                .SetRestClient(moqRestClient.Object);
+
+            Client client = clientBuilder.Build();
+
+            if (client.ActiveUser != null)
+                client.ActiveUser.Logout();
+
+            {
+                RestSharp.IRestResponse moqResponse = new RestSharp.RestResponse();
+
+                JObject moqResponseContent = new JObject();
+                moqResponseContent["_id"] = new Guid().ToString();
+                moqResponseContent["username"] = new Guid().ToString();
+
+                var kmd = new JObject();
+                kmd["authtoken"] = new Guid().ToString();
+                moqResponseContent["_kmd"] = kmd;
+
+                moqResponse.Content = moqResponseContent.ToString();
+                moqResponse.StatusCode = System.Net.HttpStatusCode.OK; // Status Code - 504
+                moqRestClient.Setup(m => m.ExecuteAsync(It.IsAny<RestSharp.IRestRequest>())).ReturnsAsync(moqResponse);
+            }
+
+            var user = User.LoginAsync(client).Result;
+
+            var dataStore = DataStore<Person>.Collection("Person", DataStoreType.SYNC, client);
+            dataStore.ClearCache();
+
+            var person = new Person { FirstName = "Victor" };
+            Assert.AreEqual(0, dataStore.GetSyncCount());
+            person = dataStore.SaveAsync(person).Result;
+            Assert.AreEqual(1, dataStore.GetSyncCount());
+
+			{
+				RestSharp.IRestResponse moqResponse = new RestSharp.RestResponse();
+
+				JObject moqResponseContent = new JObject();
+				moqResponseContent["_id"] = new Guid().ToString();
+                moqResponseContent["FirstName"] = person.FirstName;
+
+				moqResponse.Content = moqResponseContent.ToString();
+				moqResponse.StatusCode = System.Net.HttpStatusCode.OK; // Status Code - 504
+				moqRestClient.Setup(m => m.ExecuteAsync(It.IsAny<RestSharp.IRestRequest>())).ReturnsAsync(moqResponse);
+			}
+
+            var syncResultTask = dataStore.SyncAsync();
+
+            person.LastName = "Hugo";
+            var person2 = dataStore.SaveAsync(person).Result;
+
+            var syncResult = syncResultTask.Result;
+            Assert.AreEqual(1, dataStore.GetSyncCount());
+            Assert.AreEqual(1, syncResult.PushResponse.PushCount);
+            Assert.AreEqual(1, syncResult.PushResponse.PushEntities.Count);
+
+			person.LastName = "Barros";
+			var person3 = dataStore.SaveAsync(person).Result;
+
+			{
+				RestSharp.IRestResponse moqResponse = new RestSharp.RestResponse();
+
+				JObject moqResponseContent = new JObject();
+				moqResponseContent["_id"] = new Guid().ToString();
+				moqResponseContent["LastName"] = person.LastName;
+
+				moqResponse.Content = moqResponseContent.ToString();
+				moqResponse.StatusCode = System.Net.HttpStatusCode.OK; // Status Code - 504
+				moqRestClient.Setup(m => m.ExecuteAsync(It.IsAny<RestSharp.IRestRequest>())).ReturnsAsync(moqResponse);
+			}
+
+            var syncResult2 = dataStore.SyncAsync().Result;
+			Assert.AreEqual(0, dataStore.GetSyncCount());
+			Assert.AreEqual(1, syncResult.PushResponse.PushCount);
+			Assert.AreEqual(1, syncResult.PushResponse.PushEntities.Count);
+        }
+    }
+}


### PR DESCRIPTION
#### Description

Make sure the code is thread safe, so in case of any operation is performed while `sync()` still running everything still consistent

#### Changes

* Deleting the pending operation by `key` (pending operation key) instead of `entityId`

#### Tests

* To be added soon