### PR TITLE
MLIBZ-2334 Add separated SetInstanceID method to client builder.

### DIFF
--- a/Kinvey.Core/Client/Client.cs
+++ b/Kinvey.Core/Client/Client.cs
@@ -145,6 +145,8 @@ namespace Kinvey
 
 			private string ssoGroupKey;
 
+            private string instanceID;
+
 			/// <summary>
 			/// Initializes a new instance of the <see cref="T:KinveyXamarin.Client.Builder"/> class.
 			/// </summary>
@@ -154,6 +156,7 @@ namespace Kinvey
 				: base(new RestClient(), new KinveyClientRequestInitializer(appKey, appSecret, new KinveyHeaders()))
 			{
 				ssoGroupKey = appKey;
+                instanceID = string.Empty;
 			}
 
 			/// <summary>
@@ -186,8 +189,12 @@ namespace Kinvey
 				c.logger = this.log;
 				c.senderID = this.senderID;
 				c.SSOGroupKey = this.ssoGroupKey;
+                if (!string.IsNullOrEmpty(instanceID))
+                {
+                    c.MICHostName = $"{Constants.STR_PROTOCOL_HTTPS + instanceID + Constants.STR_HYPHEN + Constants.STR_HOSTNAME_AUTH}";
+                }
 
-				Logger.initialize (c.logger);
+                Logger.initialize (c.logger);
 
 				SharedClient = c;
 
@@ -285,6 +292,14 @@ namespace Kinvey
 				this.ssoGroupKey = ssoGroupKey;
 				return this;
 			}
-		}
+
+            public Builder SetInstanceID(string instanceID)
+            {
+                this.instanceID = instanceID;
+                string url = $"{Constants.STR_PROTOCOL_HTTPS + instanceID + Constants.STR_HYPHEN + Constants.STR_HOSTNAME_API}";
+                this.setBaseURL(url);
+                return this;
+            }
+        }
 	}
 }

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -28,6 +28,7 @@ namespace Kinvey
 		public const string STR_EQUAL = "=";
 		internal const string STR_SQUARE_BRACKET_OPEN = "[";
 		internal const string STR_SQUARE_BRACKET_CLOSE = "]";
+        internal const string STR_HYPHEN = "-";
 
 		// Core Product Strings
 		internal const string STR_APP_KEY = "appKey";
@@ -58,5 +59,10 @@ namespace Kinvey
         internal const string STR_REST_METHOD_POST = "POST";
         internal const string STR_REST_METHOD_PUT = "PUT";
         internal const string STR_REST_METHOD_DELETE = "DELETE";
+
+        // Hostname Strings
+        internal const string STR_PROTOCOL_HTTPS = "https://";
+        internal const string STR_HOSTNAME_API = "baas.kinvey.com";
+        internal const string STR_HOSTNAME_AUTH = "auth.kinvey.com";
 	}
 }

--- a/TestFramework/Tests.Unit/Tests/ClientUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/ClientUnitTests.cs
@@ -126,6 +126,26 @@ namespace TestFramework
 			Assert.True(string.Equals(builder.BaseUrl, url));
 		}
 
+        [Test]
+        public void ClientBuilderSetInstanceID()
+        {
+            // Arrange
+            const string instanceID = "testInstanceID";
+            Client.Builder builder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret);
+
+            // Act
+            builder.SetInstanceID(instanceID);
+            var client = builder.Build();
+
+            // Assert
+            Assert.False(string.IsNullOrEmpty(builder.BaseUrl));
+            Assert.False(string.Equals(builder.BaseUrl, AbstractClient.DefaultBaseUrl));
+            Assert.True(string.Equals(builder.BaseUrl, "https://testInstanceID-baas.kinvey.com/"));
+
+            Assert.False(string.Equals(client.MICHostName, "https://auth.kinvey.com/"));
+            Assert.True(string.Equals(client.MICHostName, "https://testInstanceID-auth.kinvey.com/"));
+        }
+
 		[Test]
 		public void ClientBuilderSetBaseURLBad()
 		{


### PR DESCRIPTION
#### Description
Feature to create a new way of setting an instance ID on a client initialization, so that correct API and Auth hostnames are created without having to provide a FQDN.

#### Changes
New setter created in the client builder to set the instance ID.

#### Tests
Unit tests
