### PR TITLE
MLIBZ-1881:Push registration fails silently when configuration is not correct (Manifest changes)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ matrix:
       os: linux
       language: csharp
       mono: none
-      dotnet: 2.1
+      dist: xenial
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ matrix:
       os: linux
       language: csharp
       mono: none
+      dotnet: 2.2
       dist: xenial
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ matrix:
       os: linux
       language: csharp
       mono: none
-      dotnet: 2.2
-      dist: xenial
+      dotnet: 2.1
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"
@@ -44,7 +43,7 @@ matrix:
     #   after_success:
     #     - bash <(curl -s https://codecov.io/bash) -F Mono
 install:
-  - dotnet tool install --global coverlet.console
+  - dotnet tool install --global coverlet.console --version 1.4.1
   - export PATH="$PATH:/home/travis/.dotnet/tools"
 script:
   - cd Kinvey.Tests; dotnet build

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
     #   after_success:
     #     - bash <(curl -s https://codecov.io/bash) -F Mono
 install:
-  - dotnet tool install --global coverlet.console --version 1.4.1
+  - dotnet tool install --global coverlet.console
   - export PATH="$PATH:/home/travis/.dotnet/tools"
 script:
   - cd Kinvey.Tests; dotnet build

--- a/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
+++ b/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
@@ -219,10 +219,15 @@ namespace Kinvey
 		/// </summary>
 		ERROR_REQUIREMENT_INVALID_PARAMETER,
 
-		/// <summary>
-		/// Error condition for a method not being implemented
+        /// <summary>
+		/// Requirement Error - Missing configuration for push. FCM receivers are absent.
 		/// </summary>
-		ERROR_METHOD_NOT_IMPLEMENTED,
+        ERROR_REQUIREMENT_MISSING_PUSH_CONFIGURATION_RECEIVERS,
+
+        /// <summary>
+        /// Error condition for a method not being implemented
+        /// </summary>
+        ERROR_METHOD_NOT_IMPLEMENTED,
 
 		/// <summary>
 		/// Error condition for a LINQ where clause not supported.

--- a/Kinvey.Core/Troubleshooting/KinveyException.cs
+++ b/Kinvey.Core/Troubleshooting/KinveyException.cs
@@ -232,7 +232,13 @@ namespace Kinvey
 					description = "A valid username and password is required for login.";
 					break;
 
-				case EnumErrorCode.ERROR_USER_ALREADY_LOGGED_IN:
+                case EnumErrorCode.ERROR_REQUIREMENT_MISSING_PUSH_CONFIGURATION_RECEIVERS:
+                    error = "FCM receivers are absent for push configuration.";
+                    debug = "";
+                    description = "To use FCM for push notifications, add com.google.firebase.iid.FirebaseInstanceIdInternalReceiver and com.google.firebase.iid.FirebaseInstanceIdReceiver to your project.";
+                    break;
+
+                case EnumErrorCode.ERROR_USER_ALREADY_LOGGED_IN:
 					error = "Attempting to login when a user is already logged in";
 					debug = "call `myClient.user().logout().execute() first -or- check `myClient.user().isUserLoggedIn()` before attempting to login again";
 					description = "Only one user can be active at a time, and logging in a new user will replace the current user which might not be intended\")";

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -10,6 +10,8 @@
             public const string User = "";
             public const string Password = "";
             public const string ContractsCollection = "contracts";
+
+
         }
 
         public static class Exceptions

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -10,7 +10,6 @@
             public const string User = "";
             public const string Password = "";
             public const string ContractsCollection = "contracts";
-
         }
 
         public static class Exceptions


### PR DESCRIPTION
#### Description
When you don't configure push completely push registration fails silently: http://devcenter.kinvey.com/xamarin/guides/push#RegisteringtheDevice
Kinvey SDK should provide a warning to the developer to inform them that push may not be configured correctly.

#### Changes
The "InitializeAsync()" method of the  "FCMPush"  class.

#### Tests
No tests
