### PR TITLE
Feature/mlibz 1430 entity properties should only capitalize first letter

### DIFF
--- a/Kinvey.Core/Model/Entity.cs
+++ b/Kinvey.Core/Model/Entity.cs
@@ -32,7 +32,7 @@ namespace Kinvey
         [DataMember(Name = "_id")]
         [Preserve]
 		[PrimaryKey, Column("_id")]
-		public string ID { get; set; }
+		public string Id { get; set; }
 
 		/// <summary>
 		/// Gets or sets the <see cref="AccessControlList"/> for this Kinvey-backed object.

--- a/Kinvey.Core/Model/Entity.cs
+++ b/Kinvey.Core/Model/Entity.cs
@@ -42,7 +42,7 @@ namespace Kinvey
         [DataMember(Name = "_acl")]
         [Preserve]
 		[Column("_acl")]
-		public AccessControlList ACL { get; set; }
+		public AccessControlList Acl { get; set; }
 
 		/// <summary>
 		/// Gets or sets the <see cref="KinveyMetaData"/> for this Kinvey-backed object.

--- a/Kinvey.Core/Model/Entity.cs
+++ b/Kinvey.Core/Model/Entity.cs
@@ -52,6 +52,6 @@ namespace Kinvey
         [DataMember(Name = "_kmd")]
         [Preserve]
 		[Column("_kmd")]
-		public KinveyMetaData KMD { get; set; }
+		public KinveyMetaData Kmd { get; set; }
 	}
 }

--- a/Kinvey.Core/Model/IPersistable.cs
+++ b/Kinvey.Core/Model/IPersistable.cs
@@ -29,7 +29,7 @@ namespace Kinvey
 		/// <see cref="AccessControlList"/>  field which maps back to Kinvey _acl
 		/// </summary>
 		/// <value>The acl.</value>
-		AccessControlList ACL { get; set; }
+		AccessControlList Acl { get; set; }
 
 		/// <summary>
 		/// <see cref="KinveyMetaData"/> field which maps back to Kinvey _kmd

--- a/Kinvey.Core/Model/IPersistable.cs
+++ b/Kinvey.Core/Model/IPersistable.cs
@@ -35,6 +35,6 @@ namespace Kinvey
 		/// <see cref="KinveyMetaData"/> field which maps back to Kinvey _kmd
 		/// </summary>
 		/// <value>The kmd.</value>
-		KinveyMetaData KMD { get; set; }
+		KinveyMetaData Kmd { get; set; }
 	}
 }

--- a/Kinvey.Core/Model/IPersistable.cs
+++ b/Kinvey.Core/Model/IPersistable.cs
@@ -23,7 +23,7 @@ namespace Kinvey
 		/// ID field which maps back to Kinvey _id
 		/// </summary>
 		/// <value>The identifier.</value>
-		string ID { get; set; }
+		string Id { get; set; }
 
 		/// <summary>
 		/// <see cref="AccessControlList"/>  field which maps back to Kinvey _acl

--- a/Kinvey.Core/Offline/SQLiteCache.cs
+++ b/Kinvey.Core/Offline/SQLiteCache.cs
@@ -594,7 +594,7 @@ namespace Kinvey
 						foreach (var match in results)
 						{
 							IPersistable entity = match as IPersistable;
-							matchIDs.Add(entity.ID);
+							matchIDs.Add(entity.Id);
 						}
 
 						kdr = this.DeleteByIDs(matchIDs);

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -511,7 +511,7 @@ namespace Kinvey
 				var ids = new List<string>();
 				var entities = cache.FindByQuery(query.Expression);
                 var pendings = entities.Select(entity => entity as IPersistable)
-                                       .Select(persistable => syncQueue.GetByID(persistable.ID));
+                                       .Select(persistable => syncQueue.GetByID(persistable.Id));
 				return syncQueue.Remove(pendings);
 			}
 

--- a/Kinvey.Core/Store/ReadRequest.cs
+++ b/Kinvey.Core/Store/ReadRequest.cs
@@ -87,8 +87,8 @@ namespace Kinvey
 			foreach (var cacheItem in cacheItems)
 			{
 				var item = cacheItem as IPersistable;
-				if (item.KMD?.lastModifiedTime != null) {  //if lmt doesn't exist for cache entity, avoid crashing
-					dictCachedEntities.Add(item.Id, item.KMD.lastModifiedTime);
+				if (item.Kmd?.lastModifiedTime != null) {  //if lmt doesn't exist for cache entity, avoid crashing
+					dictCachedEntities.Add(item.Id, item.Kmd.lastModifiedTime);
 				}
 			}
 

--- a/Kinvey.Core/Store/ReadRequest.cs
+++ b/Kinvey.Core/Store/ReadRequest.cs
@@ -88,7 +88,7 @@ namespace Kinvey
 			{
 				var item = cacheItem as IPersistable;
 				if (item.KMD?.lastModifiedTime != null) {  //if lmt doesn't exist for cache entity, avoid crashing
-					dictCachedEntities.Add(item.ID, item.KMD.lastModifiedTime);
+					dictCachedEntities.Add(item.Id, item.KMD.lastModifiedTime);
 				}
 			}
 
@@ -279,7 +279,7 @@ namespace Kinvey
                             List<string> listDeletedIDs = new List<string>();
                             foreach (var deletedItem in results.Deleted)
                             {
-                                listDeletedIDs.Add(deletedItem.ID);
+                                listDeletedIDs.Add(deletedItem.Id);
                             }
                             Cache.DeleteByIDs(listDeletedIDs);
 

--- a/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
@@ -113,7 +113,7 @@ namespace Kinvey.Tests
 			ToDo networkEntity = null;
 			ToDo cacheEntity = null;
 
-			networkEntity = await todoStore.FindByIDAsync(t.ID, new KinveyDelegate<ToDo>
+			networkEntity = await todoStore.FindByIDAsync(t.Id, new KinveyDelegate<ToDo>
 			{
 				onSuccess = (result) => cacheEntity = result,
 				onError = (error) => Assert.Fail("TestCacheStoreFindByIDAsync: Cache find returned error")
@@ -121,13 +121,13 @@ namespace Kinvey.Tests
 
 			// Assert
 			Assert.IsNotNull(networkEntity);
-			Assert.IsTrue(string.Equals(networkEntity.ID, t.ID));
+			Assert.IsTrue(string.Equals(networkEntity.Id, t.Id));
 			Assert.IsNotNull(cacheEntity);
-			Assert.IsTrue(string.Equals(cacheEntity.ID, t.ID));
-			Assert.IsTrue(string.Equals(cacheEntity.ID, networkEntity.ID));
+			Assert.IsTrue(string.Equals(cacheEntity.Id, t.Id));
+			Assert.IsTrue(string.Equals(cacheEntity.Id, networkEntity.Id));
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
+			await todoStore.RemoveAsync(t.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -181,8 +181,8 @@ namespace Kinvey.Tests
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -241,8 +241,8 @@ namespace Kinvey.Tests
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -306,9 +306,9 @@ namespace Kinvey.Tests
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -372,9 +372,9 @@ namespace Kinvey.Tests
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -441,9 +441,9 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, sum);
@@ -506,9 +506,9 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, min);
@@ -571,9 +571,9 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, max);
@@ -642,10 +642,10 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p4.ID);
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p4.Id);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, avg);
@@ -691,7 +691,7 @@ namespace Kinvey.Tests
 			Assert.IsTrue(string.Equals(newItem.Details, savedItem.Details));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedItem.ID);
+			await todoStore.RemoveAsync(savedItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -734,9 +734,9 @@ namespace Kinvey.Tests
 			newItem3 = await todoStore.SaveAsync(newItem3);
 
 			List<string> listIDs = new List<string>();
-			listIDs.Add(newItem1.ID);
-			listIDs.Add(newItem2.ID);
-			listIDs.Add(newItem3.ID);
+			listIDs.Add(newItem1.Id);
+			listIDs.Add(newItem2.Id);
+			listIDs.Add(newItem3.Id);
 
 			// Act
 			ICache<ToDo> cache = kinveyClient.CacheManager.GetCache<ToDo>(collectionName);
@@ -747,9 +747,9 @@ namespace Kinvey.Tests
 			Assert.AreEqual(3, listEntities.Count);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -792,9 +792,9 @@ namespace Kinvey.Tests
 			newItem3 = await todoStore.SaveAsync(newItem3);
 
 			List<string> listIDs = new List<string>();
-			listIDs.Add(newItem1.ID);
-			listIDs.Add(newItem2.ID);
-			listIDs.Add(newItem3.ID);
+			listIDs.Add(newItem1.Id);
+			listIDs.Add(newItem2.Id);
+			listIDs.Add(newItem3.Id);
 
 			// Act
 			List<ToDo> listEntities = new List<ToDo>();
@@ -810,9 +810,9 @@ namespace Kinvey.Tests
 			});
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -844,7 +844,7 @@ namespace Kinvey.Tests
 
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.CACHE);
 			ToDo savedItem = await todoStore.SaveAsync(newItem);
-			string savedItemID = savedItem.ID;
+			string savedItemID = savedItem.Id;
 
 			// Act
 			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(savedItemID);
@@ -895,9 +895,9 @@ namespace Kinvey.Tests
 			newItem3 = await todoStore.SaveAsync(newItem3);
 
 			List<string> listIDs = new List<string>();
-			listIDs.Add(newItem1.ID);
-			listIDs.Add(newItem2.ID);
-			listIDs.Add(newItem3.ID);
+			listIDs.Add(newItem1.Id);
+			listIDs.Add(newItem2.Id);
+			listIDs.Add(newItem3.Id);
 
 			// Act
 			ICache<ToDo> cache = kinveyClient.CacheManager.GetCache<ToDo>(collectionName);
@@ -908,9 +908,9 @@ namespace Kinvey.Tests
 			Assert.AreEqual(3, kdr.count);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -952,7 +952,7 @@ namespace Kinvey.Tests
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -1012,7 +1012,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1078,7 +1078,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1133,7 +1133,7 @@ namespace Kinvey.Tests
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
@@ -1145,12 +1145,12 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1213,7 +1213,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1285,7 +1285,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1337,13 +1337,13 @@ namespace Kinvey.Tests
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.PullAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
@@ -1352,7 +1352,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1410,7 +1410,7 @@ namespace Kinvey.Tests
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.PullAsync();
 
             var localEntities = await store.FindAsync();
@@ -1418,7 +1418,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1475,7 +1475,7 @@ namespace Kinvey.Tests
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -1532,7 +1532,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1597,7 +1597,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1651,7 +1651,7 @@ namespace Kinvey.Tests
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
@@ -1663,12 +1663,12 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1729,7 +1729,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1801,7 +1801,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1853,12 +1853,12 @@ namespace Kinvey.Tests
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.SyncAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             var secondResponse = await store.SyncAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             var thirdResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -1866,7 +1866,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1924,7 +1924,7 @@ namespace Kinvey.Tests
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -1932,7 +1932,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();

--- a/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
@@ -97,7 +97,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -130,7 +130,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -175,7 +175,7 @@ namespace Kinvey.Tests
             Assert.IsTrue(savedToDo.ACL.Groups.Readers[2].Equals("groupread3"));
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -218,7 +218,7 @@ namespace Kinvey.Tests
             Assert.IsTrue(savedToDo.ACL.Groups.Writers[1].Equals("groupwrite2"));
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -258,7 +258,7 @@ namespace Kinvey.Tests
             Assert.IsTrue(savedToDo.ACL.Readers[1].Equals("reader2"));
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -300,7 +300,7 @@ namespace Kinvey.Tests
             Assert.IsTrue(savedToDo.ACL.Writers[2].Equals("writer3"));
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -364,7 +364,7 @@ namespace Kinvey.Tests
             ToDo deleteToDo = await todoStore.SaveAsync(newItem);
 
             // Act
-            KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.ID);
+            KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.Id);
 
             // Assert
             Assert.IsNotNull(kdr);
@@ -422,8 +422,8 @@ namespace Kinvey.Tests
             Assert.AreEqual(2u, count);
 
             // Teardown
-            await todoStore.RemoveAsync(t1.ID);
-            await todoStore.RemoveAsync(t2.ID);
+            await todoStore.RemoveAsync(t1.Id);
+            await todoStore.RemoveAsync(t2.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -461,8 +461,8 @@ namespace Kinvey.Tests
             Assert.AreEqual(2, todoList.Count);
 
             // Teardown
-            await todoStore.RemoveAsync(t.ID);
-            await todoStore.RemoveAsync(t2.ID);
+            await todoStore.RemoveAsync(t.Id);
+            await todoStore.RemoveAsync(t2.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -538,14 +538,14 @@ namespace Kinvey.Tests
 
 			// Act
 			ToDo entity = null;
-			entity = await todoStore.FindByIDAsync(t.ID);
+			entity = await todoStore.FindByIDAsync(t.Id);
 
 			// Assert
 			Assert.IsNotNull(entity);
-			Assert.IsTrue(string.Equals(entity.ID, t.ID));
+			Assert.IsTrue(string.Equals(entity.Id, t.Id));
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
+			await todoStore.RemoveAsync(t.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -587,8 +587,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindWithMongoQueryAsync(mongoQuery);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -650,8 +650,8 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -703,8 +703,8 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -752,8 +752,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -803,8 +803,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -862,9 +862,9 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
-            await todoStore.RemoveAsync(newItem3.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
+            await todoStore.RemoveAsync(newItem3.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -922,9 +922,9 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
-            await todoStore.RemoveAsync(newItem3.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
+            await todoStore.RemoveAsync(newItem3.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -982,9 +982,9 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
-            await todoStore.RemoveAsync(newItem3.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
+            await todoStore.RemoveAsync(newItem3.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1042,9 +1042,9 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
-            await todoStore.RemoveAsync(newItem3.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
+            await todoStore.RemoveAsync(newItem3.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1101,9 +1101,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1162,9 +1162,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1221,9 +1221,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1280,9 +1280,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1330,8 +1330,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1382,8 +1382,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1434,8 +1434,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1486,8 +1486,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1543,8 +1543,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1593,8 +1593,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1643,8 +1643,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1693,8 +1693,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1743,8 +1743,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1793,8 +1793,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1843,8 +1843,8 @@ namespace Kinvey.Tests
 
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1901,8 +1901,8 @@ namespace Kinvey.Tests
 			Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_LINQ_WHERE_CLAUSE_NOT_SUPPORTED);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1947,8 +1947,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -1986,7 +1986,7 @@ namespace Kinvey.Tests
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
             foreach (var item in await todoStore.FindAsync())
             {
-                await todoStore.RemoveAsync(item.ID);
+                await todoStore.RemoveAsync(item.Id);
             }
 
             newItem1 = await todoStore.SaveAsync(newItem1);
@@ -2002,8 +2002,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -2057,8 +2057,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -2114,8 +2114,8 @@ namespace Kinvey.Tests
             listToDo = await todoStore.FindAsync(query);
 
             // Teardown
-            await todoStore.RemoveAsync(newItem1.ID);
-            await todoStore.RemoveAsync(newItem2.ID);
+            await todoStore.RemoveAsync(newItem1.Id);
+            await todoStore.RemoveAsync(newItem2.Id);
             kinveyClient.ActiveUser.Logout();
 
             // Assert
@@ -2169,8 +2169,8 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -2218,8 +2218,8 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -2268,8 +2268,8 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -2327,10 +2327,10 @@ namespace Kinvey.Tests
             }
 
             // Teardown
-            await personStore.RemoveAsync(p4.ID);
-            await personStore.RemoveAsync(p3.ID);
-            await personStore.RemoveAsync(p2.ID);
-            await personStore.RemoveAsync(p1.ID);
+            await personStore.RemoveAsync(p4.Id);
+            await personStore.RemoveAsync(p3.Id);
+            await personStore.RemoveAsync(p2.Id);
+            await personStore.RemoveAsync(p1.Id);
 
             // Assert
             Assert.AreNotEqual(0, avg);
@@ -2380,9 +2380,9 @@ namespace Kinvey.Tests
             }
 
             // Teardown
-            await personStore.RemoveAsync(p3.ID);
-            await personStore.RemoveAsync(p2.ID);
-            await personStore.RemoveAsync(p1.ID);
+            await personStore.RemoveAsync(p3.Id);
+            await personStore.RemoveAsync(p2.Id);
+            await personStore.RemoveAsync(p1.Id);
 
             // Assert
             Assert.AreNotEqual(0, max);
@@ -2432,9 +2432,9 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, min);
@@ -2489,9 +2489,9 @@ namespace Kinvey.Tests
             }
 
             // Teardown
-            await personStore.RemoveAsync(p3.ID);
-            await personStore.RemoveAsync(p2.ID);
-            await personStore.RemoveAsync(p1.ID);
+            await personStore.RemoveAsync(p3.Id);
+            await personStore.RemoveAsync(p2.Id);
+            await personStore.RemoveAsync(p1.Id);
 
             // Assert
             Assert.AreNotEqual(0, sum);
@@ -2524,7 +2524,7 @@ namespace Kinvey.Tests
 			Assert.IsTrue(string.Equals(savedToDo.Name, newItem.Name));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 

--- a/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
@@ -83,7 +83,7 @@ namespace Kinvey.Tests
             acl.GloballyReadable = true;
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
             ToDo todo = new ToDo();
-            todo.ACL = acl;
+            todo.Acl = acl;
 
             // Act
             ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -91,10 +91,10 @@ namespace Kinvey.Tests
             // Assert
             Assert.AreEqual(true, acl.GloballyReadable);
             Assert.AreEqual(false, acl.GloballyWriteable);
-            Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-            Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-            Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-            Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
+            Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+            Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+            Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+            Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.Id);
@@ -116,7 +116,7 @@ namespace Kinvey.Tests
             acl.GloballyWriteable = true;
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
             ToDo todo = new ToDo();
-            todo.ACL = acl;
+            todo.Acl = acl;
 
             // Act
             ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -124,10 +124,10 @@ namespace Kinvey.Tests
             // Assert
             Assert.AreEqual(false, acl.GloballyReadable);
             Assert.AreEqual(true, acl.GloballyWriteable);
-            Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-            Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-            Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-            Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
+            Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+            Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+            Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+            Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.Id);
@@ -151,7 +151,7 @@ namespace Kinvey.Tests
             acl.Groups.Readers.Add("groupread3");
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
             ToDo todo = new ToDo();
-            todo.ACL = acl;
+            todo.Acl = acl;
 
             // Act
             ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -159,20 +159,20 @@ namespace Kinvey.Tests
             // Assert
             Assert.AreEqual(false, acl.GloballyReadable);
             Assert.AreEqual(false, acl.GloballyWriteable);
-            Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-            Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-            Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-            Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-            Assert.IsNotNull(savedToDo.ACL.Readers);
-            Assert.IsNotNull(savedToDo.ACL.Writers);
-            Assert.IsNotNull(savedToDo.ACL.Groups);
-            Assert.IsNotNull(savedToDo.ACL.Groups.Writers);
-            Assert.IsNotNull(savedToDo.ACL.Groups.Readers);
-            CollectionAssert.AreEqual(todo.ACL.Groups.Readers, savedToDo.ACL.Groups.Readers);
-            Assert.AreEqual(3, savedToDo.ACL.Groups.Readers.Count);
-            Assert.IsTrue(savedToDo.ACL.Groups.Readers[0].Equals("groupread1"));
-            Assert.IsTrue(savedToDo.ACL.Groups.Readers[1].Equals("groupread2"));
-            Assert.IsTrue(savedToDo.ACL.Groups.Readers[2].Equals("groupread3"));
+            Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+            Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+            Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+            Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+            Assert.IsNotNull(savedToDo.Acl.Readers);
+            Assert.IsNotNull(savedToDo.Acl.Writers);
+            Assert.IsNotNull(savedToDo.Acl.Groups);
+            Assert.IsNotNull(savedToDo.Acl.Groups.Writers);
+            Assert.IsNotNull(savedToDo.Acl.Groups.Readers);
+            CollectionAssert.AreEqual(todo.Acl.Groups.Readers, savedToDo.Acl.Groups.Readers);
+            Assert.AreEqual(3, savedToDo.Acl.Groups.Readers.Count);
+            Assert.IsTrue(savedToDo.Acl.Groups.Readers[0].Equals("groupread1"));
+            Assert.IsTrue(savedToDo.Acl.Groups.Readers[1].Equals("groupread2"));
+            Assert.IsTrue(savedToDo.Acl.Groups.Readers[2].Equals("groupread3"));
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.Id);
@@ -195,7 +195,7 @@ namespace Kinvey.Tests
             acl.Groups.Writers.Add("groupwrite2");
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
             ToDo todo = new ToDo();
-            todo.ACL = acl;
+            todo.Acl = acl;
 
             // Act
             ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -203,19 +203,19 @@ namespace Kinvey.Tests
             // Assert
             Assert.AreEqual(false, acl.GloballyReadable);
             Assert.AreEqual(false, acl.GloballyWriteable);
-            Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-            Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-            Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-            Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-            Assert.IsNotNull(savedToDo.ACL.Readers);
-            Assert.IsNotNull(savedToDo.ACL.Writers);
-            Assert.IsNotNull(savedToDo.ACL.Groups);
-            Assert.IsNotNull(savedToDo.ACL.Groups.Readers);
-            Assert.IsNotNull(savedToDo.ACL.Groups.Writers);
-            CollectionAssert.AreEqual(todo.ACL.Groups.Writers, savedToDo.ACL.Groups.Writers);
-            Assert.AreEqual(2, savedToDo.ACL.Groups.Writers.Count);
-            Assert.IsTrue(savedToDo.ACL.Groups.Writers[0].Equals("groupwrite1"));
-            Assert.IsTrue(savedToDo.ACL.Groups.Writers[1].Equals("groupwrite2"));
+            Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+            Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+            Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+            Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+            Assert.IsNotNull(savedToDo.Acl.Readers);
+            Assert.IsNotNull(savedToDo.Acl.Writers);
+            Assert.IsNotNull(savedToDo.Acl.Groups);
+            Assert.IsNotNull(savedToDo.Acl.Groups.Readers);
+            Assert.IsNotNull(savedToDo.Acl.Groups.Writers);
+            CollectionAssert.AreEqual(todo.Acl.Groups.Writers, savedToDo.Acl.Groups.Writers);
+            Assert.AreEqual(2, savedToDo.Acl.Groups.Writers.Count);
+            Assert.IsTrue(savedToDo.Acl.Groups.Writers[0].Equals("groupwrite1"));
+            Assert.IsTrue(savedToDo.Acl.Groups.Writers[1].Equals("groupwrite2"));
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.Id);
@@ -238,7 +238,7 @@ namespace Kinvey.Tests
             acl.Readers.Add("reader2");
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
             ToDo todo = new ToDo();
-            todo.ACL = acl;
+            todo.Acl = acl;
 
             // Act
             ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -246,16 +246,16 @@ namespace Kinvey.Tests
             // Assert
             Assert.AreEqual(false, acl.GloballyReadable);
             Assert.AreEqual(false, acl.GloballyWriteable);
-            Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-            Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-            Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-            Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-            Assert.IsNotNull(savedToDo.ACL.Writers);
-            Assert.IsNotNull(savedToDo.ACL.Readers);
-            CollectionAssert.AreEqual(todo.ACL.Readers, savedToDo.ACL.Readers);
-            Assert.AreEqual(2, savedToDo.ACL.Readers.Count);
-            Assert.IsTrue(savedToDo.ACL.Readers[0].Equals("reader1"));
-            Assert.IsTrue(savedToDo.ACL.Readers[1].Equals("reader2"));
+            Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+            Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+            Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+            Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+            Assert.IsNotNull(savedToDo.Acl.Writers);
+            Assert.IsNotNull(savedToDo.Acl.Readers);
+            CollectionAssert.AreEqual(todo.Acl.Readers, savedToDo.Acl.Readers);
+            Assert.AreEqual(2, savedToDo.Acl.Readers.Count);
+            Assert.IsTrue(savedToDo.Acl.Readers[0].Equals("reader1"));
+            Assert.IsTrue(savedToDo.Acl.Readers[1].Equals("reader2"));
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.Id);
@@ -279,7 +279,7 @@ namespace Kinvey.Tests
             acl.Writers.Add("writer3");
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
             ToDo todo = new ToDo();
-            todo.ACL = acl;
+            todo.Acl = acl;
 
             // Act
             ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -287,17 +287,17 @@ namespace Kinvey.Tests
             // Assert
             Assert.AreEqual(false, acl.GloballyReadable);
             Assert.AreEqual(false, acl.GloballyWriteable);
-            Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-            Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-            Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-            Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-            Assert.IsNotNull(savedToDo.ACL.Readers);
-            Assert.IsNotNull(savedToDo.ACL.Writers);
-            CollectionAssert.AreEqual(todo.ACL.Writers, savedToDo.ACL.Writers);
-            Assert.AreEqual(3, savedToDo.ACL.Writers.Count);
-            Assert.IsTrue(savedToDo.ACL.Writers[0].Equals("writer1"));
-            Assert.IsTrue(savedToDo.ACL.Writers[1].Equals("writer2"));
-            Assert.IsTrue(savedToDo.ACL.Writers[2].Equals("writer3"));
+            Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+            Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+            Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+            Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+            Assert.IsNotNull(savedToDo.Acl.Readers);
+            Assert.IsNotNull(savedToDo.Acl.Writers);
+            CollectionAssert.AreEqual(todo.Acl.Writers, savedToDo.Acl.Writers);
+            Assert.AreEqual(3, savedToDo.Acl.Writers.Count);
+            Assert.IsTrue(savedToDo.Acl.Writers[0].Equals("writer1"));
+            Assert.IsTrue(savedToDo.Acl.Writers[1].Equals("writer2"));
+            Assert.IsTrue(savedToDo.Acl.Writers[2].Equals("writer3"));
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.Id);

--- a/Kinvey.Tests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreSyncIntegrationTests.cs
@@ -132,8 +132,8 @@ namespace Kinvey.Tests
 			Assert.AreEqual(2, listToDo.Count);
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
-			await todoStore.RemoveAsync(t2.ID);
+			await todoStore.RemoveAsync(t.Id);
+			await todoStore.RemoveAsync(t2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -157,14 +157,14 @@ namespace Kinvey.Tests
 
 			// Act
 			ToDo entity = null;
-			entity = await todoStore.FindByIDAsync(t.ID);
+			entity = await todoStore.FindByIDAsync(t.Id);
 
 			// Assert
 			Assert.IsNotNull(entity);
-			Assert.IsTrue(string.Equals(entity.ID, t.ID));
+			Assert.IsTrue(string.Equals(entity.Id, t.Id));
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
+			await todoStore.RemoveAsync(t.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -211,8 +211,8 @@ namespace Kinvey.Tests
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -269,9 +269,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -330,9 +330,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -389,9 +389,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -448,9 +448,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -508,9 +508,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -568,9 +568,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -628,9 +628,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -688,9 +688,9 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -734,8 +734,8 @@ namespace Kinvey.Tests
 			Assert.AreEqual(2u, count);
 
 			// Teardown
-			await todoStore.RemoveAsync(t1.ID);
-			await todoStore.RemoveAsync(t2.ID);
+			await todoStore.RemoveAsync(t1.Id);
+			await todoStore.RemoveAsync(t2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -781,9 +781,9 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, sum);
@@ -832,9 +832,9 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, min);
@@ -884,9 +884,9 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, max);
@@ -939,10 +939,10 @@ namespace Kinvey.Tests
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p4.ID);
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p4.Id);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, avg);
@@ -975,7 +975,7 @@ namespace Kinvey.Tests
 			Assert.IsTrue(string.Equals(savedToDo.Name, newItem.Name));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -994,7 +994,7 @@ namespace Kinvey.Tests
             newItem.Name = "Next Task";
             newItem.Details = "A test";
             newItem.DueDate = "2016-04-19T20:02:17.635Z";
-            newItem.ID = "12345";
+            newItem.Id = "12345";
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
 
             // Act
@@ -1017,7 +1017,7 @@ namespace Kinvey.Tests
             Assert.IsTrue(string.Compare("12345", pwaAfter.entityId) == 0);
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -1039,7 +1039,7 @@ namespace Kinvey.Tests
 			ToDo deleteToDo = await todoStore.SaveAsync(newItem);
 
 			// Act
-			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.ID);
+			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.Id);
 
 			// Assert
 			Assert.IsNotNull(kdr);
@@ -1064,7 +1064,7 @@ namespace Kinvey.Tests
 			newItem.Name = "Next Task";
 			newItem.Details = "A test";
 			newItem.DueDate = "2016-04-19T20:02:17.635Z";
-			newItem.ID = "12345";
+			newItem.Id = "12345";
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
 
 			// Act
@@ -1085,7 +1085,7 @@ namespace Kinvey.Tests
 			Assert.IsTrue(string.Compare("12345", pwaAfter.entityId) == 0);
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1117,7 +1117,7 @@ namespace Kinvey.Tests
 			Assert.IsTrue(String.Equals("POST", pwa.action));
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
+			await todoStore.RemoveAsync(newItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1136,7 +1136,7 @@ namespace Kinvey.Tests
 			ToDo newItem = new ToDo();
 			newItem.Name = "Task to save to SyncQ";
 			newItem.Details = "A sync add test";
-			newItem.ID = "12345";
+			newItem.Id = "12345";
 			newItem = await todoStore.SaveAsync(newItem);
 
 			// Act
@@ -1151,11 +1151,11 @@ namespace Kinvey.Tests
 			Assert.IsTrue(String.Equals("PUT", pwa.action));
 			Assert.IsNotNull(t);
 			Assert.AreEqual(1, t.Count);
-			Assert.AreEqual("12345", t.First().ID);
-			Assert.IsTrue(String.Equals(t.First().ID, pwa.entityId));
+			Assert.AreEqual("12345", t.First().Id);
+			Assert.IsTrue(String.Equals(t.First().Id, pwa.entityId));
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
+			await todoStore.RemoveAsync(newItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1175,7 +1175,7 @@ namespace Kinvey.Tests
 			newItem.Name = "Task to save to SyncQ";
 			newItem.Details = "A sync add test";
 			newItem = await todoStore.SaveAsync(newItem);
-			var responseDelete = await todoStore.RemoveAsync(newItem.ID);
+			var responseDelete = await todoStore.RemoveAsync(newItem.Id);
 
 			// Act
 			PendingWriteAction pwa = kinveyClient.CacheManager.GetSyncQueue(collectionName).Peek();
@@ -1195,7 +1195,7 @@ namespace Kinvey.Tests
 			Assert.AreEqual(0, syncQueueCount);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
+			await todoStore.RemoveAsync(newItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1241,7 +1241,7 @@ namespace Kinvey.Tests
 			KinveyDeleteResponse kdr;
 			foreach (ToDo td in listRemoveToDo)
 			{
-				kdr = await todoStore.RemoveAsync(td.ID);
+				kdr = await todoStore.RemoveAsync(td.Id);
 			}
 
 			dsr = await todoStore.SyncAsync();
@@ -1288,8 +1288,8 @@ namespace Kinvey.Tests
 			Assert.AreEqual(2, syncCountTotal);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
-			await todoStore.RemoveAsync(firstFlashCard.ID);
+			await todoStore.RemoveAsync(newItem.Id);
+			await todoStore.RemoveAsync(firstFlashCard.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1337,7 +1337,7 @@ namespace Kinvey.Tests
 
             foreach (ToDo td in listRemoveToDo)
             {
-                await todoStore.RemoveAsync(td.ID);
+                await todoStore.RemoveAsync(td.Id);
             }
 
             List<FlashCard> listRemoveFlash = new List<FlashCard>();
@@ -1345,7 +1345,7 @@ namespace Kinvey.Tests
 
             foreach (FlashCard fc in listRemoveFlash)
             {
-                await flashCardStore.RemoveAsync(fc.ID);
+                await flashCardStore.RemoveAsync(fc.Id);
             }
 
             SyncDataStoreResponse<ToDo> dsrDelete = await todoStore.SyncAsync();
@@ -1395,7 +1395,7 @@ namespace Kinvey.Tests
 
 			foreach (ToDo t in listRemoveToDo)
 			{
-				await todoStore.RemoveAsync(t.ID);
+				await todoStore.RemoveAsync(t.Id);
 			}
 
 			await todoStore.SyncAsync();
@@ -1446,7 +1446,7 @@ namespace Kinvey.Tests
 			// Teardown
 			foreach (var todo in todosAfterSave.PullEntities)
 			{
-				await todoStore.RemoveAsync(todo.ID);
+				await todoStore.RemoveAsync(todo.Id);
 			}
 			await todoStore.PushAsync();
 			kinveyClient.ActiveUser.Logout();
@@ -1499,7 +1499,7 @@ namespace Kinvey.Tests
 			PullDataStoreResponse<ToDo> todoCleanup = await todoStore.PullAsync();
 			foreach (var todo in todoCleanup.PullEntities)
 			{
-				await todoStore.RemoveAsync(todo.ID);
+				await todoStore.RemoveAsync(todo.Id);
 			}
 			await todoStore.PushAsync();
 			kinveyClient.ActiveUser.Logout();
@@ -1549,7 +1549,7 @@ namespace Kinvey.Tests
 			PullDataStoreResponse<ToDo> todoCleanup = await todoStore.PullAsync();
 			foreach (var todo in todoCleanup.PullEntities)
 			{
-				await todoStore.RemoveAsync(todo.ID);
+				await todoStore.RemoveAsync(todo.Id);
 			}
 			await todoStore.PushAsync();
 			kinveyClient.ActiveUser.Logout();
@@ -1610,10 +1610,10 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
-			await todoStore.RemoveAsync(newItem4.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
+			await todoStore.RemoveAsync(newItem4.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1678,10 +1678,10 @@ namespace Kinvey.Tests
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
-			await todoStore.RemoveAsync(newItem4.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
+			await todoStore.RemoveAsync(newItem4.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1740,8 +1740,8 @@ namespace Kinvey.Tests
 			Assert.IsTrue(String.Compare(addr.Street, savedAddr.Street) == 0);
 
 			// Teardown
-			await personStore.RemoveAsync(addr.ID);
-			await addrStore.RemoveAsync(addr.ID);
+			await personStore.RemoveAsync(addr.Id);
+			await addrStore.RemoveAsync(addr.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1791,8 +1791,8 @@ namespace Kinvey.Tests
 			Assert.IsTrue(String.Compare(addr.Street, savedAddr.Street) == 0);
 
 			// Teardown
-			await personStore.RemoveAsync(addr.ID);
-			await addrStore.RemoveAsync(addr.ID);
+			await personStore.RemoveAsync(addr.Id);
+			await addrStore.RemoveAsync(addr.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1950,7 +1950,7 @@ namespace Kinvey.Tests
             var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.SYNC);
             foreach (var item in (await store.PullAsync()).PullEntities)
             {
-                await store.RemoveAsync(item.ID);
+                await store.RemoveAsync(item.Id);
             }
             await store.PushAsync();
 
@@ -1968,7 +1968,7 @@ namespace Kinvey.Tests
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -2026,7 +2026,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2090,7 +2090,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2143,7 +2143,7 @@ namespace Kinvey.Tests
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
@@ -2155,12 +2155,12 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2221,7 +2221,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2291,7 +2291,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2341,13 +2341,13 @@ namespace Kinvey.Tests
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.PullAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
@@ -2356,7 +2356,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2412,7 +2412,7 @@ namespace Kinvey.Tests
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.PullAsync();
 
             var localEntities = await store.FindAsync();
@@ -2420,7 +2420,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2476,7 +2476,7 @@ namespace Kinvey.Tests
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -2531,7 +2531,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2594,7 +2594,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2646,7 +2646,7 @@ namespace Kinvey.Tests
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
@@ -2658,12 +2658,12 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2723,7 +2723,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2793,7 +2793,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2843,12 +2843,12 @@ namespace Kinvey.Tests
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.SyncAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             var secondResponse = await store.SyncAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             var thirdResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -2856,7 +2856,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2912,7 +2912,7 @@ namespace Kinvey.Tests
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -2920,7 +2920,7 @@ namespace Kinvey.Tests
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();

--- a/Kinvey.Tests/Support Files/Address.cs
+++ b/Kinvey.Tests/Support Files/Address.cs
@@ -13,7 +13,7 @@ namespace Kinvey.Tests
         [DataMember(Name = "_id")]
         [Preserve]
 		[PrimaryKey, Column("_id")]
-		public string ID { get; set; }
+		public string Id { get; set; }
 
 		[JsonProperty("_acl")]
         [DataMember(Name = "_acl")]

--- a/Kinvey.Tests/Support Files/Address.cs
+++ b/Kinvey.Tests/Support Files/Address.cs
@@ -19,7 +19,7 @@ namespace Kinvey.Tests
         [DataMember(Name = "_acl")]
         [Preserve]
 		[Column("_acl")]
-        public AccessControlList ACL { get; set; }
+        public AccessControlList Acl { get; set; }
 
 		[JsonProperty("_kmd")]
         [DataMember(Name = "_kmd")]

--- a/Kinvey.Tests/Support Files/Address.cs
+++ b/Kinvey.Tests/Support Files/Address.cs
@@ -25,7 +25,7 @@ namespace Kinvey.Tests
         [DataMember(Name = "_kmd")]
         [Preserve]
 		[Column("_kmd")]
-		public KinveyMetaData KMD { get; set; }
+		public KinveyMetaData Kmd { get; set; }
 
 		[JsonProperty]
         [DataMember]

--- a/Kinvey.Tests/Support Files/Person.cs
+++ b/Kinvey.Tests/Support Files/Person.cs
@@ -15,7 +15,7 @@ namespace Kinvey.Tests
 		[JsonProperty("_acl")]
 		[Preserve]
 		[Column("_acl")]
-		public AccessControlList ACL { get; set; }
+		public AccessControlList Acl { get; set; }
 
 		[JsonProperty("_kmd")]
 		[Preserve]

--- a/Kinvey.Tests/Support Files/Person.cs
+++ b/Kinvey.Tests/Support Files/Person.cs
@@ -10,7 +10,7 @@ namespace Kinvey.Tests
 		[JsonProperty("_id")]
 		[Preserve]
 		[PrimaryKey, Column("_id")]
-		public string ID { get; set; }
+		public string Id { get; set; }
 
 		[JsonProperty("_acl")]
 		[Preserve]

--- a/Kinvey.Tests/Support Files/Person.cs
+++ b/Kinvey.Tests/Support Files/Person.cs
@@ -20,7 +20,7 @@ namespace Kinvey.Tests
 		[JsonProperty("_kmd")]
 		[Preserve]
 		[Column("_kmd")]
-		public KinveyMetaData KMD { get; set; }
+		public KinveyMetaData Kmd { get; set; }
 
 		[JsonProperty]
 		public string FirstName { get; set; }

--- a/TestFramework/TestSupportFiles/Address.cs
+++ b/TestFramework/TestSupportFiles/Address.cs
@@ -14,7 +14,7 @@ namespace TestFramework
 		[Kinvey.Preserve]
         [SQLite.Preserve]
         [PrimaryKey, Column("_id")]
-		public string ID { get; set; }
+		public string Id { get; set; }
 
 		[JsonProperty("_acl")]
         [DataMember(Name = "_acl")]

--- a/TestFramework/TestSupportFiles/Address.cs
+++ b/TestFramework/TestSupportFiles/Address.cs
@@ -28,7 +28,7 @@ namespace TestFramework
         [Kinvey.Preserve]
         [SQLite.Preserve]
         [Column("_kmd")]
-		public KinveyMetaData KMD { get; set; }
+		public KinveyMetaData Kmd { get; set; }
 
 		[JsonProperty]
         [DataMember]

--- a/TestFramework/TestSupportFiles/Address.cs
+++ b/TestFramework/TestSupportFiles/Address.cs
@@ -21,7 +21,7 @@ namespace TestFramework
         [Kinvey.Preserve]
         [SQLite.Preserve]
         [Column("_acl")]
-		public AccessControlList ACL { get; set; }
+		public AccessControlList Acl { get; set; }
 
 		[JsonProperty("_kmd")]
         [DataMember(Name = "_kmd")]

--- a/TestFramework/TestSupportFiles/Person.cs
+++ b/TestFramework/TestSupportFiles/Person.cs
@@ -23,7 +23,7 @@ namespace TestFramework
         [Kinvey.Preserve]
         [SQLite.Preserve]
         [Column("_kmd")]
-		public KinveyMetaData KMD { get; set; }
+		public KinveyMetaData Kmd { get; set; }
 
 		[JsonProperty]
 		public string FirstName { get; set; }

--- a/TestFramework/TestSupportFiles/Person.cs
+++ b/TestFramework/TestSupportFiles/Person.cs
@@ -11,7 +11,7 @@ namespace TestFramework
         [Kinvey.Preserve]
         [SQLite.Preserve]
         [PrimaryKey, Column("_id")]
-		public string ID { get; set; }
+		public string Id { get; set; }
 
 		[JsonProperty("_acl")]
         [Kinvey.Preserve]

--- a/TestFramework/TestSupportFiles/Person.cs
+++ b/TestFramework/TestSupportFiles/Person.cs
@@ -17,7 +17,7 @@ namespace TestFramework
         [Kinvey.Preserve]
         [SQLite.Preserve]
         [Column("_acl")]
-		public AccessControlList ACL { get; set; }
+		public AccessControlList Acl { get; set; }
 
 		[JsonProperty("_kmd")]
         [Kinvey.Preserve]

--- a/TestFramework/Tests.Integration/Tests/DataStoreCacheIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreCacheIntegrationTests.cs
@@ -121,7 +121,7 @@ namespace TestFramework
 			ToDo networkEntity = null;
 			ToDo cacheEntity = null;
 
-			networkEntity = await todoStore.FindByIDAsync(t.ID, new KinveyDelegate<ToDo>
+			networkEntity = await todoStore.FindByIDAsync(t.Id, new KinveyDelegate<ToDo>
 			{
 				onSuccess = (result) => cacheEntity = result,
 				onError = (error) => Assert.Fail("TestCacheStoreFindByIDAsync: Cache find returned error")
@@ -129,13 +129,13 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(networkEntity);
-			Assert.True(string.Equals(networkEntity.ID, t.ID));
+			Assert.True(string.Equals(networkEntity.Id, t.Id));
 			Assert.NotNull(cacheEntity);
-			Assert.True(string.Equals(cacheEntity.ID, t.ID));
-			Assert.True(string.Equals(cacheEntity.ID, networkEntity.ID));
+			Assert.True(string.Equals(cacheEntity.Id, t.Id));
+			Assert.True(string.Equals(cacheEntity.Id, networkEntity.Id));
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
+			await todoStore.RemoveAsync(t.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -191,8 +191,8 @@ namespace TestFramework
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -247,8 +247,8 @@ namespace TestFramework
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -308,9 +308,9 @@ namespace TestFramework
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -370,9 +370,9 @@ namespace TestFramework
 			listToDo.AddRange(listToDoCache);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -455,9 +455,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, sum);
@@ -514,9 +514,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, min);
@@ -573,9 +573,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, max);
@@ -638,10 +638,10 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p4.ID);
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p4.Id);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, avg);
@@ -682,7 +682,7 @@ namespace TestFramework
 			Assert.True(string.Equals(newItem.Details, savedItem.Details));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedItem.ID);
+			await todoStore.RemoveAsync(savedItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -797,9 +797,9 @@ namespace TestFramework
 			newItem3 = await todoStore.SaveAsync(newItem3);
 
 			List<string> listIDs = new List<string>();
-			listIDs.Add(newItem1.ID);
-			listIDs.Add(newItem2.ID);
-			listIDs.Add(newItem3.ID);
+			listIDs.Add(newItem1.Id);
+			listIDs.Add(newItem2.Id);
+			listIDs.Add(newItem3.Id);
 
 			// Act
 			ICache<ToDo> cache = kinveyClient.CacheManager.GetCache<ToDo>(collectionName);
@@ -810,9 +810,9 @@ namespace TestFramework
 			Assert.AreEqual(3, listEntities.Count);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -872,9 +872,9 @@ namespace TestFramework
 			newItem3 = await todoStore.SaveAsync(newItem3);
 
 			List<string> listIDs = new List<string>();
-			listIDs.Add(newItem1.ID);
-			listIDs.Add(newItem2.ID);
-			listIDs.Add(newItem3.ID);
+			listIDs.Add(newItem1.Id);
+			listIDs.Add(newItem2.Id);
+			listIDs.Add(newItem3.Id);
 
 			// Act
 			List<ToDo> listEntities = new List<ToDo>();
@@ -890,9 +890,9 @@ namespace TestFramework
 			});
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -919,7 +919,7 @@ namespace TestFramework
 
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.CACHE);
 			ToDo savedItem = await todoStore.SaveAsync(newItem);
-			string savedItemID = savedItem.ID;
+			string savedItemID = savedItem.Id;
 
 			// Act
 			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(savedItemID);
@@ -987,9 +987,9 @@ namespace TestFramework
 			newItem3 = await todoStore.SaveAsync(newItem3);
 
 			List<string> listIDs = new List<string>();
-			listIDs.Add(newItem1.ID);
-			listIDs.Add(newItem2.ID);
-			listIDs.Add(newItem3.ID);
+			listIDs.Add(newItem1.Id);
+			listIDs.Add(newItem2.Id);
+			listIDs.Add(newItem3.Id);
 
 			// Act
 			ICache<ToDo> cache = kinveyClient.CacheManager.GetCache<ToDo>(collectionName);
@@ -1000,9 +1000,9 @@ namespace TestFramework
 			Assert.AreEqual(3, kdr.count);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1100,7 +1100,7 @@ namespace TestFramework
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -1153,7 +1153,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1212,7 +1212,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1260,7 +1260,7 @@ namespace TestFramework
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
@@ -1272,12 +1272,12 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1334,7 +1334,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1399,7 +1399,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1444,13 +1444,13 @@ namespace TestFramework
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.PullAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
@@ -1459,7 +1459,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1510,7 +1510,7 @@ namespace TestFramework
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.PullAsync();
 
             var localEntities = await store.FindAsync();
@@ -1518,7 +1518,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1569,7 +1569,7 @@ namespace TestFramework
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -1619,7 +1619,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1677,7 +1677,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1724,7 +1724,7 @@ namespace TestFramework
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
@@ -1736,12 +1736,12 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1796,7 +1796,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1861,7 +1861,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1906,12 +1906,12 @@ namespace TestFramework
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.SyncAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             var secondResponse = await store.SyncAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             var thirdResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -1919,7 +1919,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -1970,7 +1970,7 @@ namespace TestFramework
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -1978,7 +1978,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2036,7 +2036,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2089,7 +2089,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2137,9 +2137,9 @@ namespace TestFramework
             int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
             int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
 
-            await store.RemoveAsync(fc1.ID);
-            await store.RemoveAsync(fc2.ID);
-            await store.RemoveAsync(fc3.ID);
+            await store.RemoveAsync(fc1.Id);
+            await store.RemoveAsync(fc2.Id);
+            await store.RemoveAsync(fc3.Id);
 
             // Assert
             Assert.AreEqual(1, pullCount1);

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -193,8 +193,8 @@ namespace TestFramework
 			Assert.AreEqual(2, todoList.Count);
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
-			await todoStore.RemoveAsync(t2.ID);
+			await todoStore.RemoveAsync(t.Id);
+			await todoStore.RemoveAsync(t2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -214,14 +214,14 @@ namespace TestFramework
 
 			// Act
 			ToDo entity = null;
-			entity = await todoStore.FindByIDAsync(t.ID);
+			entity = await todoStore.FindByIDAsync(t.Id);
 
 			// Assert
 			Assert.NotNull(entity);
-			Assert.True(string.Equals(entity.ID, t.ID));
+			Assert.True(string.Equals(entity.Id, t.Id));
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
+			await todoStore.RemoveAsync(t.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -309,8 +309,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -354,8 +354,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -401,8 +401,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -450,8 +450,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -495,8 +495,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -549,9 +549,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -606,9 +606,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -661,9 +661,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -716,9 +716,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -772,9 +772,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -828,9 +828,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -884,9 +884,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -940,9 +940,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -995,8 +995,8 @@ namespace TestFramework
 			Assert.True(ke.ErrorCode == EnumErrorCode.ERROR_LINQ_WHERE_CLAUSE_NOT_SUPPORTED);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1035,8 +1035,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1080,8 +1080,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1125,8 +1125,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1171,8 +1171,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1219,8 +1219,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1270,8 +1270,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1323,8 +1323,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1373,8 +1373,8 @@ namespace TestFramework
 			listToDo = await todoStore.FindWithMongoQueryAsync(mongoQuery);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1425,8 +1425,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1473,8 +1473,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1519,8 +1519,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1565,8 +1565,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1611,8 +1611,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1657,8 +1657,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1705,8 +1705,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1753,8 +1753,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1799,8 +1799,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1845,8 +1845,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1897,8 +1897,8 @@ namespace TestFramework
 			Assert.AreEqual(2, count);
 
 			// Teardown
-			await todoStore.RemoveAsync(t1.ID);
-			await todoStore.RemoveAsync(t2.ID);
+			await todoStore.RemoveAsync(t1.Id);
+			await todoStore.RemoveAsync(t2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1954,9 +1954,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, sum);
@@ -2000,9 +2000,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, min);
@@ -2046,9 +2046,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, max);
@@ -2098,10 +2098,10 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p4.ID);
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p4.Id);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, avg);
@@ -2130,7 +2130,7 @@ namespace TestFramework
 			Assert.True(string.Equals(savedToDo.Name, newItem.Name));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -2159,7 +2159,7 @@ namespace TestFramework
 			ToDo deleteToDo = await todoStore.SaveAsync(newItem);
 
 			// Act
-			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.ID);
+			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.Id);
 
 			// Assert
 			Assert.NotNull(kdr);
@@ -2229,7 +2229,7 @@ namespace TestFramework
 			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -2258,7 +2258,7 @@ namespace TestFramework
 			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -2294,7 +2294,7 @@ namespace TestFramework
 			Assert.True(savedToDo.ACL.Readers[1].Equals("reader2"));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -2332,7 +2332,7 @@ namespace TestFramework
 			Assert.True(savedToDo.ACL.Writers[2].Equals("writer3"));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -2373,7 +2373,7 @@ namespace TestFramework
 			Assert.True(savedToDo.ACL.Groups.Readers[2].Equals("groupread3"));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -2412,7 +2412,7 @@ namespace TestFramework
 			Assert.True(savedToDo.ACL.Groups.Writers[1].Equals("groupwrite2"));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 	}

--- a/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreNetworkIntegrationTests.cs
@@ -2215,7 +2215,7 @@ namespace TestFramework
 			acl.GloballyReadable = true;
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 			ToDo todo = new ToDo();
-			todo.ACL = acl;
+			todo.Acl = acl;
 
 			// Act
 			ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -2223,10 +2223,10 @@ namespace TestFramework
 			// Assert
 			Assert.AreEqual(true, acl.GloballyReadable);
 			Assert.AreEqual(false, acl.GloballyWriteable);
-			Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-			Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-			Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
+			Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+			Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+			Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+			Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
 
 			// Teardown
 			await todoStore.RemoveAsync(savedToDo.Id);
@@ -2244,7 +2244,7 @@ namespace TestFramework
 			acl.GloballyWriteable = true;
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 			ToDo todo = new ToDo();
-			todo.ACL = acl;
+			todo.Acl = acl;
 
 			// Act
 			ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -2252,10 +2252,10 @@ namespace TestFramework
 			// Assert
 			Assert.AreEqual(false, acl.GloballyReadable);
 			Assert.AreEqual(true, acl.GloballyWriteable);
-			Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-			Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-			Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
+			Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+			Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+			Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+			Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
 
 			// Teardown
 			await todoStore.RemoveAsync(savedToDo.Id);
@@ -2274,7 +2274,7 @@ namespace TestFramework
 			acl.Readers.Add("reader2");
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 			ToDo todo = new ToDo();
-			todo.ACL = acl;
+			todo.Acl = acl;
 
 			// Act
 			ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -2282,16 +2282,16 @@ namespace TestFramework
 			// Assert
 			Assert.AreEqual(false, acl.GloballyReadable);
 			Assert.AreEqual(false, acl.GloballyWriteable);
-			Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-			Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-			Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-			Assert.IsNotNull(savedToDo.ACL.Writers);
-			Assert.IsNotNull(savedToDo.ACL.Readers);
-			Assert.AreEqual(todo.ACL.Readers, savedToDo.ACL.Readers);
-			Assert.AreEqual(2, savedToDo.ACL.Readers.Count);
-			Assert.True(savedToDo.ACL.Readers[0].Equals("reader1"));
-			Assert.True(savedToDo.ACL.Readers[1].Equals("reader2"));
+			Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+			Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+			Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+			Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+			Assert.IsNotNull(savedToDo.Acl.Writers);
+			Assert.IsNotNull(savedToDo.Acl.Readers);
+			Assert.AreEqual(todo.Acl.Readers, savedToDo.Acl.Readers);
+			Assert.AreEqual(2, savedToDo.Acl.Readers.Count);
+			Assert.True(savedToDo.Acl.Readers[0].Equals("reader1"));
+			Assert.True(savedToDo.Acl.Readers[1].Equals("reader2"));
 
 			// Teardown
 			await todoStore.RemoveAsync(savedToDo.Id);
@@ -2311,7 +2311,7 @@ namespace TestFramework
 			acl.Writers.Add("writer3");
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 			ToDo todo = new ToDo();
-			todo.ACL = acl;
+			todo.Acl = acl;
 
 			// Act
 			ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -2319,17 +2319,17 @@ namespace TestFramework
 			// Assert
 			Assert.AreEqual(false, acl.GloballyReadable);
 			Assert.AreEqual(false, acl.GloballyWriteable);
-			Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-			Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-			Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-			Assert.IsNotNull(savedToDo.ACL.Readers);
-			Assert.IsNotNull(savedToDo.ACL.Writers);
-			Assert.AreEqual(todo.ACL.Writers, savedToDo.ACL.Writers);
-			Assert.AreEqual(3, savedToDo.ACL.Writers.Count);
-			Assert.True(savedToDo.ACL.Writers[0].Equals("writer1"));
-			Assert.True(savedToDo.ACL.Writers[1].Equals("writer2"));
-			Assert.True(savedToDo.ACL.Writers[2].Equals("writer3"));
+			Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+			Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+			Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+			Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+			Assert.IsNotNull(savedToDo.Acl.Readers);
+			Assert.IsNotNull(savedToDo.Acl.Writers);
+			Assert.AreEqual(todo.Acl.Writers, savedToDo.Acl.Writers);
+			Assert.AreEqual(3, savedToDo.Acl.Writers.Count);
+			Assert.True(savedToDo.Acl.Writers[0].Equals("writer1"));
+			Assert.True(savedToDo.Acl.Writers[1].Equals("writer2"));
+			Assert.True(savedToDo.Acl.Writers[2].Equals("writer3"));
 
 			// Teardown
 			await todoStore.RemoveAsync(savedToDo.Id);
@@ -2349,7 +2349,7 @@ namespace TestFramework
 			acl.Groups.Readers.Add("groupread3");
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 			ToDo todo = new ToDo();
-			todo.ACL = acl;
+			todo.Acl = acl;
 
 			// Act
 			ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -2357,20 +2357,20 @@ namespace TestFramework
 			// Assert
 			Assert.AreEqual(false, acl.GloballyReadable);
 			Assert.AreEqual(false, acl.GloballyWriteable);
-			Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-			Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-			Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-			Assert.IsNotNull(savedToDo.ACL.Readers);
-			Assert.IsNotNull(savedToDo.ACL.Writers);
-			Assert.IsNotNull(savedToDo.ACL.Groups);
-			Assert.IsNotNull(savedToDo.ACL.Groups.Writers);
-			Assert.IsNotNull(savedToDo.ACL.Groups.Readers);
-			Assert.AreEqual(todo.ACL.Groups.Readers, savedToDo.ACL.Groups.Readers);
-			Assert.AreEqual(3, savedToDo.ACL.Groups.Readers.Count);
-			Assert.True(savedToDo.ACL.Groups.Readers[0].Equals("groupread1"));
-			Assert.True(savedToDo.ACL.Groups.Readers[1].Equals("groupread2"));
-			Assert.True(savedToDo.ACL.Groups.Readers[2].Equals("groupread3"));
+			Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+			Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+			Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+			Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+			Assert.IsNotNull(savedToDo.Acl.Readers);
+			Assert.IsNotNull(savedToDo.Acl.Writers);
+			Assert.IsNotNull(savedToDo.Acl.Groups);
+			Assert.IsNotNull(savedToDo.Acl.Groups.Writers);
+			Assert.IsNotNull(savedToDo.Acl.Groups.Readers);
+			Assert.AreEqual(todo.Acl.Groups.Readers, savedToDo.Acl.Groups.Readers);
+			Assert.AreEqual(3, savedToDo.Acl.Groups.Readers.Count);
+			Assert.True(savedToDo.Acl.Groups.Readers[0].Equals("groupread1"));
+			Assert.True(savedToDo.Acl.Groups.Readers[1].Equals("groupread2"));
+			Assert.True(savedToDo.Acl.Groups.Readers[2].Equals("groupread3"));
 
 			// Teardown
 			await todoStore.RemoveAsync(savedToDo.Id);
@@ -2389,7 +2389,7 @@ namespace TestFramework
 			acl.Groups.Writers.Add("groupwrite2");
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 			ToDo todo = new ToDo();
-			todo.ACL = acl;
+			todo.Acl = acl;
 
 			// Act
 			ToDo savedToDo = await todoStore.SaveAsync(todo);
@@ -2397,19 +2397,19 @@ namespace TestFramework
 			// Assert
 			Assert.AreEqual(false, acl.GloballyReadable);
 			Assert.AreEqual(false, acl.GloballyWriteable);
-			Assert.AreNotEqual(todo.ACL, savedToDo.ACL);
-			Assert.AreNotEqual(todo.ACL.Creator, savedToDo.ACL.Creator);
-			Assert.AreEqual(todo.ACL.GloballyReadable, savedToDo.ACL.GloballyReadable);
-			Assert.AreEqual(todo.ACL.GloballyWriteable, savedToDo.ACL.GloballyWriteable);
-			Assert.IsNotNull(savedToDo.ACL.Readers);
-			Assert.IsNotNull(savedToDo.ACL.Writers);
-			Assert.IsNotNull(savedToDo.ACL.Groups);
-			Assert.IsNotNull(savedToDo.ACL.Groups.Readers);
-			Assert.IsNotNull(savedToDo.ACL.Groups.Writers);
-			Assert.AreEqual(todo.ACL.Groups.Writers, savedToDo.ACL.Groups.Writers);
-			Assert.AreEqual(2, savedToDo.ACL.Groups.Writers.Count);
-			Assert.True(savedToDo.ACL.Groups.Writers[0].Equals("groupwrite1"));
-			Assert.True(savedToDo.ACL.Groups.Writers[1].Equals("groupwrite2"));
+			Assert.AreNotEqual(todo.Acl, savedToDo.Acl);
+			Assert.AreNotEqual(todo.Acl.Creator, savedToDo.Acl.Creator);
+			Assert.AreEqual(todo.Acl.GloballyReadable, savedToDo.Acl.GloballyReadable);
+			Assert.AreEqual(todo.Acl.GloballyWriteable, savedToDo.Acl.GloballyWriteable);
+			Assert.IsNotNull(savedToDo.Acl.Readers);
+			Assert.IsNotNull(savedToDo.Acl.Writers);
+			Assert.IsNotNull(savedToDo.Acl.Groups);
+			Assert.IsNotNull(savedToDo.Acl.Groups.Readers);
+			Assert.IsNotNull(savedToDo.Acl.Groups.Writers);
+			Assert.AreEqual(todo.Acl.Groups.Writers, savedToDo.Acl.Groups.Writers);
+			Assert.AreEqual(2, savedToDo.Acl.Groups.Writers.Count);
+			Assert.True(savedToDo.Acl.Groups.Writers[0].Equals("groupwrite1"));
+			Assert.True(savedToDo.Acl.Groups.Writers[1].Equals("groupwrite2"));
 
 			// Teardown
 			await todoStore.RemoveAsync(savedToDo.Id);

--- a/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/DataStoreSyncIntegrationTests.cs
@@ -158,8 +158,8 @@ namespace TestFramework
 			Assert.AreEqual(2, listToDo.Count);
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
-			await todoStore.RemoveAsync(t2.ID);
+			await todoStore.RemoveAsync(t.Id);
+			await todoStore.RemoveAsync(t2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -179,14 +179,14 @@ namespace TestFramework
 
 			// Act
 			ToDo entity = null;
-			entity = await todoStore.FindByIDAsync(t.ID);
+			entity = await todoStore.FindByIDAsync(t.Id);
 
 			// Assert
 			Assert.NotNull(entity);
-			Assert.True(string.Equals(entity.ID, t.ID));
+			Assert.True(string.Equals(entity.Id, t.Id));
 
 			// Teardown
-			await todoStore.RemoveAsync(t.ID);
+			await todoStore.RemoveAsync(t.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -267,8 +267,8 @@ namespace TestFramework
 
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -321,9 +321,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -378,9 +378,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -433,9 +433,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -488,9 +488,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -544,9 +544,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -600,9 +600,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -656,9 +656,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -712,9 +712,9 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -765,8 +765,8 @@ namespace TestFramework
 			Assert.AreEqual(2, count);
 
 			// Teardown
-			await todoStore.RemoveAsync(t1.ID);
-			await todoStore.RemoveAsync(t2.ID);
+			await todoStore.RemoveAsync(t1.Id);
+			await todoStore.RemoveAsync(t2.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -819,9 +819,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, sum);
@@ -866,9 +866,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, min);
@@ -914,9 +914,9 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, max);
@@ -965,10 +965,10 @@ namespace TestFramework
 			}
 
 			// Teardown
-			await personStore.RemoveAsync(p4.ID);
-			await personStore.RemoveAsync(p3.ID);
-			await personStore.RemoveAsync(p2.ID);
-			await personStore.RemoveAsync(p1.ID);
+			await personStore.RemoveAsync(p4.Id);
+			await personStore.RemoveAsync(p3.Id);
+			await personStore.RemoveAsync(p2.Id);
+			await personStore.RemoveAsync(p1.Id);
 
 			// Assert
 			Assert.AreNotEqual(0, avg);
@@ -997,7 +997,7 @@ namespace TestFramework
 			Assert.True(string.Equals(savedToDo.Name, newItem.Name));
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1012,7 +1012,7 @@ namespace TestFramework
             newItem.Name = "Next Task";
             newItem.Details = "A test";
             newItem.DueDate = "2016-04-19T20:02:17.635Z";
-            newItem.ID = "12345";
+            newItem.Id = "12345";
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
 
             // Act
@@ -1035,7 +1035,7 @@ namespace TestFramework
             Assert.True(string.Compare("12345", pwaAfter.entityId) == 0);
 
             // Teardown
-            await todoStore.RemoveAsync(savedToDo.ID);
+            await todoStore.RemoveAsync(savedToDo.Id);
             kinveyClient.ActiveUser.Logout();
         }
 
@@ -1064,7 +1064,7 @@ namespace TestFramework
 			ToDo deleteToDo = await todoStore.SaveAsync(newItem);
 
 			// Act
-			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.ID);
+			KinveyDeleteResponse kdr = await todoStore.RemoveAsync(deleteToDo.Id);
 
 			// Assert
 			Assert.NotNull(kdr);
@@ -1085,7 +1085,7 @@ namespace TestFramework
 			newItem.Name = "Next Task";
 			newItem.Details = "A test";
 			newItem.DueDate = "2016-04-19T20:02:17.635Z";
-			newItem.ID = "12345";
+			newItem.Id = "12345";
 			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
 
 			// Act
@@ -1106,7 +1106,7 @@ namespace TestFramework
 			Assert.True(string.Compare("12345", pwaAfter.entityId) == 0);
 
 			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
+			await todoStore.RemoveAsync(savedToDo.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1145,7 +1145,7 @@ namespace TestFramework
 			Assert.True(String.Equals("POST", pwa.action));
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
+			await todoStore.RemoveAsync(newItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1160,7 +1160,7 @@ namespace TestFramework
 			ToDo newItem = new ToDo();
 			newItem.Name = "Task to save to SyncQ";
 			newItem.Details = "A sync add test";
-			newItem.ID = "12345";
+			newItem.Id = "12345";
 			newItem = await todoStore.SaveAsync(newItem);
 
 			// Act
@@ -1175,11 +1175,11 @@ namespace TestFramework
 			Assert.True(String.Equals("PUT", pwa.action));
 			Assert.NotNull(t);
 			Assert.AreEqual(1, t.Count);
-			Assert.AreEqual("12345", t.First().ID);
-			Assert.True(String.Equals(t.First().ID, pwa.entityId));
+			Assert.AreEqual("12345", t.First().Id);
+			Assert.True(String.Equals(t.First().Id, pwa.entityId));
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
+			await todoStore.RemoveAsync(newItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1195,7 +1195,7 @@ namespace TestFramework
 			newItem.Name = "Task to save to SyncQ";
 			newItem.Details = "A sync add test";
 			newItem = await todoStore.SaveAsync(newItem);
-			var responseDelete = await todoStore.RemoveAsync(newItem.ID);
+			var responseDelete = await todoStore.RemoveAsync(newItem.Id);
 
 			// Act
 			PendingWriteAction pwa = kinveyClient.CacheManager.GetSyncQueue(collectionName).Peek();
@@ -1215,7 +1215,7 @@ namespace TestFramework
 			Assert.AreEqual(0, syncQueueCount);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
+			await todoStore.RemoveAsync(newItem.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1259,7 +1259,7 @@ namespace TestFramework
 
 			foreach (ToDo td in listRemoveToDo)
 			{
-				await todoStore.RemoveAsync(td.ID);
+				await todoStore.RemoveAsync(td.Id);
 			}
 
 			List<FlashCard> listRemoveFlash = new List<FlashCard>();
@@ -1267,7 +1267,7 @@ namespace TestFramework
 
 			foreach (FlashCard fc in listRemoveFlash)
 			{
-				await flashCardStore.RemoveAsync(fc.ID);
+				await flashCardStore.RemoveAsync(fc.Id);
 			}
 
 			SyncDataStoreResponse<ToDo> dsrDelete = await todoStore.SyncAsync();
@@ -1316,7 +1316,7 @@ namespace TestFramework
 			KinveyDeleteResponse kdr;
 			foreach (ToDo td in listRemoveToDo)
 			{
-				kdr = await todoStore.RemoveAsync(td.ID);
+				kdr = await todoStore.RemoveAsync(td.Id);
 			}
 
 			dsr = await todoStore.SyncAsync();
@@ -1359,8 +1359,8 @@ namespace TestFramework
 			Assert.AreEqual(2, syncCountTotal);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem.ID);
-			await todoStore.RemoveAsync(firstFlashCard.ID);
+			await todoStore.RemoveAsync(newItem.Id);
+			await todoStore.RemoveAsync(firstFlashCard.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1399,7 +1399,7 @@ namespace TestFramework
 
 			foreach (ToDo t in listRemoveToDo)
 			{
-				await todoStore.RemoveAsync(t.ID);
+				await todoStore.RemoveAsync(t.Id);
 			}
 
 			await todoStore.SyncAsync();
@@ -1446,7 +1446,7 @@ namespace TestFramework
 			// Teardown
 			foreach (var todo in todosAfterSave.PullEntities)
 			{
-				await todoStore.RemoveAsync(todo.ID);
+				await todoStore.RemoveAsync(todo.Id);
 			}
 			await todoStore.PushAsync();
 			kinveyClient.ActiveUser.Logout();
@@ -1495,7 +1495,7 @@ namespace TestFramework
 			PullDataStoreResponse<ToDo> todoCleanup = await todoStore.PullAsync();
 			foreach (var todo in todoCleanup.PullEntities)
 			{
-				await todoStore.RemoveAsync(todo.ID);
+				await todoStore.RemoveAsync(todo.Id);
 			}
 			await todoStore.PushAsync();
 			kinveyClient.ActiveUser.Logout();
@@ -1541,7 +1541,7 @@ namespace TestFramework
 			PullDataStoreResponse<ToDo> todoCleanup = await todoStore.PullAsync();
 			foreach (var todo in todoCleanup.PullEntities)
 			{
-				await todoStore.RemoveAsync(todo.ID);
+				await todoStore.RemoveAsync(todo.Id);
 			}
 			await todoStore.PushAsync();
 			kinveyClient.ActiveUser.Logout();
@@ -1598,10 +1598,10 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
-			await todoStore.RemoveAsync(newItem4.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
+			await todoStore.RemoveAsync(newItem4.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1662,10 +1662,10 @@ namespace TestFramework
 			listToDo = await todoStore.FindAsync(query);
 
 			// Teardown
-			await todoStore.RemoveAsync(newItem1.ID);
-			await todoStore.RemoveAsync(newItem2.ID);
-			await todoStore.RemoveAsync(newItem3.ID);
-			await todoStore.RemoveAsync(newItem4.ID);
+			await todoStore.RemoveAsync(newItem1.Id);
+			await todoStore.RemoveAsync(newItem2.Id);
+			await todoStore.RemoveAsync(newItem3.Id);
+			await todoStore.RemoveAsync(newItem4.Id);
 			kinveyClient.ActiveUser.Logout();
 
 			// Assert
@@ -1720,8 +1720,8 @@ namespace TestFramework
 			Assert.IsTrue(String.Compare(addr.Street, savedAddr.Street) == 0);
 
 			// Teardown
-			await personStore.RemoveAsync(addr.ID);
-			await addrStore.RemoveAsync(addr.ID);
+			await personStore.RemoveAsync(addr.Id);
+			await addrStore.RemoveAsync(addr.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1767,8 +1767,8 @@ namespace TestFramework
 			Assert.IsTrue(String.Compare(addr.Street, savedAddr.Street) == 0);
 
 			// Teardown
-			await personStore.RemoveAsync(addr.ID);
-			await addrStore.RemoveAsync(addr.ID);
+			await personStore.RemoveAsync(addr.Id);
+			await addrStore.RemoveAsync(addr.Id);
 			kinveyClient.ActiveUser.Logout();
 		}
 
@@ -1914,7 +1914,7 @@ namespace TestFramework
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -1967,7 +1967,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2026,7 +2026,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2074,7 +2074,7 @@ namespace TestFramework
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
@@ -2086,12 +2086,12 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2148,7 +2148,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2213,7 +2213,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2258,13 +2258,13 @@ namespace TestFramework
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.PullAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
@@ -2273,7 +2273,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2324,7 +2324,7 @@ namespace TestFramework
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.PullAsync();
 
             var localEntities = await store.FindAsync();
@@ -2332,7 +2332,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2383,7 +2383,7 @@ namespace TestFramework
             var localEntities = await store.FindAsync();
             if (localEntities != null)
             {
-                await store.RemoveAsync(localEntities.First().ID);
+                await store.RemoveAsync(localEntities.First().Id);
                 await store.SyncAsync();
             }
 
@@ -2433,7 +2433,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2491,7 +2491,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2538,7 +2538,7 @@ namespace TestFramework
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
             fc2 = (await store.FindAsync(fc2Query)).First();
-            int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
+            int localDeleteCount = (await networkStore.RemoveAsync(fc2.Id)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
@@ -2550,12 +2550,12 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    if (fc2.ID == localEntity.ID)
+                    if (fc2.Id == localEntity.Id)
                     {
                         localCopy = true;
                     }
 
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2610,7 +2610,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2675,7 +2675,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2720,12 +2720,12 @@ namespace TestFramework
             fc3 = await networkStore.SaveAsync(fc3);
             var firstResponse = await store.SyncAsync();
 
-            var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
+            var firstDeleteResponse = await store.RemoveAsync(fc1.Id);
             var secondResponse = await store.SyncAsync();
             var firstStoreCount = (await store.FindAsync()).Count;
 
-            var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
-            var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
+            var secondDeleteResponse = await store.RemoveAsync(fc2.Id);
+            var thirdDeleteResponse = await store.RemoveAsync(fc3.Id);
             var thirdResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -2733,7 +2733,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2784,7 +2784,7 @@ namespace TestFramework
             fc2 = (await store.FindAsync(fc2Query)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
-            var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
+            var deleteResponse = await networkStore.RemoveAsync(fc3.Id);
             var secondResponse = await store.SyncAsync();
 
             var localEntities = await store.FindAsync();
@@ -2792,7 +2792,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2850,7 +2850,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2903,7 +2903,7 @@ namespace TestFramework
             {
                 foreach (var localEntity in localEntities)
                 {
-                    await store.RemoveAsync(localEntity.ID);
+                    await store.RemoveAsync(localEntity.Id);
                 }
 
                 await store.SyncAsync();
@@ -2951,9 +2951,9 @@ namespace TestFramework
             int pullCount1 = (await store.PullAsync(fc2Query)).PullCount;
             int pullCount2 = (await store.PullAsync(fc2Query)).PullCount;
 
-            await store.RemoveAsync(fc1.ID);
-            await store.RemoveAsync(fc2.ID);
-            await store.RemoveAsync(fc3.ID);
+            await store.RemoveAsync(fc1.Id);
+            await store.RemoveAsync(fc2.Id);
+            await store.RemoveAsync(fc3.Id);
 
             // Assert
             Assert.AreEqual(1, pullCount1);

--- a/TestFramework/Tests.Integration/Tests/RealtimeIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/RealtimeIntegrationTests.cs
@@ -114,7 +114,7 @@ namespace TestFramework
             bool signal = autoEvent.WaitOne(20000);
 
             // Teardown
-            await store.RemoveAsync(todo.ID);
+            await store.RemoveAsync(todo.Id);
             await store.Unsubscribe();
             await Client.SharedClient.ActiveUser.UnregisterRealtimeAsync();
             kinveyClient.ActiveUser.Logout();
@@ -166,7 +166,7 @@ namespace TestFramework
             bool signal = autoEvent.WaitOne(10000);
 
             // Teardown
-            await store.RemoveAsync(todo.ID);
+            await store.RemoveAsync(todo.Id);
             await store.Unsubscribe();
             await Client.SharedClient.ActiveUser.UnregisterRealtimeAsync();
             kinveyClient.ActiveUser.Logout();
@@ -217,7 +217,7 @@ namespace TestFramework
             bool signal = autoEvent.WaitOne(10000);
 
             // Teardown
-            await store.RemoveAsync(todo.ID);
+            await store.RemoveAsync(todo.Id);
             await store.Unsubscribe();
             await Client.SharedClient.ActiveUser.UnregisterRealtimeAsync();
             kinveyClient.ActiveUser.Logout();

--- a/TestFramework/Tests.Integration/Tests/RealtimeIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/RealtimeIntegrationTests.cs
@@ -160,7 +160,7 @@ namespace TestFramework
             var acl = new AccessControlList();
             acl.GloballyReadable = false;
             acl.Readers.Add(Client.SharedClient.ActiveUser.Id);
-            todo.ACL = acl;
+            todo.Acl = acl;
             todo = await store.SaveAsync(todo);
 
             bool signal = autoEvent.WaitOne(10000);
@@ -211,7 +211,7 @@ namespace TestFramework
             todo.Details = "Test Todo Details";
             var acl = new AccessControlList();
             acl.GloballyReadable = false;
-            todo.ACL = acl;
+            todo.Acl = acl;
             todo = await store.SaveAsync(todo);
 
             bool signal = autoEvent.WaitOne(10000);


### PR DESCRIPTION
#### Description
Entity properties were renamed as they have only capitalize first letter

#### Changes
No changes. Only renaming where Acl, Id, Kmd properties are being used.

#### Tests
No tests
