### PR TITLE
MLIBZ-2885: Implement `AUTO` DataStore tests

### DIFF
--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -10,7 +10,6 @@
             public const string User = "";
             public const string Password = "";
             public const string ContractsCollection = "contracts";
-
         }
 
         public static class Exceptions

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -220,10 +220,20 @@ namespace Kinvey.Tests
 
                 if (user != null)
                 {
-                    user["_kmd"] = new JObject
+                    if (user["username"].ToString().Equals(TestSetup.user_without_permissions) && user["password"].ToString().Equals(TestSetup.pass_for_user_without_permissions))
                     {
-                        ["authtoken"] = Guid.NewGuid().ToString()
-                    };
+                        user["_kmd"] = new JObject
+                        {
+                            ["authtoken"] = TestSetup.auth_token_for_401_response_fake
+                        };
+                    }
+                    else
+                    {
+                        user["_kmd"] = new JObject
+                        {
+                            ["authtoken"] = Guid.NewGuid().ToString()
+                        };
+                    }
 
                     var clone = new JObject(user);
                     clone.Remove("password");
@@ -744,10 +754,23 @@ namespace Kinvey.Tests
                         }
                     };
 
+                    var userWithoutPermissionsId = Guid.NewGuid().ToString();
+                    users[userWithoutPermissionsId] = new JObject
+                    {
+                        ["_id"] = userWithoutPermissionsId,
+                        ["username"] = TestSetup.user_without_permissions,
+                        ["password"] = TestSetup.pass_for_user_without_permissions,
+                        ["email"] = $"{Guid.NewGuid().ToString()}@kinvey.com",
+                        ["_acl"] = new JObject()
+                        {
+                            ["creator"] = userWithoutPermissionsId,
+                        },
+                    };
+
                     #endregion Existing users
 
                     #region Social networks users
-                    
+
                     var signedUsers = new Dictionary<string, JObject>();
 
                     signedUsers[TestSetup.facebook_access_token_fake] = new JObject

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -361,6 +361,11 @@ namespace Kinvey.Tests
         protected static void MockAppDataPost(HttpListenerContext context, List<JObject> items, Client client)
         {
             var obj = Read<JObject>(context);
+            MockAppDataPost(context, obj, items, client);
+        }
+
+        protected static void MockAppDataPost(HttpListenerContext context, JObject obj, List<JObject> items, Client client)
+        {
             if (obj["_id"] == null || obj["_id"].Type == JTokenType.Null)
             {
                 obj["_id"] = Guid.NewGuid().ToString();
@@ -467,6 +472,13 @@ namespace Kinvey.Tests
         {
             var obj = Read<JObject>(context);
             var index = items.FindIndex((x) => id.Equals(x["_id"].Value<string>()));
+
+            if(index == -1)
+            {
+                MockAppDataPost(context, obj, items, client);
+                return;
+            }
+
             var item = items[index];
             obj["_id"] = id;
             var acl = obj["_acl"];

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -3986,7 +3986,7 @@ namespace Kinvey.Tests
             // Setup
             if (MockData)
             {
-                MockResponses(7, kinveyClient);
+                MockResponses(6, kinveyClient);
             }
 
             // Arrange
@@ -4015,8 +4015,6 @@ namespace Kinvey.Tests
             // Act            
             var existingItemInNetwork = await autoStore.FindByIDAsync(savedItem1.ID);
 
-            var listToDoAuto = await autoStore.FindAsync();
-
             SetRootUrlToKinveyClient(unreachableUrl);
             var existingItemInLocalStorage = await autoStore.FindByIDAsync(savedItem1.ID);
             SetRootUrlToKinveyClient(kinveyUrl);
@@ -4026,10 +4024,8 @@ namespace Kinvey.Tests
             await networkStore.RemoveAsync(savedItem2.ID);
 
             // Assert
-            Assert.IsNotNull(listToDoAuto);
             Assert.IsNotNull(existingItemInNetwork);
             Assert.IsNotNull(existingItemInLocalStorage);
-            Assert.AreEqual(2, listToDoAuto.Count);
             Assert.AreEqual(existingItemInNetwork.ID, savedItem1.ID);
             Assert.AreEqual(existingItemInNetwork.Name, savedItem1.Name);
             Assert.AreEqual(existingItemInNetwork.Details, savedItem1.Details);

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -3004,6 +3004,33 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestFindInvalidPermissionsNetworkConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(2, kinveyClient);
+            }
+
+            // Arrange
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await autoStore.FindAsync();
+            });
+
+            // Assert
+            Assert.IsTrue(exception.GetType() == typeof(KinveyException));
+            KinveyException ke = exception as KinveyException;
+            Assert.IsTrue(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
+            Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
+        }
+
+        [TestMethod]
         public async Task TestFindNetworkConnectionIssueAsync()
         {
             // Setup
@@ -3927,6 +3954,33 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestFindByIDInvalidPermissionsNetworkConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(2, kinveyClient);
+            }
+
+            // Arrange
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await autoStore.FindByIDAsync(Guid.NewGuid().ToString());
+            });
+
+            // Assert
+            Assert.IsTrue(exception.GetType() == typeof(KinveyException));
+            KinveyException ke = exception as KinveyException;
+            Assert.IsTrue(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
+            Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
+        }
+
+        [TestMethod]
         public async Task TestFindByIDExistingItemNetworkConnectionIssueAsync()
         {
             // Setup
@@ -4846,6 +4900,33 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestGetCountInvalidPermissionsNetworkConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(2, kinveyClient);
+            }
+
+            // Arrange
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await autoStore.GetCountAsync();
+            });
+
+            // Assert
+            Assert.IsTrue(exception.GetType() == typeof(KinveyException));
+            KinveyException ke = exception as KinveyException;
+            Assert.IsTrue(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
+            Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
+        }
+
+        [TestMethod]
         public async Task TestGetCountNetworkConnectionAvailableAsync()
         {
             // Setup
@@ -5654,6 +5735,33 @@ namespace Kinvey.Tests
             Assert.AreEqual(4, localEntities.Count);
             Assert.AreEqual(fc1.Answer, localEntities.FirstOrDefault(e=> e.ID == fc1.ID).Answer);
             Assert.AreEqual(fc2.Answer, localEntities.FirstOrDefault(e => e.ID == fc2.ID).Answer);
+        }
+
+        [TestMethod]
+        public async Task TestPullDataInvalidPermissionsNetworkConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(2, kinveyClient);
+            }
+
+            // Arrange
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await autoStore.PullAsync();
+            });
+
+            // Assert
+            Assert.IsTrue(exception.GetType() == typeof(KinveyException));
+            KinveyException ke = exception as KinveyException;
+            Assert.IsTrue(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
+            Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
         }
 
         [TestMethod]

--- a/Kinvey.Tests/Support Files/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/TestSetup.cs
@@ -12,6 +12,9 @@ namespace Kinvey.Tests
 		public const string user = "testuser";
 		public const string pass = "testpass";
 
+        public const string user_without_permissions = "testuserwithoutpermissions";
+        public const string pass_for_user_without_permissions = "testuserwithoutpermissions";
+
         public const string app_key = "kid_Zy0JOYPKkZ";
 		public const string app_secret = "d83de70e64d540e49acd6cfce31415df";
 


### PR DESCRIPTION
#### Description
The QA team has prepared a set of tests for verifying the functionality of the `AUTO` data store. The goal of this ticket is to implement as many of these tickets as is feasible.

#### Changes
No changes

#### Tests
TestFindNetworkConnectionAvailableAsync()
TestFindWithQueryNetworkConnectionAvailableAsync()
TestFindWithSkipLimitQueryNetworkConnectionAvailableAsync()
TestFindWithDeltaSetTurnOnNetworkConnectionAvailableAsync()
TestFindDescendingOrderNetworkConnectionAvailableAsync()
TestFindDeletingItemNetworkConnectionAvailableAsync()
TestFindInvalidQueryNetworkConnectionAvailableAsync()
TestFindInvalidPermissionsNetworkConnectionAvailableAsync()
TestFindNetworkConnectionIssueAsync()
TestFindNetworkConnectionEliminatedAsync()
TestFindWithQueryNetworkConnectionIssueAsync()
TestFindSkip1Take1NetworkConnectionIssueAsync()
TestFindDescendingOrderNetworkConnectionIssueAsync()
TestFindWithDeltaSetTurnOnNetworkConnectionIssueAsync()
TestFindDeletedItemNetworkConnectionAvailableAsync()

TestFindByIDExistingItemNetworkConnectionAvailableAsync()
TestFindByIDNotExistingItemNetworkConnectionAvailableAsync()
TestFindByIDInvalidPermissionsNetworkConnectionAvailableAsync()
TestFindByIDExistingItemNetworkConnectionIssueAsync()
TestFindByIDDeletedItemNetworkConnectionAvailableAsync()

TestGetCountAllItemsNetworkConnectionAvailableAsync()
TestGetCountByQueryNetworkConnectionAvailableAsync()
TestGetCountInvalidQueryNetworkConnectionAvailableAsync()
TestGetCountAllItemsNetworkConnectionIssueAsync()
TestGetCountInvalidPermissionsNetworkConnectionAvailableAsync()

TestPushCreatedDataNetworkConnectionAvailableAsync()
TestPushUpdatedDataNetworkConnectionAvailableAsync()
TestPushDeletedDataNetworkConnectionAvailableAsync()
TestPushCreatedDataNetworkConnectionIssueAsync()
TestPushRecreatedDataNetworkConnectionAvailableAsync()

TestPullDataNetworkConnectionAvailableAsync()
TestPullDataNetworkConnectionIssueAsync()
TestPullDataWithQueryNetworkConnectionAvailableAsync()
TestPullDataDeletedFromBackendNetworkConnectionAvailableAsync()
TestPullDataChangedInBackendNetworkConnectionAvailableAsync()
TestPullDataInvalidPermissionsNetworkConnectionAvailableAsync()
TestPullDataNotSyncedNetworkConnectionAvailableAsync()
TestPullDataDeletedAndChangedInBackendNetworkConnectionAvailableAsync()


