### PR TITLE
MLIBZ-2989: Push registration fails silently when configuration is not correct (Class overrides)

### DIFF
--- a/Kinvey.Android/Push/FcmPush.cs
+++ b/Kinvey.Android/Push/FcmPush.cs
@@ -32,6 +32,7 @@ namespace Kinvey
         public async Task InitializeAsync(Context appContext)
         {
             CheckPushReceiversExistence(appContext);
+            CheckKinveyFCMServiceClassOverrideExistence();
 
             var senders = base.client.senderID;
             Intent intent;
@@ -115,5 +116,26 @@ namespace Kinvey
                 throw new KinveyException(EnumErrorCategory.ERROR_REQUIREMENT, EnumErrorCode.ERROR_REQUIREMENT_MISSING_PUSH_CONFIGURATION_RECEIVERS, string.Empty);
             }
         }
+
+        private void CheckKinveyFCMServiceClassOverrideExistence()
+        {
+            Type kinveyFCMServiceSubType = null;
+
+            foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                kinveyFCMServiceSubType = assembly.GetTypes().FirstOrDefault(t => t.IsClass && !t.IsAbstract && t.IsSubclassOf(typeof(KinveyFCMService)));
+
+                if (kinveyFCMServiceSubType != null)
+                {
+                    break;
+                }
+            }
+
+            if (kinveyFCMServiceSubType == null)
+            {
+                throw new KinveyException(EnumErrorCategory.ERROR_REQUIREMENT, EnumErrorCode.ERROR_REQUIREMENT_MISSING_PUSH_CONFIGURATION_CLASS_OVERRIDE, string.Empty);
+            }
+        }
+
     }
 }

--- a/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
+++ b/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
@@ -225,6 +225,11 @@ namespace Kinvey
         ERROR_REQUIREMENT_MISSING_PUSH_CONFIGURATION_RECEIVERS,
 
         /// <summary>
+        /// Requirement Error - Missing configuration for push. KinveyFCMService class override is absent.
+        /// </summary>
+        ERROR_REQUIREMENT_MISSING_PUSH_CONFIGURATION_CLASS_OVERRIDE,
+
+        /// <summary>
         /// Error condition for a method not being implemented
         /// </summary>
         ERROR_METHOD_NOT_IMPLEMENTED,

--- a/Kinvey.Core/Troubleshooting/KinveyException.cs
+++ b/Kinvey.Core/Troubleshooting/KinveyException.cs
@@ -238,6 +238,12 @@ namespace Kinvey
                     description = "To use FCM for push notifications, add com.google.firebase.iid.FirebaseInstanceIdInternalReceiver and com.google.firebase.iid.FirebaseInstanceIdReceiver to your project.";
                     break;
 
+                case EnumErrorCode.ERROR_REQUIREMENT_MISSING_PUSH_CONFIGURATION_CLASS_OVERRIDE:
+                    error = "KinveyFCMService class override is absent for push configuration.";
+                    debug = "";
+                    description = "To use FCM for push notifications, add KinveyFCMService class override to your project.";
+                    break;
+
                 case EnumErrorCode.ERROR_USER_ALREADY_LOGGED_IN:
 					error = "Attempting to login when a user is already logged in";
 					debug = "call `myClient.user().logout().execute() first -or- check `myClient.user().isUserLoggedIn()` before attempting to login again";


### PR DESCRIPTION
#### Description
When you don't configure push completely push registration fails silently: http://devcenter.kinvey.com/xamarin/guides/push#RegisteringtheDevice
Kinvey SDK should provide a warning to the developer to inform them that push may not be configured correctly.

#### Changes
The "InitializeAsync()" method of the "FCMPush" class.

#### Tests
No tests