### PR TITLE
MLIBZ-2196 Correctly persist client ID in credential store for normal MIC flow.

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -685,6 +685,7 @@ namespace Kinvey
 				currentCred.AccessToken = result["access_token"].ToString();
 				currentCred.RefreshToken = result["refresh_token"].ToString();
 				currentCred.RedirectUri = uc.MICRedirectURI;
+                currentCred.MICClientID = clientID;
 				uc.Store.Store(u.Id, uc.SSOGroupKey, currentCred);
 
 				if (uc.MICDelegate != null)


### PR DESCRIPTION
#### Description
In normal MIC flow, the refresh token is not being respected, and users are being logged out after the TTL expires.

#### Changes
The root cause is that the MIC Client ID is not being properly persisted in the credential store, which is preventing the refresh token from being used properly.

#### Tests
Tested with customer app.