### PR TITLE
MLIBZ-2027 Add check for enqueuing a PUT when a PUT already exists for that entityId.

### DIFF
--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -52,5 +52,10 @@ namespace Kinvey
 		internal const string STR_REALTIME_CHANNEL_GROUP = "userChannelGroup";
 		internal const string STR_REALTIME_STREAM_NAME = "streamName";
 		internal const string STR_REALTIME_PUBLISH_SUBSTREAM_CHANNEL_NAME = "substreamChannelName";
+
+        // REST Method Strings
+        internal const string STR_REST_METHOD_POST = "POST";
+        internal const string STR_REST_METHOD_PUT = "PUT";
+        internal const string STR_REST_METHOD_DELETE = "DELETE";
 	}
 }


### PR DESCRIPTION
#### Description
In the cases where offline data is stored, if an entity is created on the client with a custom ID, all save actions performed on that client ID appear as `PUT` operation. In this case, if another modification was made to the entity and saved, this would also appear as a `PUT`, and duplicated in the sync queue.

#### Changes
Add check for enqueuing a `PUT` operation for an entity when another `PUT` already exists for that entity.  In this case, we do not enqueue anything.

#### Tests
Unit tests added to cover custom ID case.
