### PR TITLE
MLIBZ-1415: IsActive should be a property and not a method

### DIFF
--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -175,14 +175,31 @@ namespace Kinvey
 			}
 		}
 
-		#endregion
-
-		#region User class Constructors and Initializers
-
-		/// <summary>
-		/// Initializes a new instance of the <see cref="KinveyXamarin.User"/> class.
+        /// <summary>
+		/// A boolean flag to know whether a user is active.
 		/// </summary>
-		internal User()
+        [JsonIgnore]
+        public bool IsActive
+        {
+            get
+            {
+                if (KinveyClient.IsUserLoggedIn() &&
+                KinveyClient.ActiveUser.Id == this.Id)
+                {
+                    return true;
+                }
+                return false;
+            }
+        }
+
+        #endregion
+
+        #region User class Constructors and Initializers
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KinveyXamarin.User"/> class.
+        /// </summary>
+        internal User()
 		{
 			// This ctor is necessary for deserailzation of the JSON representation of the User.
 			this.Attributes = new Dictionary<string, JToken>();
@@ -192,17 +209,6 @@ namespace Kinvey
 		{
 			this.client = client;
 			this.Attributes = new Dictionary<string, JToken>();
-		}
-
-		public bool IsActive()
-		{
-			if (KinveyClient.IsUserLoggedIn() &&
-			    KinveyClient.ActiveUser.Id == this.Id)
-			{
-				return true;
-			}
-
-			return false;
 		}
 
 		/// <summary>
@@ -736,7 +742,7 @@ namespace Kinvey
         /// <param name="realtimeReconnectionPolicy"> Realtime reconnection policy </param>
         public async Task RegisterRealtimeAsync(AbstractClient userClient = null, CancellationToken ct = default(CancellationToken), RealtimeReconnectionPolicy realtimeReconnectionPolicy = RealtimeReconnectionPolicy.EXPONENTIAL)
 		{
-			if (!IsActive())
+			if (!IsActive)
 			{
 				// throw an error stating that user object has to be the active user in order to register for realtime messages
 			}
@@ -833,7 +839,7 @@ namespace Kinvey
 			ct.ThrowIfCancellationRequested();
 			User u = await retrieveRequest.ExecuteAsync();
 
-			if (this.IsActive())
+			if (this.IsActive)
 			{
 				UpdateActiveUser(u);
 			}

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -183,12 +183,7 @@ namespace Kinvey
         {
             get
             {
-                if (KinveyClient.IsUserLoggedIn() &&
-                KinveyClient.ActiveUser.Id == this.Id)
-                {
-                    return true;
-                }
-                return false;
+                return KinveyClient.IsUserLoggedIn() && KinveyClient.ActiveUser.Id == this.Id;
             }
         }
 

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -179,7 +179,7 @@ namespace Kinvey
 		/// A boolean flag to know whether the current user is active.
 		/// </summary>
         [JsonIgnore]
-        public bool IsActive
+        public bool Active
         {
             get
             {
@@ -451,16 +451,22 @@ namespace Kinvey
 			}
 		}
 
-		#region User class login methods - MIC methods
+        [Obsolete("This method has been deprecated. Please use Active property instead.")]
+        public bool IsActive()
+        {
+            return this.Active;
+        }
 
-		/// <summary>
-		/// Login with Auth Link Credentials
-		/// </summary>
-		/// <returns>The async task.</returns>
-		/// <param name="accesstoken">Auth Link Accesstoken.</param>
-		/// <param name="refreshtoken">Auth Link Refreshtoken.</param>
-		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		public async Task<User> LoginAuthlinkAsync(string accesstoken, string refreshtoken, CancellationToken ct = default(CancellationToken))
+        #region User class login methods - MIC methods
+
+        /// <summary>
+        /// Login with Auth Link Credentials
+        /// </summary>
+        /// <returns>The async task.</returns>
+        /// <param name="accesstoken">Auth Link Accesstoken.</param>
+        /// <param name="refreshtoken">Auth Link Refreshtoken.</param>
+        /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+        public async Task<User> LoginAuthlinkAsync(string accesstoken, string refreshtoken, CancellationToken ct = default(CancellationToken))
 		{
 			Provider provider = new Provider();
 			ct.ThrowIfCancellationRequested();
@@ -742,7 +748,7 @@ namespace Kinvey
         /// <param name="realtimeReconnectionPolicy"> Realtime reconnection policy </param>
         public async Task RegisterRealtimeAsync(AbstractClient userClient = null, CancellationToken ct = default(CancellationToken), RealtimeReconnectionPolicy realtimeReconnectionPolicy = RealtimeReconnectionPolicy.EXPONENTIAL)
 		{
-			if (!IsActive)
+			if (!Active)
 			{
 				// throw an error stating that user object has to be the active user in order to register for realtime messages
 			}
@@ -839,7 +845,7 @@ namespace Kinvey
 			ct.ThrowIfCancellationRequested();
 			User u = await retrieveRequest.ExecuteAsync();
 
-			if (this.IsActive)
+			if (this.Active)
 			{
 				UpdateActiveUser(u);
 			}

--- a/Kinvey.Core/Auth/User.cs
+++ b/Kinvey.Core/Auth/User.cs
@@ -176,7 +176,7 @@ namespace Kinvey
 		}
 
         /// <summary>
-		/// A boolean flag to know whether a user is active.
+		/// A boolean flag to know whether the current user is active.
 		/// </summary>
         [JsonIgnore]
         public bool IsActive

--- a/Kinvey.Tests/UserTests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserTests/UserIntegrationTests.cs
@@ -104,7 +104,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(kinveyClient.ActiveUser);
-            Assert.IsTrue(u.Active);
+            Assert.IsTrue(u.IsActive());
         }
 
         [TestMethod]
@@ -118,7 +118,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(Client.SharedClient.ActiveUser);
-            Assert.IsTrue(u.Active);
+            Assert.IsTrue(u.IsActive());
         }
 
         [TestMethod]
@@ -157,7 +157,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(kinveyClient.ActiveUser);
-            Assert.IsTrue(u.Active);
+            Assert.IsTrue(u.IsActive());
         }
 
         [TestMethod]

--- a/Kinvey.Tests/UserTests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserTests/UserIntegrationTests.cs
@@ -1160,5 +1160,22 @@ namespace Kinvey.Tests
             Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, ke.ErrorCategory);
             Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, ke.ErrorCode);
         }
+
+        [TestMethod]
+        public async Task TestActiveFalse()
+        {
+            // Arrange
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            var user = await User.LoginAsync(Client.SharedClient);
+            user.Logout();
+
+            // Act
+            // Assert
+            Assert.IsFalse(user.Active);
+        }
     }
 }

--- a/Kinvey.Tests/UserTests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserTests/UserIntegrationTests.cs
@@ -104,7 +104,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(kinveyClient.ActiveUser);
-            Assert.IsTrue(u.IsActive);
+            Assert.IsTrue(u.Active);
         }
 
         [TestMethod]
@@ -118,7 +118,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(Client.SharedClient.ActiveUser);
-            Assert.IsTrue(u.IsActive);
+            Assert.IsTrue(u.Active);
         }
 
         [TestMethod]
@@ -157,7 +157,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(kinveyClient.ActiveUser);
-            Assert.IsTrue(u.IsActive);
+            Assert.IsTrue(u.Active);
         }
 
         [TestMethod]

--- a/Kinvey.Tests/UserTests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserTests/UserIntegrationTests.cs
@@ -104,7 +104,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(kinveyClient.ActiveUser);
-            Assert.IsTrue(u.IsActive());
+            Assert.IsTrue(u.IsActive);
         }
 
         [TestMethod]
@@ -118,7 +118,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(Client.SharedClient.ActiveUser);
-            Assert.IsTrue(u.IsActive());
+            Assert.IsTrue(u.IsActive);
         }
 
         [TestMethod]
@@ -157,7 +157,7 @@ namespace Kinvey.Tests
 
             // Assert
             Assert.IsNotNull(kinveyClient.ActiveUser);
-            Assert.IsTrue(u.IsActive());
+            Assert.IsTrue(u.IsActive);
         }
 
         [TestMethod]

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -73,7 +73,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(kinveyClient.ActiveUser);
-			Assert.True(u.IsActive);
+			Assert.True(u.Active);
 
 			// Teardown
 			kinveyClient.ActiveUser.Logout();
@@ -89,7 +89,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(Client.SharedClient.ActiveUser);
-			Assert.True(u.IsActive);
+			Assert.True(u.Active);
 
 			// Teardown
 			Client.SharedClient.ActiveUser.Logout();
@@ -125,7 +125,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(kinveyClient.ActiveUser);
-			Assert.True(u.IsActive);
+			Assert.True(u.Active);
 
 			// Teardown
 			kinveyClient.ActiveUser.Logout();

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -73,7 +73,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(kinveyClient.ActiveUser);
-			Assert.True(u.Active);
+			Assert.True(u.IsActive());
 
 			// Teardown
 			kinveyClient.ActiveUser.Logout();
@@ -89,7 +89,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(Client.SharedClient.ActiveUser);
-			Assert.True(u.Active);
+			Assert.True(u.IsActive());
 
 			// Teardown
 			Client.SharedClient.ActiveUser.Logout();
@@ -125,7 +125,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(kinveyClient.ActiveUser);
-			Assert.True(u.Active);
+			Assert.True(u.IsActive());
 
 			// Teardown
 			kinveyClient.ActiveUser.Logout();

--- a/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
+++ b/TestFramework/Tests.Integration/Tests/UserIntegrationTests.cs
@@ -73,7 +73,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(kinveyClient.ActiveUser);
-			Assert.True(u.IsActive());
+			Assert.True(u.IsActive);
 
 			// Teardown
 			kinveyClient.ActiveUser.Logout();
@@ -89,7 +89,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(Client.SharedClient.ActiveUser);
-			Assert.True(u.IsActive());
+			Assert.True(u.IsActive);
 
 			// Teardown
 			Client.SharedClient.ActiveUser.Logout();
@@ -125,7 +125,7 @@ namespace TestFramework
 
 			// Assert
 			Assert.NotNull(kinveyClient.ActiveUser);
-			Assert.True(u.IsActive());
+			Assert.True(u.IsActive);
 
 			// Teardown
 			kinveyClient.ActiveUser.Logout();


### PR DESCRIPTION
#### Description
According to the Pariveda team functionality like this is typically a property instead of a method. Instead of .IsActive() this would be .Active

#### Changes
The "IsActive()" method in the "User" class.

#### Tests
TestLoginUserPassAsync()
TestSharedClientLoginAsync()
TestLoginAsync()
