### PR TITLE
MLIBZ-1417 Deprecate old method name format

### DIFF
--- a/Kinvey.Core/File/File.cs
+++ b/Kinvey.Core/File/File.cs
@@ -162,19 +162,25 @@ namespace Kinvey
 			return fmd;
 		}
 
-		#endregion
+        #endregion
 
-		#region File class download APIs
+        #region File class download APIs
 
-		/// <summary>
-		/// Download the File associated with the id of the provided metadata.  The file is copied into the byte[], with delegates returning either errors or the FileMetaData from Kinvey.
-		/// </summary>
-		/// <param name="metadata">The FileMetaData representing the file to download.  This must contain an id.</param>
-		/// <param name="content">Content.</param>
-		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> downloadAsync(FileMetaData metadata, byte[] content, CancellationToken ct = default(CancellationToken))
-		{
-			DownloadFileWithMetaDataRequest downloadRequest = buildDownloadFileRequest(metadata);
+        [Obsolete("This method has been deprecated (2018-Oct-03).  Please use DownloadAsync() instead.")]
+        public async Task<FileMetaData> downloadAsync(FileMetaData metadata, byte[] content, CancellationToken ct = default(CancellationToken))
+        {
+            return await DownloadAsync(metadata, content, ct);
+        }
+
+        /// <summary>
+        /// Download the File associated with the id of the provided metadata.  The file is copied into the byte[], with delegates returning either errors or the FileMetaData from Kinvey.
+        /// </summary>
+        /// <param name="metadata">The FileMetaData representing the file to download.  This must contain an id.</param>
+        /// <param name="content">Content.</param>
+        /// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
+        public async Task<FileMetaData> DownloadAsync(FileMetaData metadata, byte[] content, CancellationToken ct = default(CancellationToken))
+        {
+            DownloadFileWithMetaDataRequest downloadRequest = buildDownloadFileRequest(metadata);
 			ct.ThrowIfCancellationRequested();
 			FileMetaData fmd = await downloadRequest.ExecuteAsync();
 			ct.ThrowIfCancellationRequested();
@@ -182,13 +188,19 @@ namespace Kinvey
 			return fmd;
 		}
 
-		/// <summary>
-		/// Download the File associated with the id of the provided metadata.  The file is streamed into the stream, with delegates returning either errors or the FileMetaData from Kinvey.
-		/// </summary>
-		/// <param name="metadata">The FileMetaData representing the file to download.  This must contain an id.</param>
-		/// <param name="content">Where the contents of the file will be streamed.</param>
-		/// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
-		public async Task<FileMetaData> downloadAsync(FileMetaData metadata, Stream content, CancellationToken ct = default(CancellationToken))
+        [Obsolete("This method has been deprecated (2018-Oct-03).  Please use DownloadAsync() instead.")]
+        public async Task<FileMetaData> downloadAsync(FileMetaData metadata, Stream content, CancellationToken ct = default(CancellationToken))
+        {
+            return await DownloadAsync(metadata, content, ct);
+        }
+
+        /// <summary>
+        /// Download the File associated with the id of the provided metadata.  The file is streamed into the stream, with delegates returning either errors or the FileMetaData from Kinvey.
+        /// </summary>
+        /// <param name="metadata">The FileMetaData representing the file to download.  This must contain an id.</param>
+        /// <param name="content">Where the contents of the file will be streamed.</param>
+        /// <param name="ct">[optional] The cancellation token.  If cancellation is requested, an OperationCancelledException will be thrown.</param>
+        public async Task<FileMetaData> DownloadAsync(FileMetaData metadata, Stream content, CancellationToken ct = default(CancellationToken))
 		{
 			DownloadFileWithMetaDataRequest downloadRequest = buildDownloadFileRequest(metadata);
 			ct.ThrowIfCancellationRequested();

--- a/TestFramework/Tests.Integration/Tests/FileIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/FileIntegrationTests.cs
@@ -229,7 +229,7 @@ namespace TestFramework
 			byte[] downloadContent = new byte[downloadMetaData.size];
 
 			// Act
-			FileMetaData downloadFMD = await kinveyClient.File().downloadAsync(downloadMetaData, downloadContent);
+			FileMetaData downloadFMD = await kinveyClient.File().DownloadAsync(downloadMetaData, downloadContent);
 			System.IO.File.WriteAllBytes(downloadByteArrayFilePath, content);
 
 			// Assert
@@ -263,7 +263,7 @@ namespace TestFramework
 			MemoryStream downloadStreamContent = new MemoryStream();
 
 			// Act
-			FileMetaData downloadFMD = await kinveyClient.File().downloadAsync(downloadMetaData, downloadStreamContent);
+			FileMetaData downloadFMD = await kinveyClient.File().DownloadAsync(downloadMetaData, downloadStreamContent);
 			FileStream fs = new FileStream(downloadStreamFilePath, FileMode.Create);
 			downloadStreamContent.WriteTo(fs);
 			downloadStreamContent.Close();
@@ -291,7 +291,7 @@ namespace TestFramework
 			// Assert
 			Assert.CatchAsync(async delegate ()
 			{
-				await kinveyClient.File().downloadAsync(fileMetaData, content);
+				await kinveyClient.File().DownloadAsync(fileMetaData, content);
 			});
 
 			// Teardown


### PR DESCRIPTION
#### Description
Customer reported that the name of the `downloadAsync()` method name should actually start with a capital letter, to meet .NET convention.

#### Changes
Deprecated the `downloadAsync()` method in favor of `DownloadAsync()`.

#### Tests
Modified existing tests.
