### PR TITLE
Feature/mlibz 1564 resumable file upload

### DIFF
--- a/Kinvey.Core/Core/KinveyHeaders.cs
+++ b/Kinvey.Core/Core/KinveyHeaders.cs
@@ -29,7 +29,7 @@ namespace Kinvey
 
 		// The kinvey API version.
         static string kinveyApiVersionKey = "X-Kinvey-API-Version";
-        static string kinveyApiVersion = "3";
+        static string kinveyApiVersion = "4";
 
 		// The user agent.
         static string userAgentKey = "user-agent";

--- a/Kinvey.Core/File/KinveyFileRequest.cs
+++ b/Kinvey.Core/File/KinveyFileRequest.cs
@@ -114,17 +114,9 @@ namespace Kinvey
 
                             case 308:
                                 // Resumable file upload case - check range header
-                                if (actualResponse.Headers.AllKeys.Contains("Range"))
-                                {
-                                    // Parse Range header and set the start byte accordingly
-                                    foreach (string header in actualResponse.Headers.AllKeys)
-                                    {
-                                        if (header.StartsWith("Range", StringComparison.OrdinalIgnoreCase))
-                                        {
-                                            startByte = DetermineStartByteFromRange(header);
-                                        }
-                                    }
-                                }
+                                var rangeHeader = resp.Headers[System.Net.HttpRequestHeader.Range];
+                                startByte = DetermineStartByteFromRange(rangeHeader);
+
                                 break;
 
                             default:
@@ -147,20 +139,23 @@ namespace Kinvey
         {
             int startByte = 0;
 
-            // Parse Range header and set the start byte accordingly
-            int lastByteSent = 0;
+            if (rangeHeaderValue != null)
+            {
+                // Parse Range header and set the start byte accordingly
+                int lastByteSent = 0;
 
-            // Example format: bytes=0-42
-            char[] delims = new char[] { '-' };
-            lastByteSent = Int32.Parse(rangeHeaderValue.Split(delims)[1]);
-            startByte = lastByteSent + 1;
+                // Example format: bytes=0-42
+                char[] delims = new char[] { '-' };
+                lastByteSent = Int32.Parse(rangeHeaderValue.Split(delims)[1]);
+                startByte = lastByteSent + 1;
+            }
 
             return startByte;
         }
 
         #endregion
 
-		#region KinveyFileRequest download methods
+        #region KinveyFileRequest download methods
 
 		internal async Task downloadFileAsync(FileMetaData metadata, Stream stream)
 		{
@@ -187,7 +182,7 @@ namespace Kinvey
 			return response;
 		}
 
-		#endregion
+        #endregion
 	}
 }
 

--- a/Kinvey.Core/Properties/AssemblyInfo.cs
+++ b/Kinvey.Core/Properties/AssemblyInfo.cs
@@ -25,3 +25,5 @@ using System.Runtime.CompilerServices;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
+// Make internal methods visible to unit test framework
+[assembly: InternalsVisibleTo("Tests.Unit")]

--- a/TestFramework/Tests.Unit/Tests.Unit.csproj
+++ b/TestFramework/Tests.Unit/Tests.Unit.csproj
@@ -82,6 +82,7 @@
       <Link>TestSupportFiles\TestSupportFiles\TestSetup.cs</Link>
     </Compile>
     <Compile Include="Tests\DataStoreUnitTests.cs" />
+    <Compile Include="Tests\FileUnitTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Kinvey-Utils\Kinvey-Utils.csproj">

--- a/TestFramework/Tests.Unit/Tests/FileUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/FileUnitTests.cs
@@ -73,5 +73,19 @@ namespace TestFramework
             // Assert
             Assert.That(startByte == 43);
         }
+
+        [Test]
+        public void TestDetermineStartByteFromRangeNullHeaderValue()
+        {
+            // Arrange
+            string rangeHeader = null;
+            int startByte = 0;
+
+            // Act
+            startByte = KinveyFileRequest.DetermineStartByteFromRange(rangeHeader);
+
+            // Assert
+            Assert.That(startByte == 0);
+        }
     }
 }

--- a/TestFramework/Tests.Unit/Tests/FileUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/FileUnitTests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) 2017, Kinvey, Inc. All rights reserved.
+//
+// This software is licensed to you under the Kinvey terms of service located at
+// http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+// software, you hereby accept such terms of service  (and any agreement referenced
+// therein) and agree that you have read, understand and agree to be bound by such
+// terms of service and are of legal age to agree to such terms with Kinvey.
+//
+// This software contains valuable confidential and proprietary information of
+// KINVEY, INC and is subject to applicable licensing agreements.
+// Unauthorized reproduction, transmission or distribution of this file and its
+// contents is a violation of applicable laws.
+
+using System;
+using System.Threading.Tasks;
+using Moq;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using Kinvey;
+
+namespace TestFramework
+{
+    [TestFixture]
+    public class FileUnitTests
+    {
+        [SetUp]
+        public void Setup()
+        {
+        }
+
+        [TearDown]
+        public void Tear()
+        {
+            System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+            System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+        }
+
+        [Test]
+        public async Task TestFileCheckResumableStatus()
+        {
+            // Arrange
+            var moqRestClient = new Mock<RestSharp.IRestClient>();
+
+            var response = new Mock<System.Net.WebResponse>();
+            //response.Setup(r => (r as System.Net.HttpWebResponse).StatusCode).Returns((System.Net.HttpStatusCode)308);
+            var innerException = new System.Net.WebException("MOCK EXCEPTION", null, System.Net.WebExceptionStatus.ProtocolError, response.Object);
+            var ex = new Exception("MOCK RESUMABLE EXCEPTION", innerException);
+            moqRestClient.Setup(m => m.ExecuteAsync(It.IsAny<RestSharp.IRestRequest>())).ThrowsAsync(ex);
+
+            Client.Builder cb = new Client.Builder(TestSetup.app_key, TestSetup.app_secret)
+				.SetRestClient(moqRestClient.Object);
+
+            Client c = cb.Build();
+
+            // Act
+            var kfr = new KinveyFileRequest(c, null, null, null, null);
+            int startByte = await kfr.CheckResumableStateAsync("https://www.fakeurl.edu", 1000);
+
+            // Assert
+            Assert.That(startByte == 0);
+        }
+    }
+}

--- a/TestFramework/Tests.Unit/Tests/FileUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/FileUnitTests.cs
@@ -59,5 +59,19 @@ namespace TestFramework
             // Assert
             Assert.That(startByte == 0);
         }
+
+        [Test]
+        public void TestDetermineStartByteFromRange()
+        {
+            // Arrange
+            string rangeHeader = "bytes=0-42";
+            int startByte = 0;
+
+            // Act
+            startByte = KinveyFileRequest.DetermineStartByteFromRange(rangeHeader);
+
+            // Assert
+            Assert.That(startByte == 43);
+        }
     }
 }


### PR DESCRIPTION
#### Description
Implement Resumable File Uploads for Xamarin/.NET.  Currently, this is not possible for Xamarin because `308` status codes are seen as invalid by Mono, but the current code should not break uploads for Xamarin.  It will just attempt to upload the whole file.

#### Changes
Check the resumable state of the file first, and use the `Range` header (if it exists) to determine where in the file to continue the file upload. Worst-case scenario, the whole file upload will be attempted, just as it was before.

#### Tests
Unit tests added, existing integration tests still pass.
