### PR TITLE
MLIBZ-3015:Implement multi-record insert

### DIFF
--- a/Kinvey.Core/Core/NetworkFactory.cs
+++ b/Kinvey.Core/Core/NetworkFactory.cs
@@ -225,7 +225,7 @@ namespace Kinvey
         /// <returns>A created network request.</returns>
         /// <param name="collectionName">A name of a collection.</param>
         /// <param name="entities">Entities to insert.</param>
-        public NetworkRequest<U> buildMultiInsertRequest<T, U>(string collectionName, List<T> entities)
+        public NetworkRequest<U> BuildMultiInsertRequest<T, U>(string collectionName, List<T> entities)
         {
             const string REST_PATH = "appdata/{appKey}/{collectionName}";
 

--- a/Kinvey.Core/Core/NetworkFactory.cs
+++ b/Kinvey.Core/Core/NetworkFactory.cs
@@ -219,7 +219,26 @@ namespace Kinvey
 			return create;
 		}
 
-		public NetworkRequest<T> buildUpdateRequest <T> (string collectionName, T entity, string entityID)
+        /// <summary>
+        /// Creates a network request for multi insert operation.
+        /// </summary>
+        /// <returns>A created network request.</returns>
+        /// <param name="collectionName">A name of a collection.</param>
+        /// <param name="entities">Entities to insert.</param>
+        public NetworkRequest<U> buildMultiInsertRequest<T, U>(string collectionName, List<T> entities)
+        {
+            const string REST_PATH = "appdata/{appKey}/{collectionName}";
+
+            var urlParameters = new Dictionary<string, string>();
+            urlParameters.Add("appKey", ((KinveyClientRequestInitializer)client.RequestInitializer).AppKey);
+            urlParameters.Add("collectionName", collectionName);
+
+            NetworkRequest<U> create = new NetworkRequest<U>(client, "POST", REST_PATH, entities, urlParameters);
+            client.InitializeRequest(create);
+            return create;
+        }
+
+        public NetworkRequest<T> buildUpdateRequest <T> (string collectionName, T entity, string entityID)
 		{
 			const string REST_PATH = "appdata/{appKey}/{collectionName}/{entityID}";
 

--- a/Kinvey.Core/Kinvey.Core.csproj
+++ b/Kinvey.Core/Kinvey.Core.csproj
@@ -32,6 +32,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Extensions\CustomExtension.cs" />
+    <Compile Include="Model\Error.cs" />
+    <Compile Include="Model\KinveyDataStoreResponse.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Auth\Credential.cs" />
     <Compile Include="Auth\CredentialManager.cs" />
@@ -72,6 +74,7 @@
     <Compile Include="Realtime\RealtimeReconnectionPolicy.cs" />
     <Compile Include="Realtime\RealtimeReconnectionPolicyExtension.cs" />
     <Compile Include="Store\RemoveRequest.cs" />
+    <Compile Include="Store\MultiInsertRequest.cs" />
     <Compile Include="Store\WriteRequest.cs" />
     <Compile Include="Store\PushRequest.cs" />
     <Compile Include="Store\ReadRequest.cs" />

--- a/Kinvey.Core/Kinvey.Core.csproj
+++ b/Kinvey.Core/Kinvey.Core.csproj
@@ -33,7 +33,7 @@
   <ItemGroup>
     <Compile Include="Extensions\CustomExtension.cs" />
     <Compile Include="Model\Error.cs" />
-    <Compile Include="Model\KinveyDataStoreResponse.cs" />
+    <Compile Include="Model\KinveyMultiInsertResponse.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Auth\Credential.cs" />
     <Compile Include="Auth\CredentialManager.cs" />

--- a/Kinvey.Core/Model/Error.cs
+++ b/Kinvey.Core/Model/Error.cs
@@ -1,0 +1,29 @@
+﻿using Newtonsoft.Json;
+
+namespace Kinvey
+{
+    /// <summary>
+	/// Represents JSON object with information about an error. 
+	/// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class Error
+    {
+        /// <summary>
+		/// An index of an entity in the collection <see cref="Kinvey.KinveyDataStoreResponse{T}.Entities"/>.
+		/// </summary>
+        [JsonProperty]
+        public int Index { get; set; }
+
+        /// <summary>
+        /// Error code./>
+        /// </summary>
+        [JsonProperty]
+        public int Code { get; set; }
+
+        /// <summary>
+        /// Error message./>
+        /// </summary>
+        [JsonProperty]
+        public string Errmsg { get; set; }
+    }
+}

--- a/Kinvey.Core/Model/Error.cs
+++ b/Kinvey.Core/Model/Error.cs
@@ -9,7 +9,7 @@ namespace Kinvey
     public class Error
     {
         /// <summary>
-		/// An index of an entity in the collection <see cref="Kinvey.KinveyDataStoreResponse{T}.Entities"/>.
+		/// An index of an entity in the collection <see cref="Kinvey.KinveyMultiInsertResponse{T}.Entities"/>.
 		/// </summary>
         [JsonProperty]
         public int Index { get; set; }

--- a/Kinvey.Core/Model/KinveyDataStoreResponse.cs
+++ b/Kinvey.Core/Model/KinveyDataStoreResponse.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) 2019, Kinvey, Inc. All rights reserved.
+//
+// This software is licensed to you under the Kinvey terms of service located at
+// http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+// software, you hereby accept such terms of service  (and any agreement referenced
+// therein) and agree that you have read, understand and agree to be bound by such
+// terms of service and are of legal age to agree to such terms with Kinvey.
+//
+// This software contains valuable confidential and proprietary information of
+// KINVEY, INC and is subject to applicable licensing agreements.
+// Unauthorized reproduction, transmission or distribution of this file and its
+// contents is a violation of applicable laws.
+
+using Newtonsoft.Json;
+using System.Collections.Generic;
+
+namespace Kinvey
+{
+    /// <summary>
+	/// This class represents a response sent from Kinvey backend after a multi insert operation has been executed.
+	/// </summary>
+    [JsonObject(MemberSerialization.OptIn)]
+    public class KinveyDataStoreResponse<T>
+    {
+        /// <summary>
+		/// Represents a collection of entities which were inserted to Kinvey data source.
+		/// </summary>
+		/// <value>List of entities.</value>
+        [JsonProperty]
+        public List<T> Entities { get; set; }
+
+        /// <summary>
+		/// Represents a collection of errors which were occurring during  inserting operation.
+		/// </summary>
+		/// <value>List of errors.</value>
+        [JsonProperty]
+        public List<Error> Errors { get; set; }
+    }
+}

--- a/Kinvey.Core/Model/KinveyMultiInsertResponse.cs
+++ b/Kinvey.Core/Model/KinveyMultiInsertResponse.cs
@@ -20,7 +20,7 @@ namespace Kinvey
 	/// This class represents a response sent from Kinvey backend after a multi insert operation has been executed.
 	/// </summary>
     [JsonObject(MemberSerialization.OptIn)]
-    public class KinveyDataStoreResponse<T>
+    public class KinveyMultiInsertResponse<T>
     {
         /// <summary>
 		/// Represents a collection of entities which were inserted to Kinvey data source.

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -353,7 +353,12 @@ namespace Kinvey
 		/// <param name="ct">[optional] CancellationToken used to cancel a request.</param>
         public async Task<KinveyDataStoreResponse<T>> SaveAsync(List<T> entities, CancellationToken ct = default(CancellationToken))
         {
-            MultiInsertRequest<T, KinveyDataStoreResponse<T>> request = new MultiInsertRequest<T, KinveyDataStoreResponse<T>>(entities, this.client, this.CollectionName, this.cache, this.syncQueue, this.storeType.WritePolicy);
+            if (!int.TryParse(KinveyClient.ApiVersion, out int apiVersion) || apiVersion < 5)
+            {
+                throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, "Query cannot be null.");
+            }
+
+            var request = new MultiInsertRequest<T, KinveyDataStoreResponse<T>>(entities, this.client, this.CollectionName, this.cache, this.syncQueue, this.storeType.WritePolicy);
             ct.ThrowIfCancellationRequested();
             return await request.ExecuteAsync();
         }

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -348,10 +348,10 @@ namespace Kinvey
         /// <summary>
 		/// Saves specified entities to a Kinvey collection.
 		/// </summary>
-		/// <returns>An async task with the <see cref="Kinvey.KinveyDataStoreResponse{T}"/> result.</returns>
+		/// <returns>An async task with the <see cref="Kinvey.KinveyMultiInsertResponse{T}"/> result.</returns>
 		/// <param name="entities">Entities to save.</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel a request.</param>
-        public async Task<KinveyDataStoreResponse<T>> SaveAsync(IList<T> entities, CancellationToken ct = default(CancellationToken))
+        public async Task<KinveyMultiInsertResponse<T>> SaveAsync(IList<T> entities, CancellationToken ct = default(CancellationToken))
         {
             if (!int.TryParse(KinveyClient.ApiVersion, out int apiVersion) || apiVersion < 5)
             {

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -358,6 +358,16 @@ namespace Kinvey
                 throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, string.Empty);
             }
 
+            if (entities == null || entities.Count == 0)
+            {
+                throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES, string.Empty);
+            }
+
+            if(entities.Count > Constants.NUMBER_LIMIT_OF_ENTITIES)
+            {
+                throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_DATASTORE_LIMIT_OF_ENTITIES_TO_BE_SAVED, string.Empty);
+            }
+
             var request = new MultiInsertRequest<T>(entities, this.client, this.CollectionName, this.cache, this.syncQueue, this.storeType.WritePolicy);
             ct.ThrowIfCancellationRequested();
             return await request.ExecuteAsync();

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -358,7 +358,7 @@ namespace Kinvey
                 throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, string.Empty);
             }
 
-            var request = new MultiInsertRequest<T, KinveyDataStoreResponse<T>>(entities, this.client, this.CollectionName, this.cache, this.syncQueue, this.storeType.WritePolicy);
+            var request = new MultiInsertRequest<T>(entities, this.client, this.CollectionName, this.cache, this.syncQueue, this.storeType.WritePolicy);
             ct.ThrowIfCancellationRequested();
             return await request.ExecuteAsync();
         }

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -345,14 +345,26 @@ namespace Kinvey
 			return await request.ExecuteAsync();
 		}
 
-
-		/// <summary>
-		/// Deletes the entity associated with the provided id
+        /// <summary>
+		/// Saves specified entities to a Kinvey collection.
 		/// </summary>
-		/// <returns>The async task.</returns>
-		/// <param name="entityID">The Kinvey ID of the entity to delete.</param>
-		/// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
-		public async Task<KinveyDeleteResponse> RemoveAsync(string entityID, CancellationToken ct = default(CancellationToken))
+		/// <returns>An async task with the <see cref="Kinvey.KinveyDataStoreResponse{T}"/> result.</returns>
+		/// <param name="entities">Entities to save.</param>
+		/// <param name="ct">[optional] CancellationToken used to cancel a request.</param>
+        public async Task<KinveyDataStoreResponse<T>> SaveAsync(List<T> entities, CancellationToken ct = default(CancellationToken))
+        {
+            MultiInsertRequest<T, KinveyDataStoreResponse<T>> request = new MultiInsertRequest<T, KinveyDataStoreResponse<T>>(entities, this.client, this.CollectionName, this.cache, this.syncQueue, this.storeType.WritePolicy);
+            ct.ThrowIfCancellationRequested();
+            return await request.ExecuteAsync();
+        }
+
+        /// <summary>
+        /// Deletes the entity associated with the provided id
+        /// </summary>
+        /// <returns>The async task.</returns>
+        /// <param name="entityID">The Kinvey ID of the entity to delete.</param>
+        /// <param name="ct">[optional] CancellationToken used to cancel the request.</param>
+        public async Task<KinveyDeleteResponse> RemoveAsync(string entityID, CancellationToken ct = default(CancellationToken))
 		{
 			RemoveRequest<T> request = new RemoveRequest<T>(entityID, client, CollectionName, cache, syncQueue, storeType.WritePolicy);
 			ct.ThrowIfCancellationRequested();

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -355,7 +355,7 @@ namespace Kinvey
         {
             if (!int.TryParse(KinveyClient.ApiVersion, out int apiVersion) || apiVersion < 5)
             {
-                throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, "Query cannot be null.");
+                throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, string.Empty);
             }
 
             var request = new MultiInsertRequest<T, KinveyDataStoreResponse<T>>(entities, this.client, this.CollectionName, this.cache, this.syncQueue, this.storeType.WritePolicy);

--- a/Kinvey.Core/Store/DataStore.cs
+++ b/Kinvey.Core/Store/DataStore.cs
@@ -351,7 +351,7 @@ namespace Kinvey
 		/// <returns>An async task with the <see cref="Kinvey.KinveyDataStoreResponse{T}"/> result.</returns>
 		/// <param name="entities">Entities to save.</param>
 		/// <param name="ct">[optional] CancellationToken used to cancel a request.</param>
-        public async Task<KinveyDataStoreResponse<T>> SaveAsync(List<T> entities, CancellationToken ct = default(CancellationToken))
+        public async Task<KinveyDataStoreResponse<T>> SaveAsync(IList<T> entities, CancellationToken ct = default(CancellationToken))
         {
             if (!int.TryParse(KinveyClient.ApiVersion, out int apiVersion) || apiVersion < 5)
             {

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -1,0 +1,74 @@
+﻿// Copyright (c) 2019, Kinvey, Inc. All rights reserved.
+//
+// This software is licensed to you under the Kinvey terms of service located at
+// http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+// software, you hereby accept such terms of service  (and any agreement referenced
+// therein) and agree that you have read, understand and agree to be bound by such
+// terms of service and are of legal age to agree to such terms with Kinvey.
+//
+// This software contains valuable confidential and proprietary information of
+// KINVEY, INC and is subject to applicable licensing agreements.
+// Unauthorized reproduction, transmission or distribution of this file and its
+// contents is a violation of applicable laws.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Kinvey
+{
+    /// <summary>
+    /// Represents a multi insert request. 
+    /// </summary>
+    public class MultiInsertRequest<T, U> : WriteRequest<T, U>
+    {
+        private List<T> entities;
+
+        public MultiInsertRequest(List<T> entities, AbstractClient client, string collection, ICache<T> cache, ISyncQueue sync, WritePolicy policy)
+            : base(client, collection, cache, sync, policy)
+        {
+            this.entities = entities;
+        }
+
+        /// <summary>
+        /// Executes a multi insert request.
+        /// </summary>
+        /// <returns>An async task with the request result.</returns>
+        public override async Task<U> ExecuteAsync()
+        {
+            U savedEntities = default(U);
+
+            switch (Policy)
+            {
+                case WritePolicy.FORCE_LOCAL:
+
+                    for (var index = 0; index < entities.Count; index++)
+                    {
+                        var entity = entities[index];
+                        var tempIdLocal = PrepareCacheSave(ref entity);
+                        var savedEntity = Cache.Save(entity);
+                    }
+                    break;
+
+                case WritePolicy.FORCE_NETWORK:
+                    // network
+                    var request = Client.NetworkFactory.buildMultiInsertRequest<T, U>(Collection, entities);
+                    savedEntities = await request.ExecuteAsync();
+                    break;
+
+                default:
+                    throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_GENERAL, "Invalid write policy");
+            }
+            
+            return savedEntities;
+        }
+
+        /// <summary>
+        /// Cancels a multi insert request.
+        /// </summary>
+        /// <returns>An async task with a boolean result.</returns>
+        public override Task<bool> Cancel()
+        {
+            throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_METHOD_NOT_IMPLEMENTED, "Cancel method on MultiInsertRequest not implemented.");
+        }
+    }
+}

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -24,9 +24,9 @@ namespace Kinvey
     /// </summary>
     public class MultiInsertRequest<T> : WriteRequest<T, KinveyDataStoreResponse<T>>
     {
-        private List<T> entities;
+        private IList<T> entities;
 
-        public MultiInsertRequest(List<T> entities, AbstractClient client, string collection, ICache<T> cache, ISyncQueue sync, WritePolicy policy)
+        public MultiInsertRequest(IList<T> entities, AbstractClient client, string collection, ICache<T> cache, ISyncQueue sync, WritePolicy policy)
             : base(client, collection, cache, sync, policy)
         {
             this.entities = entities;

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -137,7 +137,7 @@ namespace Kinvey
                     {
                         for (var index = 0; index < kinveyDataStoreResponse.Entities.Count; index++)
                         {
-                            if (kinveyDataStoreResponse.Entities[index] != null )
+                            if (kinveyDataStoreResponse.Entities[index] != null && kinveyDataStoreNetworkResponse.Entities[index] != null)
                             {
                                 var obj = JObject.FromObject(kinveyDataStoreResponse.Entities[index]);
                                 var id = obj["_id"].ToString();

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -223,7 +223,7 @@ namespace Kinvey
                 }
             }
 
-            var multiInsertRequest = Client.NetworkFactory.buildMultiInsertRequest<T, KinveyMultiInsertResponse<T>>(Collection, entitiesToMultiInsert);
+            var multiInsertRequest = Client.NetworkFactory.BuildMultiInsertRequest<T, KinveyMultiInsertResponse<T>>(Collection, entitiesToMultiInsert);
             var multiInsertKinveyDataStoreResponse = await multiInsertRequest.ExecuteAsync();
 
             for (var index = 0; index < multiInsertKinveyDataStoreResponse.Entities.Count; index++)

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -22,7 +22,7 @@ namespace Kinvey
     /// <summary>
     /// Represents a multi insert request. 
     /// </summary>
-    public class MultiInsertRequest<T> : WriteRequest<T, KinveyDataStoreResponse<T>>
+    public class MultiInsertRequest<T> : WriteRequest<T, KinveyMultiInsertResponse<T>>
     {
         private IList<T> entities;
 
@@ -36,9 +36,9 @@ namespace Kinvey
         /// Executes a multi insert request.
         /// </summary>
         /// <returns>An async task with the request result.</returns>
-        public override async Task<KinveyDataStoreResponse<T>> ExecuteAsync()
+        public override async Task<KinveyMultiInsertResponse<T>> ExecuteAsync()
         {
-            var kinveyDataStoreResponse = new KinveyDataStoreResponse<T>
+            var kinveyDataStoreResponse = new KinveyMultiInsertResponse<T>
             {
                 Entities = new List<T>(),
                 Errors = new List<Error>()
@@ -84,7 +84,7 @@ namespace Kinvey
 
                 case WritePolicy.LOCAL_THEN_NETWORK:
                     //local cache
-                    KinveyDataStoreResponse<T> kinveyDataStoreNetworkResponse = null;
+                    KinveyMultiInsertResponse<T> kinveyDataStoreNetworkResponse = null;
 
                     var pendingWriteActions = new List<PendingWriteAction>();
 
@@ -195,9 +195,9 @@ namespace Kinvey
             return new Tuple<PendingWriteAction, T>(pendingAction, savedEntity);
         }
 
-        private async Task<KinveyDataStoreResponse<T>> HandleNetworkRequestAsync(IList<T> entities)
+        private async Task<KinveyMultiInsertResponse<T>> HandleNetworkRequestAsync(IList<T> entities)
         {
-            var kinveyDataStoreResponse = new KinveyDataStoreResponse<T>
+            var kinveyDataStoreResponse = new KinveyMultiInsertResponse<T>
             {
                 Entities = HelperMethods.Initialize<T>(default(T), entities.Count),
                 Errors = new List<Error>()
@@ -223,7 +223,7 @@ namespace Kinvey
                 }
             }
 
-            var multiInsertRequest = Client.NetworkFactory.buildMultiInsertRequest<T, KinveyDataStoreResponse<T>>(Collection, entitiesToMultiInsert);
+            var multiInsertRequest = Client.NetworkFactory.buildMultiInsertRequest<T, KinveyMultiInsertResponse<T>>(Collection, entitiesToMultiInsert);
             var multiInsertKinveyDataStoreResponse = await multiInsertRequest.ExecuteAsync();
 
             for (var index = 0; index < multiInsertKinveyDataStoreResponse.Entities.Count; index++)

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -112,8 +112,13 @@ namespace Kinvey
 
                         if(error != null)
                         {
-                            error.Index = initialIndexes[index];
-                            kinveyDataStoreResponse.Errors.Add(error);
+                            var newError = new Error
+                            {
+                                Index = initialIndexes[index],
+                                Code = error.Code,
+                                Errmsg = error.Errmsg
+                            };
+                            kinveyDataStoreResponse.Errors.Add(newError);
                         }
                     }
 
@@ -138,6 +143,9 @@ namespace Kinvey
 
                         kinveyDataStoreResponse.Entities[updateRequest.Key] = updatedEntity;
                     }
+
+                    kinveyDataStoreResponse.Errors.Sort((x, y) => x.Index.CompareTo(y.Index));
+
                     break;
 
                 case WritePolicy.LOCAL_THEN_NETWORK:

--- a/Kinvey.Core/Store/SaveRequest.cs
+++ b/Kinvey.Core/Store/SaveRequest.cs
@@ -157,18 +157,6 @@ namespace Kinvey
 		public override Task<bool> Cancel()
 		{
 			throw new KinveyException(EnumErrorCategory.ERROR_GENERAL, EnumErrorCode.ERROR_METHOD_NOT_IMPLEMENTED, "Cancel method on SaveRequest not implemented.");
-		}
-
-		private string PrepareCacheSave(ref T entity)
-		{
-			string guid = System.Guid.NewGuid().ToString();
-			string tempID = "temp_" + guid;
-
-			JObject obj = JObject.FromObject(entity);
-			obj["_id"] = tempID;
-			entity = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(obj.ToString());
-
-			return tempID;
-		}
+		}	
 	}
 }

--- a/Kinvey.Core/Store/WriteRequest.cs
+++ b/Kinvey.Core/Store/WriteRequest.cs
@@ -11,6 +11,7 @@
 // Unauthorized reproduction, transmission or distribution of this file and its
 // contents is a violation of applicable laws.
 
+using Newtonsoft.Json.Linq;
 using System;
 using System.Threading.Tasks;
 
@@ -31,5 +32,17 @@ namespace Kinvey
 			this.SyncQueue = queue;
 			this.Policy = policy;
 		}
-	}
+
+        protected string PrepareCacheSave(ref T entity)
+        {
+            string guid = System.Guid.NewGuid().ToString();
+            string tempID = "temp_" + guid;
+
+            JObject obj = JObject.FromObject(entity);
+            obj["_id"] = tempID;
+            entity = Newtonsoft.Json.JsonConvert.DeserializeObject<T>(obj.ToString());
+
+            return tempID;
+        }
+    }
 }

--- a/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
+++ b/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
@@ -124,6 +124,11 @@ namespace Kinvey
 		ERROR_DATASTORE_WHERE_CLAUSE_IS_ABSENT_IN_QUERY,
 
         /// <summary>
+        /// Error due to using not compatible Kinvey api version.
+        /// </summary>
+        ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION,
+
+        /// <summary>
         /// Error due to attempting a file metadata operation without a file ID.
         /// </summary>
         ERROR_FILE_MISSING_FILE_ID,

--- a/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
+++ b/Kinvey.Core/Troubleshooting/EnumErrorCode.cs
@@ -28,10 +28,15 @@ namespace Kinvey
 		/// </summary>
 		ERROR_DATASTORE_CACHE_SAVE_INSERT_ENTITY,
 
-		/// <summary>
-		/// Error saving the permanent entity ID in the local cache.
-		/// </summary>
-		ERROR_DATASTORE_CACHE_SAVE_UPDATE_ID,
+        /// <summary>
+        /// Error of multiple saving entities to the local cache.
+        /// </summary>
+        ERROR_DATASTORE_CACHE_MULTIPLE_SAVE,
+
+        /// <summary>
+        /// Error saving the permanent entity ID in the local cache.
+        /// </summary>
+        ERROR_DATASTORE_CACHE_SAVE_UPDATE_ID,
 
 		/// <summary>
 		/// Error saving an updated entity in the local cache.
@@ -127,6 +132,16 @@ namespace Kinvey
         /// Error due to using not compatible Kinvey api version.
         /// </summary>
         ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION,
+
+        /// <summary>
+        /// Error due to using an empty array of entities.
+        /// </summary>
+        ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES,
+
+        /// <summary>
+        /// Error due to exceeding of entities count limit.
+        /// </summary>
+        ERROR_DATASTORE_LIMIT_OF_ENTITIES_TO_BE_SAVED,
 
         /// <summary>
         /// Error due to attempting a file metadata operation without a file ID.

--- a/Kinvey.Core/Troubleshooting/KinveyException.cs
+++ b/Kinvey.Core/Troubleshooting/KinveyException.cs
@@ -316,7 +316,13 @@ namespace Kinvey
 					description = "Error in inserting new entity cache with temporary ID.";
 					break;
 
-				case EnumErrorCode.ERROR_DATASTORE_CACHE_SAVE_UPDATE_ENTITY:
+                case EnumErrorCode.ERROR_DATASTORE_CACHE_MULTIPLE_SAVE:
+                    error = "An exception was thrown while trying to save multiple entities to the cache.";
+                    debug = "";
+                    description = "An error in multiple inserting new entities or updating existing ones.";
+                    break;
+
+                case EnumErrorCode.ERROR_DATASTORE_CACHE_SAVE_UPDATE_ENTITY:
 					error = "An exception was thrown while trying to update an entity in the cache.";
 					debug = "";
 					description = "Error in updating an existing entity in the cache.";
@@ -374,6 +380,18 @@ namespace Kinvey
                     error = "Not compatible Kinvey api version.";
                     debug = "";
                     description = "The current functionality is not compatible with the existing Kinvey api version.";
+                    break;
+
+                case EnumErrorCode.ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES:
+                    error = "An empty array of entities.";
+                    debug = "";
+                    description = "An array of entities to be saved must not be empty.";
+                    break;
+
+                case EnumErrorCode.ERROR_DATASTORE_LIMIT_OF_ENTITIES_TO_BE_SAVED:
+                    error = "Entities count limit was exceeded.";
+                    debug = "";
+                    description = string.Concat("The current limit of entities count is ", Constants.NUMBER_LIMIT_OF_ENTITIES);
                     break;
 
                 case EnumErrorCode.ERROR_METHOD_NOT_IMPLEMENTED:

--- a/Kinvey.Core/Troubleshooting/KinveyException.cs
+++ b/Kinvey.Core/Troubleshooting/KinveyException.cs
@@ -370,7 +370,13 @@ namespace Kinvey
 					description = "Error while trying to clear data in the cache based on a query.  No data was deleted from the cache.";
 					break;
 
-				case EnumErrorCode.ERROR_METHOD_NOT_IMPLEMENTED:
+                case EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION:
+                    error = "Not compatible Kinvey api version.";
+                    debug = "";
+                    description = "The current functionality is not compatible with the existing Kinvey api version.";
+                    break;
+
+                case EnumErrorCode.ERROR_METHOD_NOT_IMPLEMENTED:
 					error = "An exception was thrown while trying to call a method that is not implemented.";
 					debug = "Consult the reference guides for information on supported methods for the given class.";
 					description = "The method being called on this class/object is not currently implemnted by the SDK.";

--- a/Kinvey.Core/Utils/HelperMethods.cs
+++ b/Kinvey.Core/Utils/HelperMethods.cs
@@ -97,5 +97,12 @@ namespace Kinvey
 			DateTime dateOfOrig = DateTime.Parse(date2);
 			return dateToCheck.CompareTo(dateOfOrig);
 		}
-	}
+
+        internal static List<T> Initialize<T>(T value, int count)
+        {
+            var list = new List<T>(count);
+            list.AddRange(Enumerable.Repeat(value, count));
+            return list;
+        }
+    }
 }

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -112,5 +112,8 @@ namespace Kinvey
         internal const string STR_ERROR_BACKEND_PARAMETER_VALUE_OUT_OF_RANGE = "ParameterValueOutOfRange";
 
         #endregion
+
+        //Limits
+        internal const int NUMBER_LIMIT_OF_ENTITIES = 100;
     }
 }

--- a/Kinvey.Shared/Kinvey.Shared.projitems
+++ b/Kinvey.Shared/Kinvey.Shared.projitems
@@ -161,8 +161,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\KinveyAuthSocialID.cs">
       <Link>Model\KinveyAuthSocialID.cs</Link>
     </Compile>
-	 <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\KinveyDataStoreResponse.cs">
-      <Link>Model\KinveyDataStoreResponse.cs</Link>
+	 <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\KinveyMultiInsertResponse.cs">
+      <Link>Model\KinveyMultiInsertResponse.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\KinveyDeleteResponse.cs">
       <Link>Model\KinveyDeleteResponse.cs</Link>

--- a/Kinvey.Shared/Kinvey.Shared.projitems
+++ b/Kinvey.Shared/Kinvey.Shared.projitems
@@ -137,6 +137,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\Entity.cs">
       <Link>Model\Entity.cs</Link>
     </Compile>
+	<Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\Error.cs">
+      <Link>Model\Error.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\GroupAggregationResults.cs">
       <Link>Model\GroupAggregationResults.cs</Link>
     </Compile>
@@ -157,6 +160,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\KinveyAuthSocialID.cs">
       <Link>Model\KinveyAuthSocialID.cs</Link>
+    </Compile>
+	 <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\KinveyDataStoreResponse.cs">
+      <Link>Model\KinveyDataStoreResponse.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\KinveyDeleteResponse.cs">
       <Link>Model\KinveyDeleteResponse.cs</Link>
@@ -271,6 +277,9 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Store\RemoveRequest.cs">
       <Link>Store\RemoveRequest.cs</Link>
+    </Compile>
+	 <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Store\MultiInsertRequest.cs">
+      <Link>Store\MultiInsertRequest.cs</Link>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Store\SaveRequest.cs">
       <Link>Store\SaveRequest.cs</Link>

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -12,6 +12,7 @@
             public const string ContractsCollection = "contracts";
         }
 
+
         public static class Exceptions
         {
             public const string GeneralExceptionTitle = "General exception";

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -5702,7 +5702,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(3);
+                MockResponses(1);
             }
 
             // Arrange
@@ -5854,7 +5854,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(6);
+                MockResponses(3);
             }
 
             // Arrange

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -5702,7 +5702,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(4);
+                MockResponses(3);
             }
 
             // Arrange
@@ -5854,7 +5854,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(9);
+                MockResponses(6);
             }
 
             // Arrange

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -1,6 +1,7 @@
 ﻿
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -5625,6 +5626,400 @@ namespace Kinvey.Tests
             Assert.AreEqual(savedItem.DueDate, existingItemCache.DueDate);
         }
 
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsConnectionAvailableAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(4);
+            }
+
+            // Arrange
+            var user = await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var autoToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var syncToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var savedToDos = await autoToDoStore.SaveAsync(toDos);
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDos = await syncToDoStore.FindAsync();
+
+            // Teardown
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[1].ID);
+
+            // Assert
+            Assert.AreEqual(2, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.AreEqual(user.Id, savedToDos.Entities[0].Acl.Creator);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.AreEqual(user.Id, savedToDos.Entities[1].Acl.Creator);
+            Assert.AreEqual(0, pendingWriteActions.Count);
+            Assert.AreEqual(2, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e=> e.ID == savedToDos.Entities[0].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsConnectionIssueAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(4);
+            }
+
+            // Arrange
+            var user = await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var autoToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var syncToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            SetRootUrlToKinveyClient(unreachableUrl);
+
+            var savedToDos = await autoToDoStore.SaveAsync(toDos);
+
+            SetRootUrlToKinveyClient(kinveyUrl);
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDos = await syncToDoStore.FindAsync();
+
+            // Teardown
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[1].ID);
+           
+            // Assert
+            Assert.AreEqual(2, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.IsNull(savedToDos.Entities[0].Acl);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.IsNull(savedToDos.Entities[1].Acl);
+            Assert.AreEqual(2, pendingWriteActions.Count);
+            var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
+            Assert.IsNotNull(pendingWriteAction1);
+            Assert.AreEqual("POST", pendingWriteAction1.action);
+            var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+            Assert.IsNotNull(pendingWriteAction2);
+            Assert.AreEqual("POST", pendingWriteAction2.action);
+            Assert.AreEqual(2, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[0].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsExistingItemsConnectionAvailableAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(9);
+            }
+
+            // Arrange
+            var user = await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var autoToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var syncToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
+            toDo1 = await autoToDoStore.SaveAsync(toDo1);
+            toDo1.Name = "Name33";
+            toDo1.Details = "Details33";
+            toDo1.Value = 33;
+            toDos.Add(toDo1);
+
+            var toDo2 = new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name4", Details = "Details4", Value = 4 };
+            toDos.Add(toDo2);
+
+            // Act
+            var savedToDos = await autoToDoStore.SaveAsync(toDos);
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDos = await syncToDoStore.FindAsync();
+
+            // Teardown
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[1].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[2].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[3].ID);
+
+            // Assert
+            Assert.AreEqual(4, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.AreEqual(user.Id, savedToDos.Entities[0].Acl.Creator);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.AreEqual(user.Id, savedToDos.Entities[1].Acl.Creator);
+            Assert.AreEqual(toDos[2].ID, savedToDos.Entities[2].ID);
+            Assert.AreEqual(toDos[2].Name, savedToDos.Entities[2].Name);
+            Assert.AreEqual(toDos[2].Details, savedToDos.Entities[2].Details);
+            Assert.AreEqual(toDos[2].Value, savedToDos.Entities[2].Value);
+            Assert.AreEqual(user.Id, savedToDos.Entities[2].Acl.Creator);
+            Assert.AreEqual(toDos[3].ID, savedToDos.Entities[3].ID);
+            Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
+            Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
+            Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
+            Assert.AreEqual(user.Id, savedToDos.Entities[3].Acl.Creator);
+            Assert.AreEqual(0, pendingWriteActions.Count);
+            Assert.AreEqual(4, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[0].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[2].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[3].ID));
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsExistingItemsConnectionIssueAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(9);
+            }
+
+            // Arrange
+            var user = await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var autoToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var syncToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
+            toDo1 = await autoToDoStore.SaveAsync(toDo1);
+            toDo1.Name = "Name33";
+            toDo1.Details = "Details33";
+            toDo1.Value = 33;
+            toDos.Add(toDo1);
+
+            var toDo2 = new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name4", Details = "Details4", Value = 4 };
+            toDos.Add(toDo2);
+
+            // Act
+            SetRootUrlToKinveyClient(unreachableUrl);
+
+            var savedToDos = await autoToDoStore.SaveAsync(toDos);
+
+            SetRootUrlToKinveyClient(kinveyUrl);
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDos = await syncToDoStore.FindAsync();
+
+            // Teardown
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[1].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[2].ID);
+            await autoToDoStore.RemoveAsync(savedToDos.Entities[3].ID);
+
+            // Assert
+            Assert.AreEqual(4, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.IsNull(savedToDos.Entities[0].Acl);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.IsNull(savedToDos.Entities[1].Acl);
+            Assert.AreEqual(toDos[2].ID, savedToDos.Entities[2].ID);
+            Assert.AreEqual(toDos[2].Name, savedToDos.Entities[2].Name);
+            Assert.AreEqual(toDos[2].Details, savedToDos.Entities[2].Details);
+            Assert.AreEqual(toDos[2].Value, savedToDos.Entities[2].Value);
+            Assert.AreEqual(user.Id, savedToDos.Entities[2].Acl.Creator);
+            Assert.AreEqual(toDos[3].ID, savedToDos.Entities[3].ID);
+            Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
+            Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
+            Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
+            Assert.IsNull(savedToDos.Entities[3].Acl);
+            Assert.AreEqual(4, pendingWriteActions.Count);
+            var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
+            Assert.IsNotNull(pendingWriteAction1);
+            Assert.AreEqual("POST", pendingWriteAction1.action);
+            var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+            Assert.IsNotNull(pendingWriteAction2);
+            Assert.AreEqual("POST", pendingWriteAction2.action);
+            var pendingWriteAction3 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[2].ID);
+            Assert.IsNotNull(pendingWriteAction3);
+            Assert.AreEqual("PUT", pendingWriteAction3.action);
+            var pendingWriteAction4 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[3].ID);
+            Assert.IsNotNull(pendingWriteAction4);
+            Assert.AreEqual("PUT", pendingWriteAction4.action);
+            Assert.AreEqual(4, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[0].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[2].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[3].ID));
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertEmptyArrayAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStore.SaveAsync(new List<ToDo>());
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES, kinveyException.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertCount101Async()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+
+            var toDos = new List<ToDo>();
+
+            for (var index = 0; index < 101; index++)
+            {
+                toDos.Add(new ToDo { Name = "Name" + index.ToString(), Details = "Details" + index.ToString(), Value = 0 });
+            }
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStore.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_LIMIT_OF_ENTITIES_TO_BE_SAVED, kinveyException.ErrorCode);
+        }
+
+       
         #endregion Save
 
         #region Get count

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -5525,36 +5525,54 @@ namespace Kinvey.Tests
 
                 kinveyClient = builder.Build();
 
-                MockResponses(3);
+                MockResponses(8);
 
                 // Arrange
                 await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
                 var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 
-                var toDos = new List<ToDo>
-                {
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 },
-                    new ToDo { Name = "Name2", Details = "Details2", Value = 2 },
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 }
-                };
+                var toDos = new List<ToDo>();
+                                                          
+                var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
+                toDo1 = await todoStoreNetwork.SaveAsync(toDo1);
+                toDo1.Name = TestSetup.entity_with_error;
+                toDo1.Details = "Details33";
+                toDo1.Value = 33;
+
+                toDos.Add(toDo1);
+                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 });
+                toDos.Add(toDo1);
+                toDos.Add(new ToDo { Name = "Name2", Details = "Details2", Value = 2 });
+                toDos.Add(toDo1);
+                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 });
+                toDos.Add(toDo1);
 
                 // Act
                 var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Teardown
-                await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
+                await todoStoreNetwork.RemoveAsync(savedToDos.Entities[3].ID);
 
                 // Assert
-                Assert.AreEqual(3, savedToDos.Entities.Count);
-                Assert.AreEqual(2, savedToDos.Errors.Count);
+                Assert.AreEqual(7, savedToDos.Entities.Count);
+                Assert.AreEqual(6, savedToDos.Errors.Count);
                 Assert.IsNull(savedToDos.Entities[0]);
-                Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
-                Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
-                Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+                Assert.IsNull(savedToDos.Entities[1]);
                 Assert.IsNull(savedToDos.Entities[2]);
+                Assert.IsNotNull(savedToDos.Entities[3]);               
+                Assert.IsNull(savedToDos.Entities[4]);
+                Assert.IsNull(savedToDos.Entities[5]);
+                Assert.IsNull(savedToDos.Entities[6]);
+                Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
+                Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
+                Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);                
                 Assert.AreEqual(0, savedToDos.Errors[0].Index);
-                Assert.AreEqual(2, savedToDos.Errors[1].Index);
+                Assert.AreEqual(1, savedToDos.Errors[1].Index);
+                Assert.AreEqual(2, savedToDos.Errors[2].Index);
+                Assert.AreEqual(4, savedToDos.Errors[3].Index);
+                Assert.AreEqual(5, savedToDos.Errors[4].Index);
+                Assert.AreEqual(6, savedToDos.Errors[5].Index);
             }
         }
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -5268,5 +5268,347 @@ namespace Kinvey.Tests
             Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_NETWORK, kinveyException.ErrorCategory);
             Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_INVALID_PURGE_OPERATION, kinveyException.ErrorCode);
         }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(4);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+            // Teardown
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
+
+            // Assert
+            Assert.AreEqual(2, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsExistingItemsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(9);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
+            toDo1 = await todoStoreNetwork.SaveAsync(toDo1);
+            toDo1.Name = "Name33";
+            toDo1.Details = "Details33";
+            toDo1.Value = 33;
+            toDos.Add(toDo1);
+
+            var toDo2 = new ToDo { ID = Guid.NewGuid().ToString() , Name = "Name4", Details = "Details4", Value = 4 };
+            toDos.Add(toDo2);
+
+            // Act
+            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+            // Teardown
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[2].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[3].ID);
+
+            // Assert
+            Assert.AreEqual(4, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.AreEqual(toDos[2].Name, savedToDos.Entities[2].Name);
+            Assert.AreEqual(toDos[2].Details, savedToDos.Entities[2].Details);
+            Assert.AreEqual(toDos[2].Value, savedToDos.Entities[2].Value);
+            Assert.AreEqual(toDos[3].ID, savedToDos.Entities[3].ID);
+            Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
+            Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
+            Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertEmptyArrayAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(new List<ToDo>());
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(504, kinveyException.StatusCode);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertCount101Async()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>();
+
+            for(var index = 0; index <101; index++)
+            {
+                toDos.Add(new ToDo { Name = "Name" + index.ToString(), Details = "Details" + index.ToString(), Value = 0 });
+            }
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(413, kinveyException.StatusCode);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+        }
+
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("4");
+
+            kinveyClient = builder.Build();
+            
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, kinveyException.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsExistingItemsWithErrorsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 },
+                new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 }
+            };
+
+            // Act
+            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+            // Teardown
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
+
+            // Assert
+            Assert.AreEqual(3, savedToDos.Entities.Count);
+            Assert.AreEqual(2, savedToDos.Errors.Count);
+            Assert.IsNull(savedToDos.Entities[0]);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.IsNull(savedToDos.Entities[2]);
+            Assert.AreEqual(0, savedToDos.Errors[0].Index);
+            Assert.AreEqual(2, savedToDos.Errors[1].Index);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertThrowingExceptionAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 },
+                new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 }
+            };
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(500, kinveyException.StatusCode);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+        }
     }
 }

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -5640,6 +5640,9 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoStore.SaveAsync(toDos);
 
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(collectionName).GetAll();
+            var existingToDos = await todoStore.FindAsync();
+
             // Teardown
             await todoStore.RemoveAsync(savedToDos.Entities[0].ID);
             await todoStore.RemoveAsync(savedToDos.Entities[1].ID);
@@ -5653,6 +5656,16 @@ namespace Kinvey.Tests
             Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
             Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
             Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.AreEqual(2, pendingWriteActions.Count);
+            Assert.AreEqual(2, existingToDos.Count);
+            var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
+            Assert.IsNotNull(pendingWriteAction1);
+            Assert.AreEqual("POST", pendingWriteAction1.action);
+            var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+            Assert.IsNotNull(pendingWriteAction2);
+            Assert.AreEqual("POST", pendingWriteAction2.action);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[0].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
         }
 
         [TestMethod]
@@ -5699,6 +5712,9 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoStore.SaveAsync(toDos);
 
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(collectionName).GetAll();
+            var existingToDos = await todoStore.FindAsync();
+
             // Teardown
             await todoStore.RemoveAsync(savedToDos.Entities[0].ID);
             await todoStore.RemoveAsync(savedToDos.Entities[1].ID);
@@ -5721,6 +5737,24 @@ namespace Kinvey.Tests
             Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
             Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
             Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
+            Assert.AreEqual(4, pendingWriteActions.Count);
+            var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
+            Assert.IsNotNull(pendingWriteAction1);
+            Assert.AreEqual("POST", pendingWriteAction1.action);
+            var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+            Assert.IsNotNull(pendingWriteAction2);
+            Assert.AreEqual("POST", pendingWriteAction2.action);
+            var pendingWriteAction3 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[2].ID);
+            Assert.IsNotNull(pendingWriteAction3);
+            Assert.AreEqual("POST", pendingWriteAction3.action);
+            var pendingWriteAction4 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[3].ID);
+            Assert.IsNotNull(pendingWriteAction4);
+            Assert.AreEqual("PUT", pendingWriteAction4.action);
+            Assert.AreEqual(4, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[0].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[2].ID));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[3].ID));
         }
 
         [TestMethod]
@@ -5885,6 +5919,9 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoStore.SaveAsync(toDos);
 
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(collectionName).GetAll();
+            var existingToDos = await todoStore.FindAsync();
+
             // Teardown
             await todoStore.RemoveAsync(savedToDos.Entities[1].ID);
 
@@ -5898,6 +5935,12 @@ namespace Kinvey.Tests
             Assert.IsNull(savedToDos.Entities[2]);
             Assert.AreEqual(0, savedToDos.Errors[0].Index);
             Assert.AreEqual(2, savedToDos.Errors[1].Index);
+            Assert.AreEqual(1, pendingWriteActions.Count);
+            var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+            Assert.IsNotNull(pendingWriteAction1);
+            Assert.AreEqual("POST", pendingWriteAction1.action);
+            Assert.AreEqual(1, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
         }
 
         [TestMethod]

--- a/Kinvey.Tests/Support Files/Code/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/Code/TestSetup.cs
@@ -30,6 +30,8 @@ namespace Kinvey.Tests
         public const string auth_token_for_401_response_fake = "eda5d4bc-6a47-46d2-9637-07dec479bf9c";
         public const string refresh_token_for_401_response_fake = "0f550503-f033-44ee-8c2d-ae8f9773b70a";
 
+        public const string entity_with_error = "Entity with error";
+
         public const string mic_id_fake = "ade8db71f61c46a69c91910d8fbf3994";
 
         public static string db_dir = Environment.CurrentDirectory;


### PR DESCRIPTION
#### Description
Implementing multi-record insert feature

#### Changes
Adding overloaded version of the "Save()" method in the Data Store.

#### Tests
NETWORK:
TestSaveMultiInsertNewItemsAsync()
TestSaveMultiInsertNewItemsExistingItemsAsync()
TestSaveMultiInsertEmptyArrayAsync()
TestSaveMultiInsertCount101Async()
TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
TestSaveMultiInsertNewItemsExistingItemsWithErrorsAsync()
TestSaveMultiInsertThrowingExceptionAsync()

SYNC:
TestSyncStoreSaveMultiInsertNewItemsAsync()
TestSyncStoreSaveMultiInsertNewItemsExistingItemsAsync()
TestSyncStoreSaveMultiInsertEmptyArrayAsync()
TestSyncStoreSaveMultiInsertCount101Async()
 TestSyncStoreSaveMultiInsertIncorrectKinveyApiVersionAsync()
TestSyncStoreSaveMultiInsertNewItemsExistingItemsWithErrorsAsync()
TestSyncStoreSaveMultiInsertThrowingExceptionAsync()

AUTO:
TestSaveMultiInsertNewItemsConnectionAvailableAsync()
TestSaveMultiInsertNewItemsConnectionIssueAsync()
TestSaveMultiInsertNewItemsExistingItemsConnectionAvailableAsync()
TestSaveMultiInsertNewItemsExistingItemsConnectionIssueAsync()
TestSaveMultiInsertEmptyArrayAsync()
TestSaveMultiInsertCount101Async()
TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
TestSaveMultiInsertThrowingNetworkExceptionAsync()
TestSaveMultiInsertNewItemsExistingItemsWithErrorsConnectionAvailableAsync()
TestSaveMultiInsertThrowingLocalExceptionAsync()


