### PR TITLE
Feature/mlibz 2547 ssds not ignoring query modifiers

### DIFF
--- a/Kinvey.Core/Query/KinveyQueryVisitor.cs
+++ b/Kinvey.Core/Query/KinveyQueryVisitor.cs
@@ -91,12 +91,12 @@ namespace Kinvey
 			if (resultOperator.ToString().Contains("Skip"))
 			{
 				SkipResultOperator skip = resultOperator as SkipResultOperator;
-				builderMongoQuery.AddModifier("&skip=" + skip.Count);
+                builderMongoQuery.AddModifier(Constants.STR_QUERY_MODIFIER_SKIP + skip.Count);
 			}
 			else if (resultOperator.ToString().Contains("Take"))
 			{
 				TakeResultOperator take = resultOperator as TakeResultOperator;
-				builderMongoQuery.AddModifier("&limit=" + take.Count);
+                builderMongoQuery.AddModifier(Constants.STR_QUERY_MODIFIER_LIMIT + take.Count);
 			}
 			else
 			{

--- a/Kinvey.Core/Store/ReadRequest.cs
+++ b/Kinvey.Core/Store/ReadRequest.cs
@@ -211,7 +211,12 @@ namespace Kinvey
 			{
 				string mongoQuery = this.BuildMongoQuery();
 
-                if (DeltaSetFetchingEnabled)
+                bool isQueryModifierPresent = !string.IsNullOrEmpty(mongoQuery) ?
+                                                     mongoQuery.Contains(Constants.STR_QUERY_MODIFIER_SKIP) ||
+                                                     mongoQuery.Contains(Constants.STR_QUERY_MODIFIER_LIMIT) :
+                                                     false;
+
+                if (DeltaSetFetchingEnabled && !isQueryModifierPresent)
 				{
                     if (!Cache.IsCacheEmpty())
                     {

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -96,6 +96,10 @@ namespace Kinvey
         // Request/Response Header Keys
         internal const string STR_HEADER_REQUEST_START_TIME = "x-kinvey-request-start";
 
+        // Query strings
+        internal const string STR_QUERY_MODIFIER_SKIP = "&skip=";
+        internal const string STR_QUERY_MODIFIER_LIMIT = "&limit=";
+
         #region Backend Error Strings
 
         // Server-side Delta Sync Error Strings

--- a/TestFramework/Tests.Integration/Tests/DataStoreCacheIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreCacheIntegrationTests.cs
@@ -2049,6 +2049,105 @@ namespace TestFramework
             Assert.AreEqual(1, pullCount2);
         }
 
+        [Test]
+        public async Task TestDeltaSetSyncSkipShouldNotUseDS()
+        {
+            // Arrange
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);
+            var networkStore = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.NETWORK);
+            store.DeltaSetFetchingEnabled = true;
+
+            var fc1 = new FlashCard();
+            fc1.Question = "What is 2 + 5?";
+            fc1.Answer = "7";
+
+            var fc2 = new FlashCard();
+            fc2.Question = "What is 3 + 5";
+            fc2.Answer = "8";
+
+            var fc3 = new FlashCard();
+            fc3.Question = "Why is 6 afraid of 7?";
+            fc3.Answer = "Because 7 8 9.";
+
+            // Act
+            fc1 = await networkStore.SaveAsync(fc1);
+            fc2 = await networkStore.SaveAsync(fc2);
+            fc3 = await networkStore.SaveAsync(fc3);
+            var firstResponse = await store.SyncAsync();
+
+            var fc2Query = store.Where(y => y.Question.StartsWith("W")).Skip(1);
+            int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
+            int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
+
+            var localEntities = await store.FindAsync();
+            if (localEntities != null)
+            {
+                foreach (var localEntity in localEntities)
+                {
+                    await store.RemoveAsync(localEntity.ID);
+                }
+
+                await store.SyncAsync();
+            }
+
+            // Assert
+            Assert.AreEqual(2, pullCount1);
+            Assert.AreEqual(2, pullCount2);
+        }
+
+        [Test]
+        public async Task TestDeltaSetSyncLimitShouldNotUseDS()
+        {
+            // Arrange
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);
+            var networkStore = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.NETWORK);
+            store.DeltaSetFetchingEnabled = true;
+
+            var fc1 = new FlashCard();
+            fc1.Question = "What is 2 + 5?";
+            fc1.Answer = "7";
+
+            var fc2 = new FlashCard();
+            fc2.Question = "What is 3 + 5";
+            fc2.Answer = "8";
+
+            var fc3 = new FlashCard();
+            fc3.Question = "Why is 6 afraid of 7?";
+            fc3.Answer = "Because 7 8 9.";
+
+            // Act
+            fc1 = await networkStore.SaveAsync(fc1);
+            fc2 = await networkStore.SaveAsync(fc2);
+            fc3 = await networkStore.SaveAsync(fc3);
+            var firstResponse = await store.SyncAsync();
+
+            var fc2Query = store.Where(y => y.Question.StartsWith("W")).Take(1);
+            int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
+            int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
+
+            await store.RemoveAsync(fc1.ID);
+            await store.RemoveAsync(fc2.ID);
+            await store.RemoveAsync(fc3.ID);
+
+            // Assert
+            Assert.AreEqual(1, pullCount1);
+            Assert.AreEqual(1, pullCount2);
+        }
+
         //[Test(Description = "with enable deltaset and limit and skip should not use deltaset and should not cause inconsistent data")]
 
         #endregion

--- a/TestFramework/Tests.Integration/Tests/DataStoreCacheIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreCacheIntegrationTests.cs
@@ -35,6 +35,7 @@ namespace TestFramework
 		{
 			Client.Builder builder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret)
 				.setFilePath(TestSetup.db_dir)
+                .setLogger(delegate (string msg) { Console.WriteLine(msg); })
 				.setOfflinePlatform(new SQLite.Net.Platform.Generic.SQLitePlatformGeneric());
 
 			kinveyClient = builder.Build();
@@ -1995,7 +1996,58 @@ namespace TestFramework
 
         //[Test(Description = "with enabled deltaset and autopagination should use AP for first request and DS for the next")]
 
-        //[Test(Description = "with enable deltaset and limit and skip should not use deltaset and should not override lastRunAt")]
+        [Test(Description = "with enable deltaset and limit and skip should not use deltaset and should not override lastRunAt")]
+        public async Task TestDeltaSetSyncLimitAndSkipShouldNotUseDS()
+        {
+            // Arrange
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);
+            var networkStore = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.NETWORK);
+            store.DeltaSetFetchingEnabled = true;
+
+            var fc1 = new FlashCard();
+            fc1.Question = "What is 2 + 5?";
+            fc1.Answer = "7";
+
+            var fc2 = new FlashCard();
+            fc2.Question = "What is 3 + 5";
+            fc2.Answer = "8";
+
+            var fc3 = new FlashCard();
+            fc3.Question = "Why is 6 afraid of 7?";
+            fc3.Answer = "Because 7 8 9.";
+
+            // Act
+            fc1 = await networkStore.SaveAsync(fc1);
+            fc2 = await networkStore.SaveAsync(fc2);
+            fc3 = await networkStore.SaveAsync(fc3);
+            var firstResponse = await store.SyncAsync();
+
+            var fc2Query = store.Where(y => y.Question.StartsWith("W")).Skip(1).Take(1);
+            int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
+            int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
+
+            var localEntities = await store.FindAsync();
+            if (localEntities != null)
+            {
+                foreach (var localEntity in localEntities)
+                {
+                    await store.RemoveAsync(localEntity.ID);
+                }
+
+                await store.SyncAsync();
+            }
+
+            // Assert
+            Assert.AreEqual(1, pullCount1);
+            Assert.AreEqual(1, pullCount2);
+        }
 
         //[Test(Description = "with enable deltaset and limit and skip should not use deltaset and should not cause inconsistent data")]
 

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -2810,7 +2810,157 @@ namespace TestFramework
 
         //[Test(Description = "with enabled deltaset and autopagination should use AP for first request and DS for the next")]
 
-        //[Test(Description = "with enable deltaset and limit and skip should not use deltaset and should not override lastRunAt")]
+        [Test(Description = "with enable deltaset and limit and skip should not use deltaset and should not override lastRunAt")]
+        public async Task TestDeltaSetSyncLimitAndSkipShouldNotUseDS()
+        {
+            // Arrange
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);
+            var networkStore = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.NETWORK);
+            store.DeltaSetFetchingEnabled = true;
+
+            var fc1 = new FlashCard();
+            fc1.Question = "What is 2 + 5?";
+            fc1.Answer = "7";
+
+            var fc2 = new FlashCard();
+            fc2.Question = "What is 3 + 5";
+            fc2.Answer = "8";
+
+            var fc3 = new FlashCard();
+            fc3.Question = "Why is 6 afraid of 7?";
+            fc3.Answer = "Because 7 8 9.";
+
+            // Act
+            fc1 = await networkStore.SaveAsync(fc1);
+            fc2 = await networkStore.SaveAsync(fc2);
+            fc3 = await networkStore.SaveAsync(fc3);
+            var firstResponse = await store.SyncAsync();
+
+            var fc2Query = store.Where(y => y.Question.StartsWith("W")).Skip(1).Take(1);
+            int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
+            int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
+
+            var localEntities = await store.FindAsync();
+            if (localEntities != null)
+            {
+                foreach (var localEntity in localEntities)
+                {
+                    await store.RemoveAsync(localEntity.ID);
+                }
+
+                await store.SyncAsync();
+            }
+
+            // Assert
+            Assert.AreEqual(1, pullCount1);
+            Assert.AreEqual(1, pullCount2);
+        }
+
+        [Test]
+        public async Task TestDeltaSetSyncSkipShouldNotUseDS()
+        {
+            // Arrange
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);
+            var networkStore = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.NETWORK);
+            store.DeltaSetFetchingEnabled = true;
+
+            var fc1 = new FlashCard();
+            fc1.Question = "What is 2 + 5?";
+            fc1.Answer = "7";
+
+            var fc2 = new FlashCard();
+            fc2.Question = "What is 3 + 5";
+            fc2.Answer = "8";
+
+            var fc3 = new FlashCard();
+            fc3.Question = "Why is 6 afraid of 7?";
+            fc3.Answer = "Because 7 8 9.";
+
+            // Act
+            fc1 = await networkStore.SaveAsync(fc1);
+            fc2 = await networkStore.SaveAsync(fc2);
+            fc3 = await networkStore.SaveAsync(fc3);
+            var firstResponse = await store.SyncAsync();
+
+            var fc2Query = store.Where(y => y.Question.StartsWith("W")).Skip(1);
+            int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
+            int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
+
+            var localEntities = await store.FindAsync();
+            if (localEntities != null)
+            {
+                foreach (var localEntity in localEntities)
+                {
+                    await store.RemoveAsync(localEntity.ID);
+                }
+
+                await store.SyncAsync();
+            }
+
+            // Assert
+            Assert.AreEqual(2, pullCount1);
+            Assert.AreEqual(2, pullCount2);
+        }
+
+        [Test]
+        public async Task TestDeltaSetSyncLimitShouldNotUseDS()
+        {
+            // Arrange
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);
+            var networkStore = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.NETWORK);
+            store.DeltaSetFetchingEnabled = true;
+
+            var fc1 = new FlashCard();
+            fc1.Question = "What is 2 + 5?";
+            fc1.Answer = "7";
+
+            var fc2 = new FlashCard();
+            fc2.Question = "What is 3 + 5";
+            fc2.Answer = "8";
+
+            var fc3 = new FlashCard();
+            fc3.Question = "Why is 6 afraid of 7?";
+            fc3.Answer = "Because 7 8 9.";
+
+            // Act
+            fc1 = await networkStore.SaveAsync(fc1);
+            fc2 = await networkStore.SaveAsync(fc2);
+            fc3 = await networkStore.SaveAsync(fc3);
+            var firstResponse = await store.SyncAsync();
+
+            var fc2Query = store.Where(y => y.Question.StartsWith("W")).Take(1);
+            int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
+            int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
+
+            await store.RemoveAsync(fc1.ID);
+            await store.RemoveAsync(fc2.ID);
+            await store.RemoveAsync(fc3.ID);
+
+            // Assert
+            Assert.AreEqual(1, pullCount1);
+            Assert.AreEqual(1, pullCount2);
+        }
 
         //[Test(Description = "with enable deltaset and limit and skip should not use deltaset and should not cause inconsistent data")]
 


### PR DESCRIPTION
#### Description
With the implementation of Server-side Delta Sync, the SDK was not properly ignoring the deltaset sync setting if a query was passed in with skip and/or limit modifiers.

#### Changes
Detect the presence of skip/limit modifiers on any query passed in, and perform a regular GET request in this case, even if delta set sync is enabled.

#### Tests
Integration tests added.
