### PR TITLE
[WIP] Release sqlite connection (Windows 10)

### DIFF
--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -81,15 +81,15 @@ namespace Kinvey.Tests
         [TestInitialize]
         public virtual void Setup()
         {
-            System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-            System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
         }
 
         [TestCleanup]
         public virtual void Tear()
         {
-            System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-            System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+           // System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
         }
 
         protected static void MockUserLogin(HttpListenerContext context, IEnumerable<JObject> users)

--- a/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
@@ -49,8 +49,8 @@ namespace Kinvey.Tests
 		public void Tear()
 		{
 			kinveyClient.ActiveUser?.Logout();
-			System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-			System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
 		}
 
         [TestMethod]

--- a/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
@@ -45,8 +45,8 @@ namespace Kinvey.Tests
             base.Setup();
 
             kinveyClient?.ActiveUser?.Logout();
-            System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-            System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
 
             Client.Builder builder = ClientBuilder.setFilePath(TestSetup.db_dir)
 				.setOfflinePlatform(new SQLite.Net.Platform.Generic.SQLitePlatformGeneric());
@@ -63,8 +63,8 @@ namespace Kinvey.Tests
         public override void Tear()
 		{
 			kinveyClient.ActiveUser?.Logout();
-			System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-			System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
 
             base.Tear();
 		}

--- a/Kinvey.Tests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreSyncIntegrationTests.cs
@@ -54,8 +54,8 @@ namespace Kinvey.Tests
         public override void Tear()
 		{
 			kinveyClient.ActiveUser?.Logout();
-			System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-			System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
 
             base.Tear();
 		}

--- a/Kinvey.Tests/FileUnitTests.cs
+++ b/Kinvey.Tests/FileUnitTests.cs
@@ -32,8 +32,8 @@ namespace Kinvey.Tests
         [TestCleanup]
         public void Tear()
         {
-            System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-            System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
         }
 
         [TestMethod]

--- a/Kinvey.Tests/RealtimeIntegrationTests.cs
+++ b/Kinvey.Tests/RealtimeIntegrationTests.cs
@@ -44,8 +44,8 @@ namespace Kinvey.Tests
         public override void Tear()
 		{
 			kinveyClient.ActiveUser?.Logout();
-			System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-			System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+			//System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
 
             base.Tear();
 		}

--- a/Kinvey.Tests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserIntegrationTests.cs
@@ -52,8 +52,8 @@ namespace Kinvey.Tests
             {
                 kinveyClient.ActiveUser.Logout();
             }
-            System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
-            System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
+            //System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
 
             base.Tear();
         }


### PR DESCRIPTION
#### Description
Below I described case for the certain test(TestCacheStoreFindByIDAsync).But such problem exists for bunch of tests.

There exists the test
https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Tests/DataStoreCacheIntegrationTests.cs#L96

The test is working correctly. After finishing of the test, the "Tear" method is being called.
https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Tests/DataStoreCacheIntegrationTests.cs#L49

In this point
https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Tests/DataStoreCacheIntegrationTests.cs#L52
(kinveyOffline.sqlite)
and this
https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Tests/DataStoreCacheIntegrationTests.cs#L53
kinvey_tokens.sqlite)

the error occurs (TestCleanup method Kinvey.Tests.DataStoreCacheIntegrationTests.Tear threw exception. System.IO.IOException: System.IO.IOException: The process cannot access the file 'kinveyOffline.sqlite(kinvey_tokens.sqlite)' because it is being used by another process..)

SQLite connections are being created here

https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Core/Offline/SQLiteCacheManager.cs#L62 (kinveyOffline.sqlite)
and here
https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Core/Auth/SQLiteCredentialStore.cs#L43
(kinvey_tokens.sqlite)

and are not being released explicitly.

As a result, when .sqlite files are being removed
https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Tests/DataStoreCacheIntegrationTests.cs#L52
(kinveyOffline.sqlite)

and

https://github.com/Kinvey/dotnet-sdk/blob/master/Kinvey.Tests/DataStoreCacheIntegrationTests.cs#L53
(kinvey_tokens.sqlite)

they are still busy by SQLite connection.

#### Changes
"Kinvey.Tests" project

#### Tests
All existing tests working with SQLite cover this issue.
