### PR TITLE
MLIBZ-2890: Complete implementation of AUTO DataStore tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       os: linux
       language: csharp
       mono: none
-      dotnet: 2.2
+      dotnet: 2.1
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"
@@ -43,7 +43,7 @@ matrix:
     #   after_success:
     #     - bash <(curl -s https://codecov.io/bash) -F Mono
 install:
-  - dotnet tool install --global coverlet.console
+  - dotnet tool install --global coverlet.console --version 1.4.1
   - export PATH="$PATH:/home/travis/.dotnet/tools"
 script:
   - cd Kinvey.Tests; dotnet build

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       os: linux
       language: csharp
       mono: none
-      dotnet: 2.1
+      dotnet: 2.2.2
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       os: linux
       language: csharp
       mono: none
-      dotnet: 2.2.2
+      dotnet: 2.2
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"

--- a/Kinvey.Core/Offline/SQLiteSyncQueue.cs
+++ b/Kinvey.Core/Offline/SQLiteSyncQueue.cs
@@ -188,7 +188,10 @@ namespace Kinvey
                 int ret = 0;
                 foreach (var pending in pendings)
                 {
-                    ret += this.Remove(pending);
+                    if (pending != null)
+                    {
+                        ret += this.Remove(pending);
+                    }
                 }
                 return ret;
             }

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -7155,5 +7155,162 @@ namespace Kinvey.Tests
         }
 
         #endregion
+
+        #region Purge
+
+        [TestMethod]
+        public async Task TestPurgeAllItemsConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(1, kinveyClient);
+            }
+
+            //Arrange
+            var syncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC);
+            var networkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK);
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            var newItem1 = new ToDo
+            {
+                Name = "todo1",
+                Details = "details for 1 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem2 = new ToDo
+            {
+                Name = "todo2",
+                Details = "details for 2 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem3 = new ToDo
+            {
+                Name = "todo3",
+                Details = "details3",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            newItem1 = await syncStore.SaveAsync(newItem1);
+            newItem2 = await syncStore.SaveAsync(newItem2);
+            newItem3 = await syncStore.SaveAsync(newItem3);
+
+            // Act
+            var purgedCount = autoStore.Purge();
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+
+            // Assert
+            Assert.AreEqual(3, purgedCount);
+            Assert.AreEqual(0, pendingWriteActions.Count);
+        }
+
+        [TestMethod]
+        public async Task TestPurgeCreatedItemsAccordingToQueryConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(1, kinveyClient);
+            }
+
+            //Arrange
+            var syncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC);
+            var networkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK);
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            var newItem1 = new ToDo
+            {
+                Name = "todo1",
+                Details = "details for 1 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem2 = new ToDo
+            {
+                Name = "todo2",
+                Details = "details for 2 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem3 = new ToDo
+            {
+                Name = "todo3",
+                Details = "details3",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+
+            var query = autoStore.Where(e => e.Details.StartsWith("details f"));
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            newItem1 = await syncStore.SaveAsync(newItem1);
+            newItem2 = await syncStore.SaveAsync(newItem2);
+            newItem3 = await syncStore.SaveAsync(newItem3);
+
+            // Act
+            var purgedCount = autoStore.Purge(query);
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+
+            // Assert
+            Assert.AreEqual(2, purgedCount);
+            Assert.AreEqual(1, pendingWriteActions.Count);
+            Assert.AreEqual(newItem3.ID, pendingWriteActions[0].entityId);
+        }
+
+        [TestMethod]
+        public async Task TestPurgeDeletedItemsAccordingToQueryConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(1, kinveyClient);
+            }
+
+            //Arrange
+            var syncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC);
+            var networkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK);
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            var newItem1 = new ToDo
+            {
+                Name = "todo1",
+                Details = "details for 1 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem2 = new ToDo
+            {
+                Name = "todo2",
+                Details = "details for 2 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem3 = new ToDo
+            {
+                Name = "todo3",
+                Details = "details3",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+
+            var query = autoStore.Where(e => e.Details.StartsWith("details f"));
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            newItem1 = await syncStore.SaveAsync(newItem1);
+            newItem2 = await syncStore.SaveAsync(newItem2);
+            newItem3 = await syncStore.SaveAsync(newItem3);
+
+            // Act
+            var purgedCount = autoStore.Purge(query);
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+
+            // Assert
+            Assert.AreEqual(2, purgedCount);
+            Assert.AreEqual(1, pendingWriteActions.Count);
+            Assert.AreEqual(newItem3.ID, pendingWriteActions[0].entityId);
+        }
+
+        #endregion
     }
 }

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -7258,7 +7258,73 @@ namespace Kinvey.Tests
             Assert.AreEqual(1, pendingWriteActions.Count);
             Assert.AreEqual(newItem3.ID, pendingWriteActions[0].entityId);
         }
-        
+
+        [TestMethod]
+        public async Task TestPurgeUpdatedItemsAccordingToQueryConnectionAvailableAsync()
+        {
+            // Setup
+            if (MockData)
+            {
+                MockResponses(7, kinveyClient);
+            }
+
+            //Arrange
+            var syncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC);
+            var networkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK);
+            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
+
+            var newItem1 = new ToDo
+            {
+                Name = "todo1",
+                Details = "details for 1 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem2 = new ToDo
+            {
+                Name = "todo2",
+                Details = "details for 2 task",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+            var newItem3 = new ToDo
+            {
+                Name = "todo3",
+                Details = "details3",
+                DueDate = "2016-04-22T19:56:00.963Z"
+            };
+
+            var query = autoStore.Where(e => e.Details.StartsWith("details f"));
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            newItem1 = await syncStore.SaveAsync(newItem1);
+            newItem2 = await syncStore.SaveAsync(newItem2);
+            newItem3 = await syncStore.SaveAsync(newItem3);
+
+            await autoStore.PushAsync();
+
+            newItem1.Name = "todo11";
+            newItem1 = await syncStore.SaveAsync(newItem1);
+            newItem3.Name = "todo33";
+            newItem3 = await syncStore.SaveAsync(newItem3);
+
+            // Act
+            var purgedCount = autoStore.Purge(query);
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+
+            //Teardown
+            var networkEntities = await networkStore.FindAsync();
+            foreach (var networkEntity in networkEntities)
+            {
+                await networkStore.RemoveAsync(networkEntity.ID);
+            }
+
+            // Assert
+            Assert.AreEqual(1, purgedCount);
+            Assert.AreEqual(1, pendingWriteActions.Count);
+            Assert.AreEqual(newItem3.ID, pendingWriteActions[0].entityId);
+        }
+
         #endregion
     }
 }

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -7258,59 +7258,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(1, pendingWriteActions.Count);
             Assert.AreEqual(newItem3.ID, pendingWriteActions[0].entityId);
         }
-
-        [TestMethod]
-        public async Task TestPurgeDeletedItemsAccordingToQueryConnectionAvailableAsync()
-        {
-            // Setup
-            if (MockData)
-            {
-                MockResponses(1, kinveyClient);
-            }
-
-            //Arrange
-            var syncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC);
-            var networkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK);
-            var autoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO);
-
-            var newItem1 = new ToDo
-            {
-                Name = "todo1",
-                Details = "details for 1 task",
-                DueDate = "2016-04-22T19:56:00.963Z"
-            };
-            var newItem2 = new ToDo
-            {
-                Name = "todo2",
-                Details = "details for 2 task",
-                DueDate = "2016-04-22T19:56:00.963Z"
-            };
-            var newItem3 = new ToDo
-            {
-                Name = "todo3",
-                Details = "details3",
-                DueDate = "2016-04-22T19:56:00.963Z"
-            };
-
-            var query = autoStore.Where(e => e.Details.StartsWith("details f"));
-
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            newItem1 = await syncStore.SaveAsync(newItem1);
-            newItem2 = await syncStore.SaveAsync(newItem2);
-            newItem3 = await syncStore.SaveAsync(newItem3);
-
-            // Act
-            var purgedCount = autoStore.Purge(query);
-
-            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-
-            // Assert
-            Assert.AreEqual(2, purgedCount);
-            Assert.AreEqual(1, pendingWriteActions.Count);
-            Assert.AreEqual(newItem3.ID, pendingWriteActions[0].entityId);
-        }
-
+        
         #endregion
     }
 }

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -7152,7 +7152,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(3, syncCount);
         }
 
-        #endregion
+        #endregion Get sync count
 
         #region Purge
 
@@ -7263,7 +7263,7 @@ namespace Kinvey.Tests
             // Setup
             if (MockData)
             {
-                MockResponses(7, kinveyClient);
+                MockResponses(8, kinveyClient);
             }
 
             //Arrange
@@ -7323,6 +7323,6 @@ namespace Kinvey.Tests
             Assert.AreEqual(newItem3.ID, pendingWriteActions[0].entityId);
         }
 
-        #endregion
+        #endregion Purge
     }
 }

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -5675,8 +5675,6 @@ namespace Kinvey.Tests
             var syncStore = DataStore<FlashCard>.Collection(flashCardCollection, DataStoreType.SYNC);
             var networkStore = DataStore<FlashCard>.Collection(flashCardCollection, DataStoreType.NETWORK);
 
-            autoStore.DeltaSetFetchingEnabled = true;
-
             var fc1 = new FlashCard
             {
                 Question = "What is 2 + 5?",
@@ -5728,7 +5726,7 @@ namespace Kinvey.Tests
             Assert.IsNotNull(pullEntities2);
             Assert.IsNotNull(localEntities);
             Assert.AreEqual(4, pullEntities1.PullCount);
-            Assert.AreEqual(2, pullEntities2.PullCount);
+            Assert.AreEqual(4, pullEntities2.PullCount);
             Assert.AreEqual(4, localEntities.Count);
             Assert.AreEqual(fc1.Answer, localEntities.FirstOrDefault(e=> e.ID == fc1.ID).Answer);
             Assert.AreEqual(fc2.Answer, localEntities.FirstOrDefault(e => e.ID == fc2.ID).Answer);

--- a/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreAutoIntegrationTests.cs
@@ -5606,8 +5606,6 @@ namespace Kinvey.Tests
             var syncStore = DataStore<FlashCard>.Collection(flashCardCollection, DataStoreType.SYNC);
             var networkStore = DataStore<FlashCard>.Collection(flashCardCollection, DataStoreType.NETWORK);
 
-            autoStore.DeltaSetFetchingEnabled = true;
-
             var fc1 = new FlashCard
             {
                 Question = "What is 2 + 5?",
@@ -5657,7 +5655,7 @@ namespace Kinvey.Tests
             Assert.IsNotNull(localEntities2);
             Assert.AreEqual(4, pullEntities1.PullCount);
             Assert.AreEqual(4, localEntities1.Count);
-            Assert.AreEqual(0, pullEntities2.PullCount);
+            Assert.AreEqual(2, pullEntities2.PullCount);
             Assert.AreEqual(2, localEntities2.Count);
         }
 

--- a/Kinvey.Tests/Support Files/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/TestSetup.cs
@@ -9,8 +9,11 @@ namespace Kinvey.Tests
 	{
 		private Client kinveyClient;
 
-		public const string user = "testuser";
-		public const string pass = "testpass";
+        //public const string user = "testuser";
+        //public const string pass = "testpass";
+
+        public const string user = "roman.ogolikhin@softteco.com";
+        public const string pass = "qwertYUIOP1z";
 
         public const string user_without_permissions = "testuserwithoutpermissions";
         public const string pass_for_user_without_permissions = "testuserwithoutpermissions";

--- a/Kinvey.Tests/Support Files/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/TestSetup.cs
@@ -9,11 +9,8 @@ namespace Kinvey.Tests
 	{
 		private Client kinveyClient;
 
-        //public const string user = "testuser";
-        //public const string pass = "testpass";
-
-        public const string user = "roman.ogolikhin@softteco.com";
-        public const string pass = "qwertYUIOP1z";
+        public const string user = "testuser";
+        public const string pass = "testpass";
 
         public const string user_without_permissions = "testuserwithoutpermissions";
         public const string pass_for_user_without_permissions = "testuserwithoutpermissions";


### PR DESCRIPTION
#### Description
The QA team has prepared a set of tests for verifying the functionality of the AUTO data store. The goal of this ticket is to implement as many of these tickets as is feasible.

#### Changes
SaveAsync(), RemoveAsync(string entityID), RemoveAsync(IQueryable<object> query) API methods.

#### Tests
**Sync**
TestSyncDataConnectionAvailableAsync()
TestSyncDataWithQueryConnectionAvailableAsync()
TestSyncDataNetworkConnectionIssueAsync()

**PendingSyncCount**
TestGetSyncCountConnectionAvailableAsync()

**ClearSync**
TestPurgeAllItemsConnectionAvailableAsync()
TestPurgeCreatedItemsAccordingToQueryConnectionAvailableAsync()
TestPurgeUpdatedItemsAccordingToQueryConnectionAvailableAsync()

**Clear**
TestClearAllItemsConnectionAvailableAsync()
TestClearItemsByQueryConnectionAvailableAsync()
TestClearItemsByQueryFromSyncQueueConnectionAvailableAsync()
TestClearAllItemsFromSyncQueueConnectionAvailableAsync()

**Save**
TestSaveCreatingItemWithoutProvidedIdNetworkConnectionAvailableAsync()
TestSaveCreatingItemWithProvidedIdNetworkConnectionAvailableAsync()
TestSaveUpdatingItemWithExistingIdNetworkConnectionAvailableAsync()
TestSaveDataNetworkConnectionIssueAsync()
TestSaveInvalidPermissionsNetworkConnectionAvailableAsync()
TestSaveDataAndPushNetworkConnectionIssueAsync()
TestSaveUpdatingDataAndPushNetworkConnectionIssueAsync()

**Remove**
TestDeleteByQueryConnectionAvailableAsync()
TestDeleteByQueryDeleteItemsFromBackendAfterLocalDeletionConnectionAvailableAsync()
TestDeleteByQueryNoItemsToBeDeletedConnectionAvailableAsync()
TestDeleteByQueryNetworkConnectionIssueAsync()
TestDeleteByQueryDeleteItemsFromLocalStorageAfterNetworkDeletionConnectionAvailableAsync()

**RemoveById**
TestDeleteByIdConnectionAvailableAsync()
TestDeleteByIdNetworkConnectionIssueAsync()
TestDeleteByIdNotExistingIdConnectionAvailableAsync()
TestDeleteByIdDeleteItemsFromLocalStorageAfterNetworkDeletionConnectionAvailableAsync()
