### PR TITLE
MLIBZ-2852:Deprecate CACHE DataStore type

### DIFF
--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -140,14 +140,15 @@ namespace Kinvey
 			this.AutoPagination = false;
 		}
 
-		#region Public interface
-		/// <summary>
-		/// Gets an instance of the <see cref="KinveyXamarin.DataStore{T}"/>.
-		/// </summary>
-		/// <returns>The DataStore instance.</returns>
-		/// <param name="collectionName">Collection name of the Kinvey collection backing this DataStore</param>
-		/// <param name="client">Kinvey Client used by this DataStore (optional). If the client is not specified, the <see cref="KinveyXamarin.Client.SharedClient"/> is used.</param>
-		public static DataStore<T> Collection(string collectionName, AbstractClient client = null)
+        #region Public interface
+        /// <summary>
+        /// Gets an instance of the <see cref="KinveyXamarin.DataStore{T}"/>.
+        /// </summary>
+        /// <returns>The DataStore instance.</returns>
+        /// <param name="collectionName">Collection name of the Kinvey collection backing this DataStore</param>
+        /// <param name="client">Kinvey Client used by this DataStore (optional). If the client is not specified, the <see cref="KinveyXamarin.Client.SharedClient"/> is used.</param>
+        [Obsolete("This method has been deprecated.  Please use Collection( collectionName:, type:, client: ) instead.")]
+        public static DataStore<T> Collection(string collectionName, AbstractClient client = null)
 		{
 			return new DataStore<T>(DataStoreType.CACHE, collectionName, client);
 		}

--- a/Kinvey.Core/Store/DataStoreType.cs
+++ b/Kinvey.Core/Store/DataStoreType.cs
@@ -37,10 +37,11 @@ namespace Kinvey
 		/// </summary>
 		public static readonly DataStoreType SYNC = new DataStoreType(ReadPolicy.FORCE_LOCAL, WritePolicy.FORCE_LOCAL);
 
-		/// <summary>
-		/// The CACHE store.
-		/// </summary>
-		public static readonly DataStoreType CACHE = new DataStoreType (ReadPolicy.BOTH, WritePolicy.NETWORK_THEN_LOCAL);
+        /// <summary>
+        /// The CACHE store.
+        /// </summary>
+        [Obsolete("This field has been deprecated.  Please use AUTO instead.")]
+        public static readonly DataStoreType CACHE = new DataStoreType (ReadPolicy.BOTH, WritePolicy.NETWORK_THEN_LOCAL);
 
 		/// <summary>
 		/// The NETWORK store.

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -10,6 +10,7 @@
             public const string User = "";
             public const string Password = "";
             public const string ContractsCollection = "contracts";
+
         }
 
         public static class Exceptions

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -10,7 +10,6 @@
             public const string User = "";
             public const string Password = "";
             public const string ContractsCollection = "contracts";
-
         }
 
         public static class Exceptions


### PR DESCRIPTION
#### Description
Since the CACHE DataStore will no longer be supported, the goal of this ticket is to place a deprecation notice in place for this type. 

#### Changes
Making the field "CACHE" as deprecated in  DataStoreType.cs.

#### Tests
No tests
