### PR TITLE
MLIBZ-2826: Correctly handle missing or null refresh token.

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -643,16 +643,7 @@ namespace Kinvey
                 //
                 var currentCred = uc.Store.Load(user.Id, uc.SSOGroupKey);
                 currentCred.AccessToken = accessResult["access_token"].ToString();
-
-                if (accessResult["refresh_token"] != null)
-                {
-                    var refreshToken = accessResult["refresh_token"].ToString();
-                    if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
-                    {
-                        currentCred.RefreshToken = refreshToken;
-                    }
-                }
-
+                currentCred.RefreshToken = accessResult.GetValidValue("refresh_token");
                 currentCred.RedirectUri = uc.MICRedirectURI;
                 currentCred.MICClientID = clientID;
                 uc.Store.Store(user.Id, uc.SSOGroupKey, currentCred);
@@ -703,16 +694,7 @@ namespace Kinvey
 				//store the new refresh token
 				Credential currentCred = uc.Store.Load(u.Id, uc.SSOGroupKey);
 				currentCred.AccessToken = result["access_token"].ToString();
-
-                if (result["refresh_token"] != null)
-                {
-                    var refreshToken = result["refresh_token"].ToString();
-                    if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
-                    {
-                        currentCred.RefreshToken = refreshToken;
-                    }
-                }
-
+                currentCred.RefreshToken = result.GetValidValue("refresh_token");
                 currentCred.RedirectUri = uc.MICRedirectURI;
                 currentCred.MICClientID = clientID;
 				uc.Store.Store(u.Id, uc.SSOGroupKey, currentCred);

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -703,8 +703,17 @@ namespace Kinvey
 				//store the new refresh token
 				Credential currentCred = uc.Store.Load(u.Id, uc.SSOGroupKey);
 				currentCred.AccessToken = result["access_token"].ToString();
-				currentCred.RefreshToken = result["refresh_token"].ToString();
-				currentCred.RedirectUri = uc.MICRedirectURI;
+
+                if (result["refresh_token"] != null)
+                {
+                    var refreshToken = result["refresh_token"].ToString();
+                    if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
+                    {
+                        currentCred.RefreshToken = refreshToken;
+                    }
+                }
+
+                currentCred.RedirectUri = uc.MICRedirectURI;
                 currentCred.MICClientID = clientID;
 				uc.Store.Store(u.Id, uc.SSOGroupKey, currentCred);
 

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -643,7 +643,16 @@ namespace Kinvey
                 //
                 var currentCred = uc.Store.Load(user.Id, uc.SSOGroupKey);
                 currentCred.AccessToken = accessResult["access_token"].ToString();
-                currentCred.RefreshToken = accessResult["refresh_token"].ToString();
+
+                if (accessResult["refresh_token"] != null)
+                {
+                    var refreshToken = accessResult["refresh_token"].ToString();
+                    if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
+                    {
+                        currentCred.RefreshToken = refreshToken;
+                    }
+                }
+
                 currentCred.RedirectUri = uc.MICRedirectURI;
                 currentCred.MICClientID = clientID;
                 uc.Store.Store(user.Id, uc.SSOGroupKey, currentCred);

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -521,17 +521,8 @@ namespace Kinvey
 							//store the new refresh token
 							Credential currentCred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
 							currentCred.AccessToken = result["access_token"].ToString();
-
-                            if (result["refresh_token"] != null)
-                            {
-                                var newRefreshToken = result["refresh_token"].ToString();
-                                if (!string.IsNullOrEmpty(newRefreshToken) && !newRefreshToken.ToLower().Equals("null"))
-                                {
-                                    currentCred.RefreshToken = newRefreshToken;
-                                }
-                            }
-
-							currentCred.RedirectUri = redirectUri;
+                            currentCred.RefreshToken = result.GetValidValue("refresh_token");
+                            currentCred.RedirectUri = redirectUri;
 							Client.Store.Store(Client.ActiveUser.Id, Client.SSOGroupKey, currentCred);
 
 							// Retry the original request

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -505,7 +505,7 @@ namespace Kinvey
 						redirectUri = cred.RedirectUri;
                         micClientId = cred.MICClientID;
 
-						if (refreshToken != null)
+						if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
 						{
 							//use the refresh token for a new access token
                             JObject result = await Client.ActiveUser.UseRefreshToken(refreshToken, redirectUri, micClientId).ExecuteAsync();

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -521,7 +521,16 @@ namespace Kinvey
 							//store the new refresh token
 							Credential currentCred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
 							currentCred.AccessToken = result["access_token"].ToString();
-							currentCred.RefreshToken = result["refresh_token"].ToString();
+
+                            if (result["refresh_token"] != null)
+                            {
+                                var newRefreshToken = result["refresh_token"].ToString();
+                                if (!string.IsNullOrEmpty(newRefreshToken) && !newRefreshToken.ToLower().Equals("null"))
+                                {
+                                    currentCred.RefreshToken = newRefreshToken;
+                                }
+                            }
+
 							currentCred.RedirectUri = redirectUri;
 							Client.Store.Store(Client.ActiveUser.Id, Client.SSOGroupKey, currentCred);
 

--- a/Kinvey.Core/Extensions/CustomExtension.cs
+++ b/Kinvey.Core/Extensions/CustomExtension.cs
@@ -1,0 +1,21 @@
+﻿using Newtonsoft.Json.Linq;
+
+namespace Kinvey
+{
+    internal static class CustomExtension
+    {
+        internal static string GetValidValue(this JObject jobject, string propertyName)
+        {
+            var propertyValue = jobject["refresh_token"];
+            if (propertyValue != null)
+            {
+                var newRefreshToken = propertyValue.ToString();
+                if (!string.IsNullOrEmpty(newRefreshToken) && !newRefreshToken.ToLower().Equals("null"))
+                {
+                    return newRefreshToken;
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/Kinvey.Core/Extensions/CustomExtension.cs
+++ b/Kinvey.Core/Extensions/CustomExtension.cs
@@ -6,7 +6,7 @@ namespace Kinvey
     {
         internal static string GetValidValue(this JObject jobject, string propertyName)
         {
-            var propertyValue = jobject["refresh_token"];
+            var propertyValue = jobject[propertyName];
             if (propertyValue != null)
             {
                 var newRefreshToken = propertyValue.ToString();

--- a/Kinvey.Core/Kinvey.Core.csproj
+++ b/Kinvey.Core/Kinvey.Core.csproj
@@ -31,6 +31,7 @@
     <DocumentationFile>bin\Release\Kinvey-Xamarin.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="Extensions\CustomExtension.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Auth\Credential.cs" />
     <Compile Include="Auth\CredentialManager.cs" />

--- a/Kinvey.Shared/Kinvey.Shared.projitems
+++ b/Kinvey.Shared/Kinvey.Shared.projitems
@@ -113,6 +113,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\CustomEndpoint\CustomEndpointRequest.cs">
       <Link>CustomEndpoint\CustomEndpointRequest.cs</Link>
     </Compile>
+	 <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Extensions\CustomExtension.cs">
+      <Link>Extensions\CustomExtension.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\File\File.cs">
       <Link>File\File.cs</Link>
     </Compile>

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -10,6 +10,7 @@
             public const string User = "";
             public const string Password = "";
             public const string ContractsCollection = "contracts";
+
         }
 
         public static class Exceptions

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -10,7 +10,6 @@
             public const string User = "";
             public const string Password = "";
             public const string ContractsCollection = "contracts";
-
         }
 
         public static class Exceptions

--- a/Kinvey.Tests/Support Files/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/TestSetup.cs
@@ -23,6 +23,8 @@ namespace Kinvey.Tests
         public const string twitter_access_token_fake = "aee41d86-c738-4372-9fdd-9ff8494bc416";
         public const string linkedin_access_token_fake = "1bcd22f6-2bf8-4227-9272-98e1c4cb6e15";
         public const string salesforce_access_token_fake = "8cd71dc8-846a-49f2-8cf1-c0598bbce5ec";
+        public const string access_token_for_401_response_fake = "0065cb37-a1ed-4c8b-98fc-91c312683275";
+        public const string auth_token_for_401_response_fake = "eda5d4bc-6a47-46d2-9637-07dec479bf9c";
 
         public const string mic_id_fake = "ade8db71f61c46a69c91910d8fbf3994";
 

--- a/Kinvey.Tests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserIntegrationTests.cs
@@ -444,6 +444,37 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseAsync()
+        {
+            // Arrange
+            if (MockData)
+            {
+                MockResponses(6);
+            }
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+            var todo = new ToDo
+            {
+                Name = "Test"
+            };
+
+            // Act
+            Exception exception = null;
+            try
+            {
+                await User.LoginWithMIC("test3", "test3", null, kinveyClient);
+                await todoStore.SaveAsync(todo);
+            }
+            catch (Exception ex)
+            {
+                exception = ex;
+            }
+
+            // Assert
+            Assert.IsNull(exception);
+        }
+
+        [TestMethod]
         public async Task TestLogout()
         {
             // Arrange

--- a/Kinvey.Tests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserIntegrationTests.cs
@@ -449,7 +449,11 @@ namespace Kinvey.Tests
             // Arrange
             if (MockData)
             {
-                MockResponses(6);
+                MockResponses(8);
+            }
+            else
+            {
+                Assert.Fail("Use this test only with mocks.");
             }
 
             var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
@@ -459,19 +463,17 @@ namespace Kinvey.Tests
             };
 
             // Act
-            Exception exception = null;
-            try
-            {
-                await User.LoginWithMIC("test3", "test3", null, kinveyClient);
-                await todoStore.SaveAsync(todo);
-            }
-            catch (Exception ex)
-            {
-                exception = ex;
-            }
+            await User.LoginWithMIC("test3", "test3", null, kinveyClient);
+            var savedToDo = await todoStore.SaveAsync(todo);
+            var existingToDo = await todoStore.FindByIDAsync(savedToDo.ID);
+
+            //Teardown
+            await todoStore.RemoveAsync(savedToDo.ID);
 
             // Assert
-            Assert.IsNull(exception);
+            Assert.IsNotNull(savedToDo);
+            Assert.AreEqual(savedToDo.ID, existingToDo.ID);
+            Assert.AreEqual(savedToDo.Name, existingToDo.Name);
         }
 
         [TestMethod]


### PR DESCRIPTION
#### Description
The library attempts to store for subsequent usage the "refresh_token" of the MIC token response. In case we have locally stored a refresh token we will try to use it when we receive an error from the server for expired credentials. We need to handle cases when the "refresh_token"  is null or absent.

#### Changes
LoginWithMICInternal(), GetMICAccessTokenAsync() in the "User" class.
ExecuteUnparsedAsync() in the "AbstractKinveyClientRequest" class.

#### Tests 
TestLoginMICWithAccessTokenUnauthorizedResponseAsync()
