### PR TITLE
MLIBZ-2529 Parse error string from redirect URI

### DIFF
--- a/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
+++ b/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
@@ -149,10 +149,15 @@ namespace Kinvey
 		/// </summary>
 		ERROR_MIC_MISSING_REDIRECT_CODE,
 
-		/// <summary>
-		/// MIC Error - Hostname URL missing 'HTTPS' protocol.
-		/// </summary>
-		ERROR_MIC_HOSTNAME_REQUIREMENT_HTTPS,
+        /// <summary>
+        /// MIC Error - Error in Redirect URI.
+        /// </summary>
+        ERROR_MIC_REDIRECT_ERROR,
+
+        /// <summary>
+        /// MIC Error - Hostname URL missing 'HTTPS' protocol.
+        /// </summary>
+        ERROR_MIC_HOSTNAME_REQUIREMENT_HTTPS,
 
 		/// <summary>
 		/// MIC Error - Credential could not be saved from the credential store.

--- a/Kinvey.Core/Troubleshooting/KinveyException.cs
+++ b/Kinvey.Core/Troubleshooting/KinveyException.cs
@@ -178,19 +178,25 @@ namespace Kinvey
 					description = "If the exception is caused by `Path <somekey>`, then <somekey> might be a different type than is expected (int instead of of string)";
 				break;
 
-				case EnumErrorCode.ERROR_MIC_MISSING_REDIRECT_CODE:
+				case EnumErrorCode.ERROR_MIC_HOSTNAME_REQUIREMENT_HTTPS:
 					error = "MIC Hostname must use the https protocol, trying to set: ";
 					debug = "";
 					description = "";
 					break;
 
-				case EnumErrorCode.ERROR_MIC_HOSTNAME_REQUIREMENT_HTTPS:
+				case EnumErrorCode.ERROR_MIC_MISSING_REDIRECT_CODE:
 					error = "Redirect does not contain `code=`, was: ";
 					debug = "";
 					description = "";
 					break;
 
-				case EnumErrorCode.ERROR_MIC_CREDENTIAL_SAVE:
+                case EnumErrorCode.ERROR_MIC_REDIRECT_ERROR:
+                    error = "Redirect contains an `error=`, was: ";
+                    debug = "";
+                    description = "";
+                    break;
+
+                case EnumErrorCode.ERROR_MIC_CREDENTIAL_SAVE:
 					error = "Could not save account to KeyChain.";
 					debug = "";
 					description = "";

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -45,8 +45,11 @@ namespace Kinvey
 		public const string STR_USER_KMD = "UserKMD";
 		public const string STR_CREDENTIAL = "credential";
         public const string STR_MIC_DEFAULT_VERSION = "v3";
+        public const string STR_MIC_REDIRECT_CODE = "code=";
+        public const string STR_MIC_REDIRECT_ERROR = "error=";
+        public const string STR_MIC_REDIRECT_ERROR_DESCRIPTION = "error_description=";
 
-		// Realtime Strings
+        // Realtime Strings
 		internal const string STR_REALTIME_COLLECTION_CHANNEL_PREPEND = "c-";
 		internal const string STR_REALTIME_STREAM_CHANNEL_PREPEND = "s-";
         internal const string STR_REALTIME_USER_CHANNEL_PREPEND = "u-";

--- a/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
@@ -169,5 +169,30 @@ namespace TestFramework
 			Assert.False(urlToTestForScopeID.Equals(string.Empty));
 			Assert.That(urlToTestForScopeID.Contains("scope=openid"));
 		}
-	}
+
+        [Test]
+        public async Task TestMICOnRedirectErrorParsing()
+        {
+            // Arrange
+            var error = "12345";
+            var errorDescription = "test error description";
+            Client.Builder builder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret);
+            Client client = builder.Build();
+            var loginRequest = new User.LoginToTempURLRequest(client, string.Empty, new System.Collections.Generic.Dictionary<string, string>(){{ "client_id", "none" }}, null);
+            string redirectUri = $"myredirecturi/error={error}&error_description={errorDescription}"; //error=<error code>&error_description=<error description text>
+
+            // Act
+            // Assert
+            Exception e = Assert.CatchAsync(async delegate {
+                await loginRequest.onRedirectAsync(redirectUri);
+            });
+
+            Assert.True(e.GetType() == typeof(KinveyException));
+            var ke = e as KinveyException;
+            Assert.AreEqual(ke.ErrorCategory, EnumErrorCategory.ERROR_USER);
+            Assert.AreEqual(ke.ErrorCode, EnumErrorCode.ERROR_MIC_REDIRECT_ERROR);
+            Assert.True(ke.Error.EndsWith(error));
+            Assert.AreEqual(ke.Description, errorDescription);
+        }
+    }
 }

--- a/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
@@ -179,7 +179,7 @@ namespace TestFramework
             Client.Builder builder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret);
             Client client = builder.Build();
             var loginRequest = new User.LoginToTempURLRequest(client, string.Empty, new System.Collections.Generic.Dictionary<string, string>(){{ "client_id", "none" }}, null);
-            string redirectUri = $"myredirecturi/error={error}&error_description={errorDescription}"; //error=<error code>&error_description=<error description text>
+            string redirectUri = $"myredirecturi://?error={error}&error_description={errorDescription}";
 
             // Act
             // Assert


### PR DESCRIPTION
#### Description
MIC errors from a redirect URI can now appear in the URI itself, rather than the expected `code`. The goal of this PR is to detect if an error is passed this way, and if so, parse it and throw the appropriate `Exception`.

#### Changes
Look for an `error` and `error_description` passed in the redirect URI, and throw an `Exception` with this information.

#### Tests
Unit test added.