### PR TITLE
MLIBZ-2545 Added check for ParameterValueOutOfRange

### DIFF
--- a/Kinvey.Core/Store/ReadRequest.cs
+++ b/Kinvey.Core/Store/ReadRequest.cs
@@ -233,12 +233,21 @@ namespace Kinvey
 
                                 switch (ke.StatusCode)
                                 {
-                                    case 400: // ResultSetSizeExceeded
+                                    case 400: // ResultSetSizeExceeded or ParameterValueOutOfRange
                                         if (ke.Error.Equals(Constants.STR_ERROR_BACKEND_RESULT_SET_SIZE_EXCEEDED))
                                         {
                                             // This means that there are greater than 10k items in the delta set.
                                             // Clear QueryCache table and perform regular GET.
                                             return await PerformNetworkGet(mongoQuery);
+                                        }
+                                        else if (ke.Error.Equals(Constants.STR_ERROR_BACKEND_PARAMETER_VALUE_OUT_OF_RANGE))
+                                        {
+                                            // This means that the last sync time for delta set is too far back, or
+                                            // the backend was enabled for delta set after the client was enabled
+                                            // and already attempted a GET.
+
+                                            // Perform regular GET and capture x-kinvey-request-start time
+                                            return await PerformNetworkInitialDeltaGet(mongoQuery);
                                         }
                                         break;
 

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -101,6 +101,7 @@ namespace Kinvey
         // Server-side Delta Sync Error Strings
         internal const string STR_ERROR_BACKEND_MISSING_CONFIGURATION = "MissingConfiguration";
         internal const string STR_ERROR_BACKEND_RESULT_SET_SIZE_EXCEEDED = "ResultSetSizeExceeded";
+        internal const string STR_ERROR_BACKEND_PARAMETER_VALUE_OUT_OF_RANGE = "ParameterValueOutOfRange";
 
         #endregion
     }


### PR DESCRIPTION
#### Description
The `ParameterValueOutOfRange` error was not being correctly handled by the SDK.

#### Changes
When receiving this error, handle by performing a delta set initial GET request, so that the `QueryCache` table entry is made with a new `x-kinvey-request-start` time.

#### Tests
Manual. Unit test will be added as part of `MLIBZ-2471`.
