### PR TITLE
MLIBZ-2761:Deprecate `loginWithMIC()` method for automated authorization grant flow

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -515,15 +515,15 @@ namespace Kinvey
 			LoginWithMIC(redirectURI, MICDelegate, null, userClient, ct);
 		}
 
-		/// <summary>
-		/// Performs MIC Login authorization through a login page.
-		/// </summary>
-		/// <param name="redirectURI">The redirect URI to be used for parsing the grant code</param>
-		/// <param name="MICDelegate">MIC Delegate, which has a callback to pass back the URL to render for login, as well as success and error callbacks.</param>
-		/// <param name="clientID">[optional] Client ID configured during auth provider configuration, which is to be used during authentication.  Defaults to app key.</param>
-		/// <param name="userClient">[optional] Client that the user is logged in for, defaulted to SharedClient.</param>
-		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		static public void LoginWithMIC(string redirectURI, KinveyMICDelegate<User> MICDelegate, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
+        /// <summary>
+        /// Performs MIC Login authorization through a login page.
+        /// </summary>
+        /// <param name="redirectURI">The redirect URI to be used for parsing the grant code</param>
+        /// <param name="MICDelegate">MIC Delegate, which has a callback to pass back the URL to render for login, as well as success and error callbacks.</param>
+        /// <param name="clientID">[optional] Client ID configured during auth provider configuration, which is to be used during authentication.  Defaults to app key.</param>
+        /// <param name="userClient">[optional] Client that the user is logged in for, defaulted to SharedClient.</param>
+        /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+        static public void LoginWithMIC(string redirectURI, KinveyMICDelegate<User> MICDelegate, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
 			//return URL for login page
 			//https://auth.kinvey.com/oauth/auth?client_id=<your_app_id>&redirect_uri=<redirect_uri>&response_type=code

--- a/Kinvey.Tests/UserUnitTests.cs
+++ b/Kinvey.Tests/UserUnitTests.cs
@@ -172,7 +172,7 @@ namespace Kinvey.Tests
 		}
 
         [TestMethod]
-		public async Task TestMICRenderURLScopeID()
+        public async Task TestMICRenderURLScopeID()
 		{
 			// Arrange
 			var builder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret);

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -323,7 +323,7 @@ namespace TestFramework
 		// MIC LOGIN TESTS
 		//
 		[Test]
-		public void TestMIC_LoginWithMIC_NormalFlow()
+        public void TestMIC_LoginWithMIC_NormalFlow()
 		{
 			// Arrange
 			string redirectURI = "http://test.redirect";
@@ -345,7 +345,7 @@ namespace TestFramework
 		}
 
 		[Test]
-		public void TestMIC_LoginWithMIC_NormalFlow_ClientID()
+        public void TestMIC_LoginWithMIC_NormalFlow_ClientID()
 		{
 			// Arrange
 			string redirectURI = "http://test.redirect";

--- a/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
+++ b/TestFramework/Tests.Unit/Tests/UserUnitTests.cs
@@ -140,7 +140,7 @@ namespace TestFramework
 		}
 
 		[Test]
-		public async Task TestMICRenderURLScopeID()
+        public async Task TestMICRenderURLScopeID()
 		{
 			// Arrange
 			var builder = new Client.Builder(TestSetup.app_key, TestSetup.app_secret);


### PR DESCRIPTION
#### Description
Deprecate `loginWithMIC()` method for automated authorization grant flow

#### Changes
The method
`static public void LoginWithMIC(string redirectURI, KinveyMICDelegate<User> MICDelegate, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))`
got deprecated

#### Tests
```
TestMIC_LoginWithMIC_NormalFlow(), TestMIC_LoginWithMIC_NormalFlow_ClientID(), 
TestMICRenderURLScopeID(), TestMIC_LoginWithMIC_NormalFlow(),TestMIC_LoginWithMIC_NormalFlow_ClientID(),
TestMICRenderURLScopeID()
``` 
got obsolete.
