### PR TITLE
MLIBZ-2842: Create mock responses to simulate user and login server errors (5xx)

### DIFF
--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -1304,14 +1304,21 @@ namespace Kinvey.Tests
 
                 if (splitedMicData["grant_type"] == "refresh_token")
                 {
-                    signedUsers.Remove(TestSetup.access_token_for_401_response_fake);
+                    if (splitedMicData["refresh_token"].Equals(TestSetup.refresh_token_for_401_response_fake))
+                    {
+                        accessToken = TestSetup.access_token_for_401_response_fake;
+                    }
+                    else
+                    {
+                        signedUsers.Remove(TestSetup.access_token_for_401_response_fake);
 
-                    var existingUser = existingUsers.FirstOrDefault(x => x["username"].ToString().Equals("test3") && x["password"].ToString().Equals("test3"));
+                        var existingUser = existingUsers.FirstOrDefault(x => x["username"].ToString().Equals("test3") && x["password"].ToString().Equals("test3"));
 
-                    Assert.IsNotNull(existingUser);
+                        Assert.IsNotNull(existingUser);
 
-                    accessToken = Guid.NewGuid().ToString();
-                    signedUsers.Add(accessToken, existingUser);
+                        accessToken = Guid.NewGuid().ToString();
+                        signedUsers.Add(accessToken, existingUser);
+                    }                   
                 }
                 else
                 {

--- a/Kinvey.Tests/Support Files/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/TestSetup.cs
@@ -28,6 +28,7 @@ namespace Kinvey.Tests
         public const string salesforce_access_token_fake = "8cd71dc8-846a-49f2-8cf1-c0598bbce5ec";
         public const string access_token_for_401_response_fake = "0065cb37-a1ed-4c8b-98fc-91c312683275";
         public const string auth_token_for_401_response_fake = "eda5d4bc-6a47-46d2-9637-07dec479bf9c";
+        public const string refresh_token_for_401_response_fake = "0f550503-f033-44ee-8c2d-ae8f9773b70a";
 
         public const string mic_id_fake = "ade8db71f61c46a69c91910d8fbf3994";
 

--- a/Kinvey.Tests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserIntegrationTests.cs
@@ -444,7 +444,7 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
-        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseAsync()
+        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseRefreshTokenExistsAsync()
         {
             // Arrange
             if (MockData)
@@ -474,6 +474,221 @@ namespace Kinvey.Tests
             Assert.IsNotNull(savedToDo);
             Assert.AreEqual(savedToDo.ID, existingToDo.ID);
             Assert.AreEqual(savedToDo.Name, existingToDo.Name);
+        }
+
+        [TestMethod]
+        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseTwoAttemptsRetrievingRefreshTokenAsync()
+        {
+            // Arrange
+            if (MockData)
+            {
+                MockResponses(6);
+            }
+            else
+            {
+                Assert.Fail("Use this test only with mocks.");
+            }
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+            var todo = new ToDo
+            {
+                Name = "Test"
+            };
+
+            // Act
+            await User.LoginWithMIC("test3", "test3", null, kinveyClient);
+
+            var userId = kinveyClient.ActiveUser.Id;
+
+            var credentials = kinveyClient.Store.Load(userId, null);
+            credentials.RefreshToken = TestSetup.refresh_token_for_401_response_fake;
+            kinveyClient.Store.Store(userId, null, credentials);
+
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.SaveAsync(todo);
+            });
+
+            credentials = kinveyClient.Store.Load(userId, null);
+
+            // Assert
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
+            Assert.AreEqual(401, exception.StatusCode);
+            Assert.IsNull(kinveyClient.ActiveUser);
+            Assert.IsNull(credentials);
+        }
+
+        [TestMethod]
+        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseCredentialsAreEmptyAsync()
+        {
+            // Arrange
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+            else
+            {
+                Assert.Fail("Use this test only with mocks.");
+            }
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+            var todo = new ToDo
+            {
+                Name = "Test"
+            };
+
+            // Act
+            await User.LoginWithMIC("test3", "test3", null, kinveyClient);
+
+            var userId = kinveyClient.ActiveUser.Id;
+
+            kinveyClient.Store.Delete(userId, null);
+
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.SaveAsync(todo);
+            });
+
+            // Assert
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
+            Assert.AreEqual(401, exception.StatusCode);
+            Assert.IsNull(kinveyClient.ActiveUser);
+        }
+
+        [TestMethod]
+        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseRefreshTokenIsNullAsync()
+        {
+            // Arrange
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+            else
+            {
+                Assert.Fail("Use this test only with mocks.");
+            }
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+            var todo = new ToDo
+            {
+                Name = "Test"
+            };
+
+            // Act
+            await User.LoginWithMIC("test3", "test3", null, kinveyClient);
+
+            var userId = kinveyClient.ActiveUser.Id;
+
+            var credentials = kinveyClient.Store.Load(userId, null);
+            credentials.RefreshToken = null;
+            kinveyClient.Store.Store(userId, null, credentials);
+
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.SaveAsync(todo);
+            });
+
+            credentials = kinveyClient.Store.Load(userId, null);
+
+            // Assert
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
+            Assert.AreEqual(401, exception.StatusCode);
+            Assert.IsNull(kinveyClient.ActiveUser);
+            Assert.IsNull(credentials);
+        }
+
+        [TestMethod]
+        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseRefreshTokenIsEmptyAsync()
+        {
+            // Arrange
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+            else
+            {
+                Assert.Fail("Use this test only with mocks.");
+            }
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+            var todo = new ToDo
+            {
+                Name = "Test"
+            };
+
+            // Act
+            await User.LoginWithMIC("test3", "test3", null, kinveyClient);
+
+            var userId = kinveyClient.ActiveUser.Id;
+
+            var credentials = kinveyClient.Store.Load(userId, null);
+            credentials.RefreshToken = string.Empty;
+            kinveyClient.Store.Store(userId, null, credentials);
+
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.SaveAsync(todo);
+            });
+
+            credentials = kinveyClient.Store.Load(userId, null);
+
+            // Assert
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
+            Assert.AreEqual(401, exception.StatusCode);
+            Assert.IsNull(kinveyClient.ActiveUser);
+            Assert.IsNull(credentials);
+        }
+
+        [TestMethod]
+        public async Task TestLoginMICWithAccessTokenUnauthorizedResponseRefreshTokenIsNullStringAsync()
+        {
+            // Arrange
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+            else
+            {
+                Assert.Fail("Use this test only with mocks.");
+            }
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+            var todo = new ToDo
+            {
+                Name = "Test"
+            };
+
+            // Act
+            await User.LoginWithMIC("test3", "test3", null, kinveyClient);
+
+            var userId = kinveyClient.ActiveUser.Id;
+
+            var credentials = kinveyClient.Store.Load(userId, null);
+            credentials.RefreshToken = "null";
+            kinveyClient.Store.Store(userId, null, credentials);
+
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.SaveAsync(todo);
+            });
+
+            credentials = kinveyClient.Store.Load(userId, null);
+
+            // Assert
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
+            Assert.AreEqual(401, exception.StatusCode);
+            Assert.IsNull(kinveyClient.ActiveUser);
+            Assert.IsNull(credentials);
         }
 
         [TestMethod]


### PR DESCRIPTION
#### Description
For the scope of this ticket, concentrate on mocking a 401 - Unauthorized server response, and validate through unit tests that we correctly handle this error. This includes:
No refresh token: log out the active user and delete the active user credential from the credential store.
Refresh token present: try to use the refresh token

#### Changes
No changes

#### Tests
TestLoginMICWithAccessTokenUnauthorizedResponseTwoAttemptsRetrievingRefreshTokenAsync()
TestLoginMICWithAccessTokenUnauthorizedResponseCredentialsAreEmptyAsync()
TestLoginMICWithAccessTokenUnauthorizedResponseRefreshTokenIsNullAsync()
TestLoginMICWithAccessTokenUnauthorizedResponseRefreshTokenIsEmptyAsync()
TestLoginMICWithAccessTokenUnauthorizedResponseRefreshTokenIsNullStringAsync()

