### PR TITLE
MLIBZ-2666: "+" sign is removed from query.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,18 +5,12 @@ matrix:
       language: csharp
       mono: none
       dotnet: 2.1
-      before_install:
-        - sudo apt update
-        - sudo apt install tree
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"
       os: osx
       language: generic
       osx_image: xcode9.4
-      before_install:
-        - brew update
-        - brew install tree
         - brew cask install dotnet-sdk
         - export PATH="$PATH:/usr/local/share/dotnet"
       after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
       os: osx
       language: generic
       osx_image: xcode9.4
+      before_install:
+        - brew update
         - brew cask install dotnet-sdk
         - export PATH="$PATH:/usr/local/share/dotnet"
       after_success:

--- a/Kinvey.Core/Core/NetworkFactory.cs
+++ b/Kinvey.Core/Core/NetworkFactory.cs
@@ -286,7 +286,7 @@ namespace Kinvey
             {
                 restPathParams += string.IsNullOrEmpty(restPathParams) ? "?" : "&";
                 restPathParams += "query={query}";
-                var encodedQuery = System.Net.WebUtility.UrlEncode(query);
+                var encodedQuery = Uri.EscapeDataString(query);
                 urlParameters.Add("query", encodedQuery);
             }
 
@@ -331,7 +331,7 @@ namespace Kinvey
 				uriResourceParameters.Add("fields", decodedQueryMap["fields"]);
 			}
 
-            var encodedQuery = System.Net.WebUtility.UrlEncode(decodedQueryMap["query"]);
+            var encodedQuery = Uri.EscapeDataString(decodedQueryMap["query"]);
             uriResourceParameters["querystring"] = encodedQuery;
 
             return uriResourceParameters;

--- a/Kinvey.Core/Core/NetworkFactory.cs
+++ b/Kinvey.Core/Core/NetworkFactory.cs
@@ -286,7 +286,8 @@ namespace Kinvey
             {
                 restPathParams += string.IsNullOrEmpty(restPathParams) ? "?" : "&";
                 restPathParams += "query={query}";
-                urlParameters.Add("query", query);
+                var encodedQuery = System.Net.WebUtility.UrlEncode(query);
+                urlParameters.Add("query", encodedQuery);
             }
 
             REST_PATH += restPathParams;
@@ -330,9 +331,10 @@ namespace Kinvey
 				uriResourceParameters.Add("fields", decodedQueryMap["fields"]);
 			}
 
-			uriResourceParameters["querystring"] = decodedQueryMap["query"];
+            var encodedQuery = System.Net.WebUtility.UrlEncode(decodedQueryMap["query"]);
+            uriResourceParameters["querystring"] = encodedQuery;
 
-			return uriResourceParameters;
+            return uriResourceParameters;
 		}
 	
 		#endregion

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -19,6 +19,5 @@
             public const string RequiredFieldsTitle = "Required fields!";
             public const string RequiredFieldsMessage = "Title and Number are required fields.";
         }
-
     }
 }

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -775,8 +775,9 @@ namespace Kinvey.Tests
                             case "/appdata/_kid_/ToDos/_count":
                                 {
                                     Assert.AreEqual("GET", context.Request.HttpMethod);
+                                    var results = FilterByQuery(context, memory.Todo, client);
                                     var jsonObject = new JObject();
-                                    jsonObject["count"] = memory.Todo.Count;
+                                    jsonObject["count"] = results.Count();
                                     Write(context, jsonObject);
                                     break;
                                 }

--- a/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
@@ -3918,11 +3918,6 @@ namespace Kinvey.Tests
             }
 
             // Arrange
-            if (kinveyClient.ActiveUser != null)
-            {
-                kinveyClient.ActiveUser.Logout();
-            }
-
             await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
             var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);

--- a/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreCacheIntegrationTests.cs
@@ -3908,6 +3908,69 @@ namespace Kinvey.Tests
             Assert.AreEqual(2, thirdResponse.PullCount);
         }
 
+        [TestMethod]
+        public async Task TestDeltaSetWithQueryPullReturnCorrectNumberOfUpdates()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(13, kinveyClient);
+            }
+
+            // Arrange
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var store = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.CACHE);
+            var networkStore = DataStore<FlashCard>.Collection("FlashCard", DataStoreType.NETWORK);
+            store.DeltaSetFetchingEnabled = true;
+
+            var fc1 = new FlashCard();
+            fc1.Question = "What+?";
+            fc1.Answer = "7";
+
+            var fc2 = new FlashCard();
+            fc2.Question = "What+?";
+            fc2.Answer = "8";
+
+            var fc3 = new FlashCard();
+            fc3.Question = "What+?";
+            fc3.Answer = "Because 7 8 9.";
+
+            // Act
+            fc1 = await networkStore.SaveAsync(fc1);
+            fc2 = await networkStore.SaveAsync(fc2);
+            fc3 = await networkStore.SaveAsync(fc3);
+            var query = store.Where(x => x.Question.Equals("What+?"));
+            var firstResponse = await store.PullAsync(query);
+
+            var fc2Query = store.Where(y => y.Answer.Equals("8"));
+            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2.Answer = "14";
+            fc2 = await networkStore.SaveAsync(fc2);
+            var query2 = store.Where(x => x.Question.Equals("What+?"));
+            var secondResponse = await store.PullAsync(query2);
+
+            var localEntities = await store.FindAsync();
+            if (localEntities != null)
+            {
+                foreach (var localEntity in localEntities)
+                {
+                    await store.RemoveAsync(localEntity.ID);
+                }
+
+                await store.SyncAsync();
+            }
+
+            // Assert
+            Assert.AreEqual(3, firstResponse.PullCount);
+            Assert.AreEqual(1, secondResponse.PullCount);
+        }
+
         //with enabled deltaset should return correct number of items when deleting
         [TestMethod]
         public async Task TestDeltaSetPullReturnCorrectNumberOfDeletes()

--- a/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
@@ -491,6 +491,86 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestDeleteByQueryStringValueWithPlusSymbolEqualExpressionAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(9);
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+            var newItem1 = new ToDo
+            {
+                Name = "Task1 to delete",
+                Details = "+Delete"
+            };
+            var newItem2 = new ToDo
+            {
+                Name = "Task2 to delete",
+                Details = "+Delete"
+            };
+            var newItem3 = new ToDo
+            {
+                Name = "Task3 not to delete",
+                Details = "Not delete details3"
+            };
+
+            var savedItem1 = await todoStore.SaveAsync(newItem1);
+            var savedItem2 = await todoStore.SaveAsync(newItem2);
+            var savedItem3 = await todoStore.SaveAsync(newItem3);
+
+            var query = todoStore.Where(x => x.Details.Equals("+Delete"));
+
+            // Act
+            var kinveyDeleteResponse = await todoStore.RemoveAsync(query);
+
+            ToDo existingItem1 = null;
+            ToDo existingItem2 = null;
+            ToDo existingItem3 = null;
+
+            try
+            {
+                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+            }
+            catch (Exception)
+            {
+
+            }
+
+            try
+            {
+                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+            }
+            catch (Exception)
+            {
+
+            }
+
+            try
+            {
+                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+            }
+            catch (Exception)
+            {
+
+            }
+
+            // Teardown
+            await todoStore.RemoveAsync(existingItem3.ID);
+
+            // Assert
+            Assert.IsNotNull(kinveyDeleteResponse);
+            Assert.AreEqual(2, kinveyDeleteResponse.count);
+            Assert.IsNull(existingItem1);
+            Assert.IsNull(existingItem2);
+            Assert.IsNotNull(existingItem3);
+        }
+
+        [TestMethod]
         public async Task TestDeleteByQueryOrExpressionAsync()
         {
             // Setup
@@ -2852,6 +2932,50 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestGetCountAsyncWithQuery()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(6);
+            }
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo
+            {
+                Name = "Next Task",
+                Details = "A test",
+                DueDate = "2016-04-19T20:02:17.635Z"
+            };
+
+            var newItem2 = new ToDo
+            {
+                Name = "another todo",
+                Details = "details for 2+",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+            var t1 = await todoStore.SaveAsync(newItem);
+            var t2 = await todoStore.SaveAsync(newItem2);
+
+            // Act
+            var count = 0u;
+            var query = todoStore.Where(e => e.Details.Equals("details for 2+"));
+            count = await todoStore.GetCountAsync(query);
+
+            // Teardown
+            await todoStore.RemoveAsync(t1.ID);
+            await todoStore.RemoveAsync(t2.ID);
+            kinveyClient.ActiveUser.Logout();
+
+            // Assert
+            Assert.AreEqual(1u, count);
+        }
+
+        [TestMethod]
         public async Task TestNetworkStoreFindAsync()
         {
             // Setup
@@ -3023,6 +3147,56 @@ namespace Kinvey.Tests
             Assert.IsNotNull(listToDo[0].Name);
             Assert.IsNotNull(listToDo[0].Details);
             Assert.IsTrue(listToDo[0].Details.Equals("details for 2"));
+        }
+
+        [TestMethod]
+        public async Task TestNetworkStoreFindByMongoQueryWithPlusSymbol()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(6);
+            }
+            if (kinveyClient.ActiveUser != null)
+            {
+                kinveyClient.ActiveUser.Logout();
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            ToDo newItem1 = new ToDo();
+            newItem1.Name = "todo";
+            newItem1.Details = "details for 1";
+            newItem1.DueDate = "2016-04-22T19:56:00.963Z";
+
+            ToDo newItem2 = new ToDo();
+            newItem2.Name = "another todo";
+            newItem2.Details = "details for 2+";
+            newItem2.DueDate = "2016-04-22T19:56:00.963Z";
+
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            newItem1 = await todoStore.SaveAsync(newItem1);
+            newItem2 = await todoStore.SaveAsync(newItem2);
+
+            // Act
+            string mongoQuery = "{\"details\":\"details for 2+\"}";
+            List<ToDo> listToDo = new List<ToDo>();
+
+            listToDo = await todoStore.FindWithMongoQueryAsync(mongoQuery);
+
+            // Teardown
+            await todoStore.RemoveAsync(newItem1.ID);
+            await todoStore.RemoveAsync(newItem2.ID);
+
+            // Assert
+            Assert.IsNotNull(listToDo);
+            Assert.IsTrue(listToDo.Count > 0);
+            Assert.AreEqual(1, listToDo.Count);
+            Assert.IsNotNull(listToDo[0].Name);
+            Assert.IsNotNull(listToDo[0].Details);
+            Assert.IsTrue(listToDo[0].Details.Equals("details for 2+"));
         }
 
         [TestMethod]

--- a/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreNetworkIntegrationTests.cs
@@ -2969,7 +2969,6 @@ namespace Kinvey.Tests
             // Teardown
             await todoStore.RemoveAsync(t1.ID);
             await todoStore.RemoveAsync(t2.ID);
-            kinveyClient.ActiveUser.Logout();
 
             // Assert
             Assert.AreEqual(1u, count);
@@ -3157,32 +3156,28 @@ namespace Kinvey.Tests
             {
                 MockResponses(6);
             }
-            if (kinveyClient.ActiveUser != null)
-            {
-                kinveyClient.ActiveUser.Logout();
-            }
-
+           
             await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
             // Arrange
-            ToDo newItem1 = new ToDo();
+            var newItem1 = new ToDo();
             newItem1.Name = "todo";
             newItem1.Details = "details for 1";
             newItem1.DueDate = "2016-04-22T19:56:00.963Z";
 
-            ToDo newItem2 = new ToDo();
+            var newItem2 = new ToDo();
             newItem2.Name = "another todo";
             newItem2.Details = "details for 2+";
             newItem2.DueDate = "2016-04-22T19:56:00.963Z";
 
-            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
 
             newItem1 = await todoStore.SaveAsync(newItem1);
             newItem2 = await todoStore.SaveAsync(newItem2);
 
             // Act
-            string mongoQuery = "{\"details\":\"details for 2+\"}";
-            List<ToDo> listToDo = new List<ToDo>();
+            var mongoQuery = "{\"details\":\"details for 2+\"}";
+            var listToDo = new List<ToDo>();
 
             listToDo = await todoStore.FindWithMongoQueryAsync(mongoQuery);
 


### PR DESCRIPTION
#### Description
There is not any URL query encoding in Kinvey HTTP requests. As a result the sign "+" is being lost, when a request reaches a server side.


#### Changes
Changes in the "NetworkFactory" class. Adding URL encoding for query in HTTP requests.

#### Tests
TestDeltaSetWithQueryPullReturnCorrectNumberOfUpdates()
TestDeleteByQueryStringValueWithPlusSymbolEqualExpressionAsync()
TestGetCountAsyncWithQuery()
TestNetworkStoreFindByMongoQueryWithPlusSymbol()