### PR TITLE
MLIBZ-2761:Deprecate `loginWithMIC()` method for automated authorization grant flow

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -568,7 +568,7 @@ namespace Kinvey
 		/// <param name="password">Password for authentication</param>
 		/// <param name="redirectURI">The redirect URI to be used for parsing the grant code</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		[Obsolete("This method has been deprecated.  Please use LoginWithMIC() instead.")]
+		[Obsolete("This method has been deprecated.  Please use LoginWithMIC(username:, password:, micID:, userClient:, ct: ) instead.")]
 		static public async Task LoginWithAuthorizationCodeAPIAsync(string username, string password, string redirectURI, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
 			await LoginWithMICInternal(username, password, redirectURI, null, userClient, ct);
@@ -583,7 +583,7 @@ namespace Kinvey
         /// <param name="micID">[optional] Auth Service ID</param>
         /// <param name="userClient">[optional] Client that the user is logged in, defaulted to SharedClient.</param>
         /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-        [Obsolete("This method has been deprecated.  Please use LoginWithMIC() instead.")]
+        [Obsolete("This method has been deprecated.  Please use LoginWithMIC(username:, password:, micID:, userClient:, ct: ) instead.")]
         static public async Task LoginWithMIC(string username, string password, string redirectURI, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
             await LoginWithMICInternal(username, password, redirectURI, micID, userClient, ct);

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -571,7 +571,7 @@ namespace Kinvey
 		[Obsolete("This method has been deprecated.  Please use LoginWithMIC() instead.")]
 		static public async Task LoginWithAuthorizationCodeAPIAsync(string username, string password, string redirectURI, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
-			await LoginWithMIC(username, password, redirectURI, null, userClient, ct);
+			await LoginWithMICInternal(username, password, redirectURI, null, userClient, ct);
 		}
 
         /// <summary>
@@ -583,69 +583,97 @@ namespace Kinvey
         /// <param name="micID">[optional] Auth Service ID</param>
         /// <param name="userClient">[optional] Client that the user is logged in, defaulted to SharedClient.</param>
         /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+        [Obsolete("This method has been deprecated.  Please use LoginWithMIC() instead.")]
         static public async Task LoginWithMIC(string username, string password, string redirectURI, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
-			var uc = userClient ?? Client.SharedClient;
-			uc.MICRedirectURI = redirectURI;
+            await LoginWithMICInternal(username, password, redirectURI, micID, userClient, ct);
+        }
 
-			try
-			{
-				ct.ThrowIfCancellationRequested();
+        /// <summary>
+        /// Performs MIC Login authorization through an API.
+        /// </summary>
+        /// <param name="username">Username for authentication</param>
+        /// <param name="password">Password for authentication</param>
+        /// <param name="micID">[optional] Auth Service ID</param>
+        /// <param name="userClient">[optional] Client that the user is logged in, defaulted to SharedClient.</param>
+        /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+        static public async Task LoginWithMIC(string username, string password, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
+        {
+            await LoginWithMICInternal(username, password, string.Empty, micID, userClient, ct);
+        }
 
-				var clientID = ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey;
+        /// <summary>
+        /// Performs MIC Login authorization through an API.
+        /// </summary>
+        /// <param name="username">Username for authentication</param>
+        /// <param name="password">Password for authentication</param>
+        /// <param name="redirectURI">The redirect URI to be used for parsing the grant code</param>
+        /// <param name="micID">[optional] Auth Service ID</param>
+        /// <param name="userClient">[optional] Client that the user is logged in, defaulted to SharedClient.</param>
+        /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+        static private async Task LoginWithMICInternal(string username, string password, string redirectURI, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
+        {
+            var uc = userClient ?? Client.SharedClient;
+            uc.MICRedirectURI = redirectURI;
+
+            try
+            {
+                ct.ThrowIfCancellationRequested();
+
+                var clientID = ((KinveyClientRequestInitializer)uc.RequestInitializer).AppKey;
 
                 // Check if a client ID for MIC authentication has been provided
                 //
                 if (!string.IsNullOrEmpty(micID))
-				{
-					clientID += Constants.MIC_ID_SEPARATOR + micID;
-				}
+                {
+                    clientID += Constants.MIC_ID_SEPARATOR + micID;
+                }
 
                 // Initiate token request
                 //
                 var micLoginRequest = BuildMICLogin(uc, username, password, clientID);
-				ct.ThrowIfCancellationRequested();
-				var accessResult = await micLoginRequest.ExecuteAsync();
+                ct.ThrowIfCancellationRequested();
+                var accessResult = await micLoginRequest.ExecuteAsync();
 
-				ct.ThrowIfCancellationRequested();
+                ct.ThrowIfCancellationRequested();
 
-				var accessToken = accessResult["access_token"].ToString();
+                var accessToken = accessResult["access_token"].ToString();
 
-				ct.ThrowIfCancellationRequested();
+                ct.ThrowIfCancellationRequested();
 
-				// Log into Kinvey using the token
-				//
-				var user = await LoginMICWithAccessTokenAsync(accessToken);
+                // Log into Kinvey using the token
+                //
+                var user = await LoginMICWithAccessTokenAsync(accessToken);
 
-				ct.ThrowIfCancellationRequested();
+                ct.ThrowIfCancellationRequested();
 
-				// Store the new access token and refresh token
-				//
-				var currentCred = uc.Store.Load(user.Id, uc.SSOGroupKey);
-				currentCred.AccessToken = accessResult["access_token"].ToString();
-				currentCred.RefreshToken = accessResult["refresh_token"].ToString();
-				currentCred.RedirectUri = uc.MICRedirectURI;
-				currentCred.MICClientID = clientID;
-				uc.Store.Store(user.Id, uc.SSOGroupKey, currentCred);
-			}
-			catch (KinveyException ke)
-			{
-				throw ke;
-			}
-			catch(Exception e)
-			{
-				Logger.Log("Error in LoginWithMIC: " + e.StackTrace);
-				var kinveyException = new KinveyException(EnumErrorCategory.ERROR_USER, EnumErrorCode.ERROR_GENERAL, "Unexpected error in MIC Resource Owner Credentials Grant flow", e);
-				throw kinveyException;
-			}
-		}
+                // Store the new access token and refresh token
+                //
+                var currentCred = uc.Store.Load(user.Id, uc.SSOGroupKey);
+                currentCred.AccessToken = accessResult["access_token"].ToString();
+                currentCred.RefreshToken = accessResult["refresh_token"].ToString();
+                currentCred.RedirectUri = uc.MICRedirectURI;
+                currentCred.MICClientID = clientID;
+                uc.Store.Store(user.Id, uc.SSOGroupKey, currentCred);
+            }
+            catch (KinveyException ke)
+            {
+                throw ke;
+            }
+            catch (Exception e)
+            {
+                Logger.Log("Error in LoginWithMIC: " + e.StackTrace);
+                var kinveyException = new KinveyException(EnumErrorCategory.ERROR_USER, EnumErrorCode.ERROR_GENERAL, "Unexpected error in MIC Resource Owner Credentials Grant flow", e);
+                throw kinveyException;
+            }
+        }
 
-		/// <summary>
-		/// Gets the MIC access token, given the grant code passed in.
-		/// </summary>
-		/// <param name="token">Grant token passed back from MIC grant request</param>
-		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		static public async Task GetMICAccessTokenAsync(String token, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
+        /// <summary>
+        /// Gets the MIC access token, given the grant code passed in.
+        /// </summary>
+        /// <param name="token">Grant token passed back from MIC grant request</param>
+        /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+        static public async Task GetMICAccessTokenAsync(String token, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))
 		{
 			AbstractClient uc = userClient ?? Client.SharedClient;
 

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -658,7 +658,7 @@ namespace Kinvey
             }
             catch (KinveyException ke)
             {
-                throw ke;
+                throw;
             }
             catch (Exception e)
             {

--- a/Kinvey.Tests/UserUnitTests.cs
+++ b/Kinvey.Tests/UserUnitTests.cs
@@ -82,7 +82,7 @@ namespace Kinvey.Tests
             try
             {
                 var client = clientBuilder.Build();
-                await User.LoginWithMIC("test", "test", "myRedirectURI://", null, client);
+                await User.LoginWithMIC("test", "test", null, client);
             }
             catch(Exception ex)
             {

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -385,7 +385,7 @@ namespace TestFramework
 			localClient.MICApiVersion = "v2";
 
 			// Act
-			await User.LoginWithMIC(username, password, redirectURI);
+			await User.LoginWithMIC(username, password, redirectURI, micID: null);
 
 			// Assert
 			Assert.NotNull(localClient.ActiveUser);


### PR DESCRIPTION
#### Description
Deprecate the "loginWithMIC()" method with the "redirectURI" parameter for automated authorization grant flow

#### Changes
The method
 "static public async Task LoginWithMIC(string username, string password, string redirectURI, string micID = null, AbstractClient userClient = null, CancellationToken ct = default(CancellationToken))"
got deprecated.

#### Tests
Some changes in the following tests:
TestMIC_LoginWithMIC_HeadlessFlow, TestMIC_LoginWithMIC_HeadlessFlow_ClientID, TestLoginWithMIC
