### PR TITLE
MLIBZ-3027:Creating a method for changing Kinvey api version in the Client.Builder.

### DIFF
--- a/Kinvey.Core/Auth/KinveyAuthRequest.cs
+++ b/Kinvey.Core/Auth/KinveyAuthRequest.cs
@@ -190,7 +190,14 @@ namespace Kinvey
 
             foreach (var header in kinveyHeaders)
             {
-                request.Headers.Add(header.Key, header.Value.FirstOrDefault());
+                var key = header.Key;
+                var value = header.Value.FirstOrDefault();
+
+                if (key.Equals(Constants.STR_REQUEST_HEADER_API_VERSION) && !string.IsNullOrEmpty(client.ApiVersion) && !value.Equals(client.ApiVersion))
+                {
+                    value = client.ApiVersion;
+                }
+                request.Headers.Add(key, value);
             }
 
             appKeyAuthentication.Authenticate(request);

--- a/Kinvey.Core/Client/AbstractKinveyClient.cs
+++ b/Kinvey.Core/Client/AbstractKinveyClient.cs
@@ -41,6 +41,8 @@ namespace Kinvey
 		/// </summary>
 		private HttpClient httpClient;
 
+        private string apiVersion;
+
 		private string clientAppVersion = null;
 
 		private JObject customRequestProperties = new JObject();
@@ -208,11 +210,21 @@ namespace Kinvey
             get { return this.httpClient; }
         }
 
-		/// <summary>
-		/// Initializes the request.
+        /// <summary>
+		/// Gets Kinvey api version.
 		/// </summary>
-		/// <param name="request">Request.</param>
-		/// <typeparam name="T">The Type of the response</typeparam>
+		/// <value>Kinvey api version.</value>
+        public string ApiVersion
+        {
+            get { return string.IsNullOrEmpty(apiVersion) ? KinveyHeaders.kinveyApiVersion: apiVersion; }
+            internal set { this.apiVersion = value; }
+        }
+
+        /// <summary>
+        /// Initializes the request.
+        /// </summary>
+        /// <param name="request">Request.</param>
+        /// <typeparam name="T">The Type of the response</typeparam>
         public void InitializeRequest<T>(AbstractKinveyClientRequest<T> request, string clientID = null)
         {
             if (RequestInitializer != null) 

--- a/Kinvey.Core/Client/Client.cs
+++ b/Kinvey.Core/Client/Client.cs
@@ -167,6 +167,8 @@ namespace Kinvey
 
             private Constants.DevicePlatform devicePlatform;
 
+            private string apiVersion;
+
 			/// <summary>
 			/// Initializes a new instance of the <see cref="T:KinveyXamarin.Client.Builder"/> class.
 			/// </summary>
@@ -211,6 +213,7 @@ namespace Kinvey
 				c.logger = this.log;
 				c.senderID = this.senderID;
 				c.SSOGroupKey = this.ssoGroupKey;
+                c.ApiVersion = apiVersion;
                 if (!string.IsNullOrEmpty(this.MICHostName)) c.MICHostName = this.MICHostName;
                 if (!string.IsNullOrEmpty(instanceID))
                 {
@@ -333,6 +336,17 @@ namespace Kinvey
                 this.instanceID = instanceID;
                 string url = $"{Constants.STR_PROTOCOL_HTTPS + instanceID + Constants.STR_HYPHEN + Constants.STR_HOSTNAME_API}";
                 this.setBaseURL(url);
+                return this;
+            }
+
+            /// <summary>
+            /// Sets Kinvey api version.
+            /// </summary>
+            /// <returns>The current builder.</returns>
+            /// <param name="version">Kinvey api version.</param>
+            public Builder SetApiVersion(string version)
+            {
+                apiVersion = version;
                 return this;
             }
         }

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -288,6 +288,12 @@ namespace Kinvey
 
             foreach (var header in requestHeaders)
             {
+                if (header.Key.Equals(Constants.STR_REQUEST_HEADER_API_VERSION) && !string.IsNullOrEmpty(client.ApiVersion) && !header.Value.FirstOrDefault().Equals(client.ApiVersion))
+                {
+                    request.Headers.Add(header.Key, client.ApiVersion);
+                    continue;
+                }
+
                 if (header.Value.Count() > 1)
                 {
                     request.Headers.Add(header.Key, header.Value);

--- a/Kinvey.Core/Core/KinveyHeaders.cs
+++ b/Kinvey.Core/Core/KinveyHeaders.cs
@@ -29,8 +29,7 @@ namespace Kinvey
 		public static string VERSION = "4.0.1";
 
 		// The kinvey API version.
-        static string kinveyApiVersionKey = "X-Kinvey-API-Version";
-        static string kinveyApiVersion = "4";
+        internal static readonly string kinveyApiVersion = "4";
 
 		// The user agent.
         static string userAgentKey = "user-agent";
@@ -72,7 +71,7 @@ namespace Kinvey
                 userAgentKey, new List<string> { userAgent }
             ));
             Add(new KeyValuePair<string, IEnumerable<string>>(
-                kinveyApiVersionKey, new List<string> { kinveyApiVersion }
+                Constants.STR_REQUEST_HEADER_API_VERSION, new List<string> { kinveyApiVersion }
             ));
 
             JObject deviceInfo = new JObject();

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -72,6 +72,7 @@ namespace Kinvey
 
         // Request Headers
         internal const string STR_REQUEST_HEADER_DEVICE_INFO = "X-Kinvey-Device-Info";
+        internal const string STR_REQUEST_HEADER_API_VERSION = "X-Kinvey-API-Version";
 
         // X-Kinvey-Device-Info Strings
         internal const string STR_DEVICE_INFO_HEADER_KEY = "hv";

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -12,7 +12,6 @@
             public const string ContractsCollection = "contracts";
         }
 
-
         public static class Exceptions
         {
             public const string GeneralExceptionTitle = "General exception";

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -919,11 +919,13 @@ namespace Kinvey.Tests
                         count++;
                         Console.WriteLine($"{count}");
 
+                        const string uploadUrlSection = "/_uploadURL/";
+
                         var apiVersion = context.Request.Headers[Constants.STR_REQUEST_HEADER_API_VERSION];
                         var version = 0;
                         var isParsed = int.TryParse(apiVersion, out version);
 
-                        if (!isParsed || (isParsed && version > MaxApiVersion))
+                        if (!context.Request.Url.LocalPath.StartsWith(uploadUrlSection, StringComparison.Ordinal) && (!isParsed || (isParsed && version > MaxApiVersion)))
                         {
                             context.Response.StatusCode = (int)HttpStatusCode.NotImplemented;
                             Write(context, "Not implemented");
@@ -931,7 +933,7 @@ namespace Kinvey.Tests
                         }
 
                         var authorization = context.Request.Headers["Authorization"];
-                        if (!context.Request.Url.LocalPath.StartsWith("/_uploadURL/", StringComparison.Ordinal) && !context.Request.Url.LocalPath.StartsWith("/_downloadURL/", StringComparison.Ordinal))
+                        if (!context.Request.Url.LocalPath.StartsWith(uploadUrlSection, StringComparison.Ordinal) && !context.Request.Url.LocalPath.StartsWith("/_downloadURL/", StringComparison.Ordinal))
                         {
                             Assert.IsNotNull(authorization);
                             Assert.IsFalse(string.IsNullOrEmpty(authorization));

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -68,6 +68,8 @@ namespace Kinvey.Tests
         private static readonly string REQUEST_START_HEADER = "X-Kinvey-Request-Start";
         private static readonly string DATE_FORMAT = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.fffK";
 
+        private static readonly int MaxApiVersion = 5;
+
         protected static HttpListener httpListener;
 
         public void Delete(string fileName)
@@ -916,6 +918,17 @@ namespace Kinvey.Tests
 
                         count++;
                         Console.WriteLine($"{count}");
+
+                        var apiVersion = context.Request.Headers[Constants.STR_REQUEST_HEADER_API_VERSION];
+                        var version = 0;
+                        var isParsed = int.TryParse(apiVersion, out version);
+
+                        if (!isParsed || (isParsed && version > MaxApiVersion))
+                        {
+                            context.Response.StatusCode = (int)HttpStatusCode.NotImplemented;
+                            Write(context, "Not implemented");
+                            continue;
+                        }
 
                         var authorization = context.Request.Headers["Authorization"];
                         if (!context.Request.Url.LocalPath.StartsWith("/_uploadURL/", StringComparison.Ordinal) && !context.Request.Url.LocalPath.StartsWith("/_downloadURL/", StringComparison.Ordinal))


### PR DESCRIPTION
#### Description
Customers should have possibility to change Kinvey api version.

#### Changes
New method in the Builder class:
SetApiVersion()

New property in the Client class:
ApiVersion{get;}

#### Tests
TestSetApiVersionAuthRequests()
TestSetApiVersionKinveyClientRequests()

