### PR TITLE
Show Sqlite commands for debug purposes

### DIFF
--- a/Kinvey.Core/Offline/SQLiteCacheManager.cs
+++ b/Kinvey.Core/Offline/SQLiteCacheManager.cs
@@ -13,12 +13,11 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-
+using KinveyUtils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using SQLite.Net;
@@ -37,7 +36,7 @@ namespace Kinvey
 		{
 			public void Receive(string message)
 			{
-				Debug.WriteLine(message);
+                Logger.Log(message);
 			}
 		}
 
@@ -59,7 +58,7 @@ namespace Kinvey
 					//var connectionFactory = new Func<SQLiteConnectionWithLock>(()=>new SQLiteConnectionWithLock(platform, new SQLiteConnectionString(this.dbpath, false, null, new KinveyContractResolver())));
 					//dbConnection = new SQLiteAsyncConnection (connectionFactory);
 					_dbConnectionSync = new SQLiteConnection(platform, dbpath, false, null, null, null, new KinveyContractResolver());
-                    //_dbConnectionSync.TraceListener = new DebugTraceListener();
+                    _dbConnectionSync.TraceListener = new DebugTraceListener();
 				}
 
 				return _dbConnectionSync;

--- a/Kinvey.Core/Offline/SQLiteCacheManager.cs
+++ b/Kinvey.Core/Offline/SQLiteCacheManager.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -31,6 +32,15 @@ namespace Kinvey
 	/// </summary>
 	public class SQLiteCacheManager : ICacheManager
 	{
+
+		private class DebugTraceListener : ITraceListener
+		{
+			public void Receive(string message)
+			{
+				Debug.WriteLine(message);
+			}
+		}
+
 		//The version of the internal structure of the database.
 		private int databaseSchemaVersion = 1;
 
@@ -49,6 +59,7 @@ namespace Kinvey
 					//var connectionFactory = new Func<SQLiteConnectionWithLock>(()=>new SQLiteConnectionWithLock(platform, new SQLiteConnectionString(this.dbpath, false, null, new KinveyContractResolver())));
 					//dbConnection = new SQLiteAsyncConnection (connectionFactory);
 					_dbConnectionSync = new SQLiteConnection(platform, dbpath, false, null, null, null, new KinveyContractResolver());
+                    //_dbConnectionSync.TraceListener = new DebugTraceListener();
 				}
 
 				return _dbConnectionSync;


### PR DESCRIPTION
#### Description

Show Sqlite commands for debug purposes

#### Changes

* Adding a `TraceListener` in the Sqlite connection so we can log the commands

#### Tests

* No need