### PR TITLE
MLIBZ-2578 Changes to .nuspec files to fix installation issue.

### DIFF
--- a/Kinvey-Xamarin-Android.nuspec
+++ b/Kinvey-Xamarin-Android.nuspec
@@ -13,20 +13,21 @@
     <projectUrl>http://devcenter.kinvey.com/xamarin/</projectUrl>
     <tags>Kinvey BaaS</tags>
     <dependencies>
-      <dependency id="Microsoft.Bcl" version="1.1.0"/>
-      <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
-      <dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
-      <dependency id="Microsoft.Net.Http" version="2.2.29"/>
-      <dependency id="modernhttpclient" version="2.4.2"/>
-      <dependency id="Newtonsoft.Json" version="8.0.2"/>
-      <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
-      <dependency id="SQLite.Net-PCL" version="3.1.1"/>
-      <dependency id="SQLite.Net.Platform.XamarinAndroidN" version="3.1.1"/>
-      <dependency id="Xamarin.GooglePlayServices.Gcm" version="27.0.0.0"/>
-      <dependency id="Kinvey" version="3.1.2"/>
+      <group targetFramework="monoandroid">
+        <dependency id="Microsoft.Bcl" version="1.1.10"/>
+        <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+        <dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
+        <dependency id="Microsoft.Net.Http" version="2.2.29"/>
+        <dependency id="modernhttpclient" version="2.4.2"/>
+        <dependency id="Newtonsoft.Json" version="9.0.1"/>
+        <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
+        <dependency id="SQLite.Net-PCL" version="3.1.1"/>
+        <dependency id="Xamarin.GooglePlayServices.Gcm" version="27.0.0.0"/>
+        <dependency id="Kinvey" version="3.1.2"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="Kinvey-Xamarin-Android/obj/Release/Kinvey-Xamarin-Android.dll" target="lib"/>
+    <file src="Kinvey-Xamarin-Android/obj/Release/Kinvey-Xamarin-Android.dll" target="lib\MonoAndroid"/>
   </files>
 </package>

--- a/Kinvey-Xamarin-iOS.nuspec
+++ b/Kinvey-Xamarin-iOS.nuspec
@@ -13,18 +13,20 @@
     <projectUrl>http://devcenter.kinvey.com/xamarin/</projectUrl>
     <tags>Kinvey BaaS</tags>
     <dependencies>
-      <dependency id="Microsoft.Bcl" version="1.1.0"/>
-      <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
-      <dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
-      <dependency id="Microsoft.Net.Http" version="2.2.29"/>
-      <dependency id="modernhttpclient" version="2.4.2"/>
-      <dependency id="Newtonsoft.Json" version="8.0.2"/>
-      <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
-      <dependency id="SQLite.Net-PCL" version="3.1.1"/>
-      <dependency id="Kinvey" version="3.1.2"/>
+      <group targetFramework="xamarinios10">
+        <dependency id="Microsoft.Bcl" version="1.1.10"/>
+        <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+        <dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
+        <dependency id="Microsoft.Net.Http" version="2.2.29"/>
+        <dependency id="modernhttpclient" version="2.4.2"/>
+        <dependency id="Newtonsoft.Json" version="9.0.1"/>
+        <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
+        <dependency id="SQLite.Net-PCL" version="3.1.1"/>
+        <dependency id="Kinvey" version="3.1.2"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
-    <file src="Kinvey-Xamarin-iOS/obj/Release/Kinvey-Xamarin-iOS.dll" target="lib"/>
+    <file src="Kinvey-Xamarin-iOS/obj/Release/Kinvey-Xamarin-iOS.dll" target="lib\xamarinios10"/>
   </files>
 </package>

--- a/Kinvey.Core.nuspec
+++ b/Kinvey.Core.nuspec
@@ -14,12 +14,12 @@
     <tags>Kinvey BaaS</tags>
     <dependencies>
       <group>
-        <dependency id="Microsoft.Bcl" version="1.1.0"/>
+        <dependency id="Microsoft.Bcl" version="1.1.10"/>
         <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
         <dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
         <dependency id="Microsoft.Net.Http" version="2.2.29"/>
         <dependency id="modernhttpclient" version="2.4.2"/>
-        <dependency id="Newtonsoft.Json" version="8.0.2"/>
+        <dependency id="Newtonsoft.Json" version="9.0.1"/>
         <dependency id="PubnubPCL" version="4.0.2.2"/>
         <dependency id="Remotion.Linq" version="2.0.1"/>
         <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
@@ -49,11 +49,41 @@
         <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
         <dependency id="SQLite.Net-PCL" version="3.1.1"/>
       </group>
+      <group targetFramework="monoandroid">
+        <dependency id="Microsoft.Bcl" version="1.1.0"/>
+        <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+        <dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
+        <dependency id="Microsoft.Net.Http" version="2.2.29"/>
+        <dependency id="modernhttpclient" version="2.4.2"/>
+        <dependency id="Newtonsoft.Json" version="8.0.2"/>
+        <dependency id="PubnubPCL" version="4.0.2.2"/>
+        <dependency id="Remotion.Linq" version="2.0.1"/>
+        <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
+        <dependency id="SQLite.Net-PCL" version="3.1.1"/>
+      </group>
+      <group targetFramework="xamarinios10">
+        <dependency id="Microsoft.Bcl" version="1.1.0"/>
+        <dependency id="Microsoft.Bcl.Async" version="1.0.168"/>
+        <dependency id="Microsoft.Bcl.Build" version="1.0.21"/>
+        <dependency id="Microsoft.Net.Http" version="2.2.29"/>
+        <dependency id="modernhttpclient" version="2.4.2"/>
+        <dependency id="Newtonsoft.Json" version="8.0.2"/>
+        <dependency id="PubnubPCL" version="4.0.2.2"/>
+        <dependency id="Remotion.Linq" version="2.0.1"/>
+        <dependency id="SQLite.Net.Async-PCL" version="3.1.1"/>
+        <dependency id="SQLite.Net-PCL" version="3.1.1"/>
+      </group>
     </dependencies>
   </metadata>
   <files>
     <file src="Kinvey-Utils/obj/Release/Kinvey-Utils.dll" target="lib"/>
     <file src="RestSharp.Portable/obj/Release/RestSharp.Portable.dll" target="lib"/>
     <file src="Kinvey.Core/obj/Release/Kinvey.Core.dll" target="lib"/>
+    <file src="Kinvey-Utils/obj/Release/Kinvey-Utils.dll" target="lib\MonoAndroid"/>
+    <file src="RestSharp.Portable/obj/Release/RestSharp.Portable.dll" target="lib\MonoAndroid"/>
+    <file src="Kinvey.Core/obj/Release/Kinvey.Core.dll" target="lib\MonoAndroid"/>
+    <file src="Kinvey-Utils/obj/Release/Kinvey-Utils.dll" target="lib\xamarinios10"/>
+    <file src="RestSharp.Portable/obj/Release/RestSharp.Portable.dll" target="lib\xamarinios10"/>
+    <file src="Kinvey.Core/obj/Release/Kinvey.Core.dll" target="lib\xamarinios10"/>
   </files>
 </package>

--- a/Kinvey.Core/Kinvey.Core.csproj
+++ b/Kinvey.Core/Kinvey.Core.csproj
@@ -176,9 +176,6 @@
     <Reference Include="ModernHttpClient">
       <HintPath>..\packages\modernhttpclient.2.4.2\lib\Portable-Net45+WinRT45+WP8+WPA81\ModernHttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="PubnubPCL">
-      <HintPath>..\packages\PubnubPCL.4.0.2.2\lib\portable45-net45+win8+wpa81\PubnubPCL.dll</HintPath>
-    </Reference>
     <Reference Include="Remotion.Linq">
       <HintPath>..\packages\Remotion.Linq.2.0.1\lib\portable-net45+win+wpa81+wp80\Remotion.Linq.dll</HintPath>
     </Reference>
@@ -189,7 +186,10 @@
       <HintPath>..\packages\SQLite.Net-PCL.3.1.1\lib\portable-win8+net45+wp8+wpa81+MonoAndroid1+MonoTouch1\SQLite.Net.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.11.0.2\lib\portable-net45+win8+wp8+wpa81\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\portable-net45+wp80+win8+wpa81\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="PubnubPCL">
+      <HintPath>..\packages\PubnubPCL.4.0.2.2\lib\portable45-net45+win8+wpa81\PubnubPCL.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Kinvey.Core/packages.config
+++ b/Kinvey.Core/packages.config
@@ -7,7 +7,7 @@
   <package id="Microsoft.NETCore.Platforms" version="1.0.1" targetFramework="portable45-net45+win8+wp8" />
   <package id="modernhttpclient" version="2.4.2" targetFramework="portable45-net45+win8+wpa81" />
   <package id="NETStandard.Library" version="1.6.0" targetFramework="portable45-net45+win8+wp8" />
-  <package id="Newtonsoft.Json" version="11.0.2" targetFramework="portable45-net45+win8+wpa81" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Portable.BouncyCastle" version="1.8.1.1" targetFramework="portable45-net45+win8+wp8" />
   <package id="PubnubPCL" version="4.0.2.2" targetFramework="portable45-net45+win8+wpa81" />
   <package id="Remotion.Linq" version="2.0.1" targetFramework="portable45-net45+win8+wpa81" />


### PR DESCRIPTION
#### Description
An update of the Microsoft Visual Studio IDE made a change to the NuGet package manager that cause our SDK to fail to install.

#### Changes
Make changes to the appropriate `.nuspec` files to allow the SDK to be installed again.

#### Tests
This is an installation issue, so manual testing was done on both Mac and Windows.
