### PR TITLE
MLIBZ-2499 Add scope=openid to render URL for MIC. Add unit test.

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -549,7 +549,7 @@ namespace Kinvey
 
 			ct.ThrowIfCancellationRequested();
 
-			string myURLToRender = hostname + "oauth/auth?client_id=" + clientID + "&redirect_uri=" + redirectURI + "&response_type=code";
+			string myURLToRender = hostname + "oauth/auth?client_id=" + clientID + "&redirect_uri=" + redirectURI + "&response_type=code" + "&scope=openid";
 
 			//keep a reference to the redirect uri for later
 			uc.MICRedirectURI = redirectURI;


### PR DESCRIPTION
#### Description
With MIC v3, **_"scope=openid"_** has to be passed in as a parameter to the **_/oauth/auth_** endpoint. This was missing in the render URL in normal MIC flow.

#### Changes
Add **_"scope=openid"_** to the render URL passed back to the MIC delegate during normal MIC flow.

#### Tests
Unit test added to make sure **_"scope=openid"_** is present in the URL.