### PR TITLE
Feature/mlibz 2078 update user exception

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -1485,16 +1485,10 @@ namespace Kinvey
 				{
 					KinveyAuthResponse auth = new KinveyAuthResponse();
 
-					auth.UserId =  u["_id"].ToString();
-
-					KinveyUserMetaData kmd = new KinveyUserMetaData();
-
-					kmd.Add("lmt", u["_kmd.lmt"]) ;
-					kmd.Add("authtoken", u["_kmd.authtoken"]);
-					kmd.Add("_kmd", u["_kmd"]);
-					auth.UserMetaData = kmd;
-					auth.username =  u["username"].ToString();
-					auth.Attributes = u.Attributes;
+                    auth.UserId = u.Id;
+                    auth.UserMetaData = u.Metadata;
+                    auth.username = u.UserName;
+                    auth.Attributes = u.Attributes;
 
 					string utype = user.type.ToString();
 				

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -659,16 +659,37 @@ namespace TestFramework
 			});
 		}
 
-		[Test]
-		[Ignore("Placeholder - No unit test yet")]
-		public async Task TestUpdateUserAsync()
-		{
-			// Arrange
+        [Test]
+        public async Task TestUpdateUserAsync()
+        {
+            // Setup
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+            const string TEST_KEY = "test_key";
+            const string TEST_VALUE = "test_value";
 
-			// Act
+            // Arrange
+            kinveyClient.ActiveUser.Attributes.Remove(TEST_KEY);
+            kinveyClient.ActiveUser.Attributes.Add(TEST_KEY, TEST_VALUE);
+            Assert.That(kinveyClient.ActiveUser.Attributes.ContainsKey(TEST_KEY));
 
-			// Assert
-		}
+            // Act
+            // Assert
+            User u = null;
+            Assert.DoesNotThrowAsync(async delegate ()
+            {
+                u = await kinveyClient.ActiveUser.UpdateAsync();
+            });
+
+            Assert.That(u != null);
+            Assert.That(u.Attributes.ContainsKey(TEST_KEY));
+            Assert.That(kinveyClient.ActiveUser.Attributes.ContainsKey(TEST_KEY));
+            Assert.That(kinveyClient.ActiveUser.Attributes.Count == u.Attributes.Count);
+
+            // Teardown
+            kinveyClient.ActiveUser.Attributes.Remove(TEST_KEY);
+            await kinveyClient.ActiveUser.UpdateAsync();
+            kinveyClient.ActiveUser.Logout();
+        }
 
 		[Test]
 		[Ignore("Placeholder - No unit test yet")]


### PR DESCRIPTION
#### Description
There was an issue with saving some of the `User` information in a successful `UpdateAsync` call, which would throw an exception.

#### Changes
Change the way information is saved from the successful response of `UpdateAsync`.  Previously it was accessing the response like a `JObject`. Now the deserialized `User` object is used to access the necessary fields.

#### Tests
Added an `UpdateAsync` test.
