### PR TITLE
Feature/mlibz 2403 use long form authservice id for token endpoint

### DIFF
--- a/Kinvey.Core/Auth/Credential.cs
+++ b/Kinvey.Core/Auth/Credential.cs
@@ -183,7 +183,7 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="clientRequest">Client Request.</param>
 		/// <typeparam name="T">The type of the Client Request</typeparam>
-		public void Initialize<T>(AbstractKinveyClientRequest<T> clientRequest)
+		public void Initialize<T>(AbstractKinveyClientRequest<T> clientRequest, string clientId = null)
 		{
 			if (authToken != null)
 			{

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -1045,7 +1045,7 @@ namespace Kinvey
 		#region User class blocking private classes - used to build up requests
 
 		// Generates a request to exchange the OAuth2.0 authorization code for a MIC user token
-		static private RetrieveMICAccessTokenRequest GetMICToken(AbstractClient cli, String code, string clientID)
+		static internal RetrieveMICAccessTokenRequest GetMICToken(AbstractClient cli, String code, string clientID)
 		{
 			//        grant_type: "authorization_code" - this is always set to this value
 			//        code: use the ‘code’ returned in the callback 
@@ -1093,7 +1093,7 @@ namespace Kinvey
 		}
 
 		// Generates a request to get a temporary MIC URL (automated authorization grant flow)
-		static private GetMICTempURLRequest BuildMICTempURLRequest(AbstractClient cli, string clientID)
+		static internal GetMICTempURLRequest BuildMICTempURLRequest(AbstractClient cli, string clientID)
 		{
 			//    	client_id:  this is the app’s appKey (the KID)
 			//    	redirect_uri:  the uri that the grant will redirect to on authentication, as set in the console. Note, this must exactly match one of the redirect URIs configured in the console.
@@ -1297,7 +1297,7 @@ namespace Kinvey
 		}
 
 		// Request to get MIC temp URL (automated authorization grant flow)
-		private class GetMICTempURLRequest : AbstractKinveyClientRequest<JObject>
+		internal class GetMICTempURLRequest : AbstractKinveyClientRequest<JObject>
 		{
 			private const string REST_PATH = "oauth/auth";
 

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -1065,7 +1065,7 @@ namespace Kinvey
 
 			RetrieveMICAccessTokenRequest getToken = new RetrieveMICAccessTokenRequest(cli, cli.MICHostName, data, urlParameters);
 			getToken.RequireAppCredentials =  true;
-			cli.InitializeRequest(getToken);
+            cli.InitializeRequest(getToken, clientID);
 			return getToken;
 		}
 
@@ -1088,7 +1088,7 @@ namespace Kinvey
 
 			RetrieveMICAccessTokenRequest getToken = new RetrieveMICAccessTokenRequest(client, client.MICHostName, data, urlParameters);
 			getToken.RequireAppCredentials = true;
-			client.InitializeRequest(getToken);
+            client.InitializeRequest(getToken, clientID);
 			return getToken;
 		}
 

--- a/Kinvey.Core/Client/AbstractKinveyClient.cs
+++ b/Kinvey.Core/Client/AbstractKinveyClient.cs
@@ -214,11 +214,11 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="request">Request.</param>
 		/// <typeparam name="T">The Type of the response</typeparam>
-        public void InitializeRequest<T>(AbstractKinveyClientRequest<T> request)
+        public void InitializeRequest<T>(AbstractKinveyClientRequest<T> request, string clientID = null)
         {
             if (RequestInitializer != null) 
             {
-                RequestInitializer.Initialize(request);
+                RequestInitializer.Initialize(request, clientID);
             }
         }
 

--- a/Kinvey.Core/Core/IKinveyRequestInitializer.cs
+++ b/Kinvey.Core/Core/IKinveyRequestInitializer.cs
@@ -29,8 +29,6 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="request">Request.</param>
 		/// <typeparam name="T">The response type of the request.</typeparam>
-        void Initialize<T>(AbstractKinveyClientRequest<T> request);
-
-
+        void Initialize<T>(AbstractKinveyClientRequest<T> request, string clientId = null);
     }
 }

--- a/Kinvey.Core/Core/KinveyClientRequestInitializer.cs
+++ b/Kinvey.Core/Core/KinveyClientRequestInitializer.cs
@@ -105,7 +105,8 @@ namespace Kinvey
 		/// </summary>
 		/// <param name="request">Request.</param>
 		/// <typeparam name="T">The response type of the request.</typeparam>
-        public void Initialize<T>(AbstractKinveyClientRequest<T> request)
+
+        public void Initialize<T>(AbstractKinveyClientRequest<T> request, string clientId = null)
         {
 			
 			if (!request.RequireAppCredentials)
@@ -124,7 +125,14 @@ namespace Kinvey
 			}
 			if (request.RequireAppCredentials)
             {
-                request.RequestAuth = new HttpBasicAuthenticator(AppKey, AppSecret);
+                if (string.IsNullOrEmpty(clientId))
+                {
+                    request.RequestAuth = new HttpBasicAuthenticator(AppKey, AppSecret);
+                }
+                else
+                {
+                    request.RequestAuth = new HttpBasicAuthenticator(clientId, AppSecret);
+                }
             }
             request.AppKey = appKey;
 

--- a/Kinvey.Core/Core/KinveyClientRequestInitializer.cs
+++ b/Kinvey.Core/Core/KinveyClientRequestInitializer.cs
@@ -82,6 +82,11 @@ namespace Kinvey
             get { return appSecret; }
         }
 
+        public string AuthServiceID
+        {
+            get; private set;
+        }
+
 		/// <summary>
 		/// Gets the headers.
 		/// </summary>
@@ -108,8 +113,9 @@ namespace Kinvey
 
         public void Initialize<T>(AbstractKinveyClientRequest<T> request, string clientId = null)
         {
-			
-			if (!request.RequireAppCredentials)
+            AuthServiceID = clientId ?? AppKey;
+
+            if (!request.RequireAppCredentials)
 			{
 				if (credential == null ||
 					credential.UserId == null ||
@@ -123,17 +129,12 @@ namespace Kinvey
             {
                 credential.Initialize(request);
 			}
-			if (request.RequireAppCredentials)
+
+            if (request.RequireAppCredentials)
             {
-                if (string.IsNullOrEmpty(clientId))
-                {
-                    request.RequestAuth = new HttpBasicAuthenticator(AppKey, AppSecret);
-                }
-                else
-                {
-                    request.RequestAuth = new HttpBasicAuthenticator(clientId, AppSecret);
-                }
+                request.RequestAuth = new HttpBasicAuthenticator(AuthServiceID, AppSecret);
             }
+
             request.AppKey = appKey;
 
             foreach (var header in Headers)

--- a/Kinvey.Core/Properties/AssemblyInfo.cs
+++ b/Kinvey.Core/Properties/AssemblyInfo.cs
@@ -25,3 +25,4 @@ using System.Runtime.CompilerServices;
 //[assembly: AssemblyDelaySign(false)]
 //[assembly: AssemblyKeyFile("")]
 
+[assembly: InternalsVisibleToAttribute("Tests.Unit")]

--- a/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
@@ -90,5 +90,31 @@ namespace TestFramework
 			Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, ke.ErrorCode);
 			Assert.AreEqual(504, ke.StatusCode); // HttpStatusCode.GatewayTimeout
 		}
+
+        [Test]
+        public async Task TestMICValidateAuthServiceID()
+        {
+            // Arrange
+            Client.Builder builder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret);
+            Client client = builder.Build();
+            string appKey = ((KinveyClientRequestInitializer)client.RequestInitializer).AppKey;
+            string micID = "12345";
+            string expectedClientId = TestSetup.app_key + "." + micID;
+
+            // Act
+
+            // Test AuthServiceID after setting a clientId
+            var requestWithClientID = User.GetMICToken(client, "fake_code", appKey + Constants.CHAR_PERIOD + micID);
+            string clientId = ((KinveyClientRequestInitializer)client.RequestInitializer).AuthServiceID;
+
+            // Test to verify that initializing a request other than `/oauth/token` will
+            // reset the AuthServiceID back to the default, which is AppKey.
+            var req = User.BuildMICTempURLRequest(client, null);
+            string shouldBeDefaultClientId = ((KinveyClientRequestInitializer)client.RequestInitializer).AuthServiceID;
+
+            // Assert
+            Assert.True(clientId == expectedClientId);
+            Assert.True(shouldBeDefaultClientId == appKey);
+        }
 	}
 }


### PR DESCRIPTION
#### Description
KAS requires that the full `authServiceId` be passed in the auth header for calls to the `/oauth/token` endpoint.

#### Changes
Change the request initializer to take an optional clientId parameter, which represents the `authServiceId` to use instead of `appKey`. Also change some internal access to methods and classes to allow for unit testing.

#### Tests
Unit tests.
