### PR TITLE
MLIBZ-2223 Live service collection updates filtered out

### DIFF
--- a/Kinvey.Core/Realtime/RealtimeRouter.cs
+++ b/Kinvey.Core/Realtime/RealtimeRouter.cs
@@ -164,6 +164,10 @@ namespace Kinvey
 
         internal void UnsubscribeCollection(string collectionName)
         {
+            // Remove specifically-created active user channel (see MLIBZ-2223 for more information)
+            string activeUserChannel = BuildCollectionUserChannel(collectionName, Client.SharedClient.ActiveUser.Id);
+            RemoveChannel(activeUserChannel);
+
             string appKey = (KinveyClient.RequestInitializer as KinveyClientRequestInitializer).AppKey;
             string channel = appKey + Constants.CHAR_PERIOD + Constants.STR_REALTIME_COLLECTION_CHANNEL_PREPEND + collectionName;
             RemoveChannel(channel);

--- a/Kinvey.Core/Realtime/RealtimeRouter.cs
+++ b/Kinvey.Core/Realtime/RealtimeRouter.cs
@@ -152,6 +152,14 @@ namespace Kinvey
             string appKey = (KinveyClient.RequestInitializer as KinveyClientRequestInitializer).AppKey;
             string channel = appKey + Constants.CHAR_PERIOD + Constants.STR_REALTIME_COLLECTION_CHANNEL_PREPEND + collectionName;
             AddChannel(channel, callback);
+
+            // In the case of collection subscription, in addition to creating a
+            // channel for the collection, another channel should be created for
+            // this collection and the active user, since certain ACL rules may
+            // not allow collection-wide subscription, but may allow this user
+            // access to the update (see MLIBZ-2223 for more information).
+            string activeUserChannel = channel + Constants.CHAR_PERIOD + Constants.STR_REALTIME_USER_CHANNEL_PREPEND + Client.SharedClient.ActiveUser.Id;
+            AddChannel(activeUserChannel, callback);
         }
 
         internal void UnsubscribeCollection(string collectionName)

--- a/Kinvey.Core/Realtime/RealtimeRouter.cs
+++ b/Kinvey.Core/Realtime/RealtimeRouter.cs
@@ -158,7 +158,7 @@ namespace Kinvey
             // this collection and the active user, since certain ACL rules may
             // not allow collection-wide subscription, but may allow this user
             // access to the update (see MLIBZ-2223 for more information).
-            string activeUserChannel = channel + Constants.CHAR_PERIOD + Constants.STR_REALTIME_USER_CHANNEL_PREPEND + Client.SharedClient.ActiveUser.Id;
+            string activeUserChannel = BuildCollectionUserChannel(collectionName, Client.SharedClient.ActiveUser.Id);
             AddChannel(activeUserChannel, callback);
         }
 
@@ -207,6 +207,14 @@ namespace Kinvey
         void RemoveChannel(string channel)
         {
             mapChannelToCallback.Remove(channel);
+        }
+
+        string BuildCollectionUserChannel(string collectionName, string userId)
+        {
+            string appKey = (KinveyClient.RequestInitializer as KinveyClientRequestInitializer).AppKey;
+            string collectionChannel = Constants.STR_REALTIME_COLLECTION_CHANNEL_PREPEND + collectionName;
+            string userChannel = Constants.STR_REALTIME_USER_CHANNEL_PREPEND + userId;
+            return appKey + Constants.CHAR_PERIOD + collectionChannel + Constants.CHAR_PERIOD + userChannel;
         }
 
         KinveyException HandleStatusMessage(PubnubApi.PNStatus status)

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -47,6 +47,7 @@ namespace Kinvey
 		// Realtime Strings
 		internal const string STR_REALTIME_COLLECTION_CHANNEL_PREPEND = "c-";
 		internal const string STR_REALTIME_STREAM_CHANNEL_PREPEND = "s-";
+        internal const string STR_REALTIME_USER_CHANNEL_PREPEND = "u-";
 		internal const string STR_REALTIME_DEVICEID = "deviceId";
 		internal const string STR_REALTIME_SUBSCRIBE_KEY = "subscribeKey";
 		internal const string STR_REALTIME_PUBLISH_KEY = "publishKey";


### PR DESCRIPTION
#### Description
A case was not being handled for collection subscription, where the ACL for an entity may not be set for being globally readable, but the active user may be allowed to read the update. In this case, the Live Service update was properly coming through to the SDK, but the SDK was filtering out this message because it did not correspond to a valid channel.

#### Changes
When a collection subscription channel is added, also add a collection-active user specific channel, in order to capture updates with the aforementioned ACL.

#### Tests
Integrated tests.
