### PR TITLE
MLIBZ-3020:Implement test set for multi-record insert

### DIFF
--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -137,12 +137,33 @@ namespace Kinvey
                     {
                         for (var index = 0; index < kinveyDataStoreResponse.Entities.Count; index++)
                         {
-                            if (kinveyDataStoreResponse.Entities[index] != null && kinveyDataStoreNetworkResponse.Entities[index] != null)
+                            if (kinveyDataStoreNetworkResponse.Entities[index] != null)
+                            {                               
+                                if (kinveyDataStoreResponse.Entities[index] != null)
+                                {
+                                    var obj = JObject.FromObject(kinveyDataStoreResponse.Entities[index]);
+                                    var id = obj["_id"].ToString();
+                                    Cache.UpdateCacheSave(kinveyDataStoreNetworkResponse.Entities[index], id);
+                                }
+                                else
+                                {
+                                    CacheSave(kinveyDataStoreNetworkResponse.Entities[index]);
+                                }
+                            }
+                            else
                             {
-                                var obj = JObject.FromObject(kinveyDataStoreResponse.Entities[index]);
-                                var id = obj["_id"].ToString();
+                                if (kinveyDataStoreResponse.Entities[index] != null)
+                                {
+                                    var obj = JObject.FromObject(kinveyDataStoreResponse.Entities[index]);
+                                    var id = obj["_id"].ToString();
 
-                                Cache.UpdateCacheSave(kinveyDataStoreNetworkResponse.Entities[index], id);
+                                    var existingPendingWriteAction = pendingWriteActions.Find(e => e.entityId.Equals(id));
+
+                                    if (existingPendingWriteAction!= null)
+                                    {
+                                        SyncQueue.Enqueue(existingPendingWriteAction);
+                                    }
+                                }
                             }
                         }
 

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -223,8 +223,17 @@ namespace Kinvey
                 }
             }
 
-            var multiInsertRequest = Client.NetworkFactory.BuildMultiInsertRequest<T, KinveyMultiInsertResponse<T>>(Collection, entitiesToMultiInsert);
-            var multiInsertKinveyDataStoreResponse = await multiInsertRequest.ExecuteAsync();
+            var multiInsertKinveyDataStoreResponse = new KinveyMultiInsertResponse<T>
+            {
+                Entities = new List<T>(),
+                Errors = new List<Error>()
+            };
+
+            if (entitiesToMultiInsert.Count > 0)
+            {
+                var multiInsertRequest = Client.NetworkFactory.BuildMultiInsertRequest<T, KinveyMultiInsertResponse<T>>(Collection, entitiesToMultiInsert);
+                multiInsertKinveyDataStoreResponse = await multiInsertRequest.ExecuteAsync();
+            }
 
             for (var index = 0; index < multiInsertKinveyDataStoreResponse.Entities.Count; index++)
             {

--- a/Kinvey.Core/Store/PushRequest.cs
+++ b/Kinvey.Core/Store/PushRequest.cs
@@ -145,7 +145,9 @@ namespace Kinvey
 				NetworkRequest<T> request = Client.NetworkFactory.buildUpdateRequest<T>(pwa.collection, entity, pwa.entityId);
 				entity = await request.ExecuteAsync();
 
-				result = SyncQueue.Remove(pwa);
+                Cache.UpdateCacheSave(entity, pwa.entityId);
+
+                result = SyncQueue.Remove(pwa);
 
 				if (result == 0)
 				{

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -20,5 +20,6 @@
             public const string RequiredFieldsTitle = "Required fields!";
             public const string RequiredFieldsMessage = "Title and Number are required fields.";
         }
+
     }
 }

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -847,7 +847,7 @@ namespace Kinvey.Tests
                 httpListener.Prefixes.Add(client.MICHostName);
             }
             httpListener.Start();
-            var thread = new Thread(new ThreadStart(() =>
+            var thread = new Thread(new ThreadStart(async () =>
             {
                 try
                 {
@@ -1069,11 +1069,15 @@ namespace Kinvey.Tests
                         HttpListenerContext context;
                         try
                         {
-                            context = httpListener.GetContext();
+                            context = await httpListener.GetContextAsync();
                         }
                         catch (HttpListenerException)
                         {
                             continue;
+                        }
+                        catch (System.ObjectDisposedException)
+                        {
+                            break;
                         }
 
                         count++;

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -454,8 +454,8 @@ namespace Kinvey.Tests
             if (jObjects.Count == 0)
             {
                 var response = context.Response;
-                response.StatusCode = 504;
-                Write(context, "Timeout");
+                response.StatusCode = 400;
+                Write(context, "Request body cannot be an empty array");
                 return;
             }
 
@@ -1091,10 +1091,6 @@ namespace Kinvey.Tests
                         catch (HttpListenerException)
                         {
                             continue;
-                        }
-                        catch (System.ObjectDisposedException)
-                        {
-                            break;
                         }
 
                         count++;

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -847,7 +847,7 @@ namespace Kinvey.Tests
                 httpListener.Prefixes.Add(client.MICHostName);
             }
             httpListener.Start();
-            var thread = new Thread(new ThreadStart(() => {
+            var thread = new Thread(new ThreadStart(async () => {
                 try
                 {
                     #region Existing users
@@ -1067,7 +1067,7 @@ namespace Kinvey.Tests
                         HttpListenerContext context;
                         try
                         {
-                            context = httpListener.GetContext();
+                            context = await httpListener.GetContextAsync();
                         }
                         catch (HttpListenerException)
                         {

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -58,6 +58,23 @@ namespace Kinvey.Tests
             }
         }
 
+        protected Client BuildClient(string apiVersion = null)
+        {
+            Client.Builder builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            if (!string.IsNullOrEmpty(apiVersion))
+            {
+                builder.SetApiVersion(apiVersion);
+            }
+
+            return builder.Build();
+        }
+
         public static class EnvironmentVariable
         {
             public static string AppKey => Environment.GetEnvironmentVariable("KINVEY_APP_KEY");

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -847,7 +847,8 @@ namespace Kinvey.Tests
                 httpListener.Prefixes.Add(client.MICHostName);
             }
             httpListener.Start();
-            var thread = new Thread(new ThreadStart(async () => {
+            var thread = new Thread(new ThreadStart(() =>
+            {
                 try
                 {
                     #region Existing users
@@ -1063,11 +1064,12 @@ namespace Kinvey.Tests
                     while (
                         (expectedRequests == null && httpListener.IsListening) ||
                         (expectedRequests != null && count < expectedRequests)
-                    ) {
+                    )
+                    {
                         HttpListenerContext context;
                         try
                         {
-                            context = await httpListener.GetContextAsync();
+                            context = httpListener.GetContext();
                         }
                         catch (HttpListenerException)
                         {

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -415,6 +415,14 @@ namespace Kinvey.Tests
                 return;
             }
 
+            if (obj["name"] != null && obj["name"].ToString().Equals(TestSetup.entity_with_error))
+            {
+                var response = context.Response;
+                response.StatusCode = 400;
+                Write(context, "Error.");
+                return;
+            }
+
             PopulateEntity(obj, client);
             items.Add(obj);
             Write(context, obj);

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -6443,7 +6443,7 @@ namespace Kinvey.Tests
             // Arrange
             await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
-            var todoStoreNetwork = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var todoStoreAuto = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
 
             var toDos = new List<ToDo>();
 
@@ -6453,12 +6453,12 @@ namespace Kinvey.Tests
             }
 
             // Act
-            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+            var savedToDos = await todoStoreAuto.SaveAsync(toDos);
 
-            var existingToDos = await todoStoreNetwork.FindAsync();
+            var existingToDos = await todoStoreAuto.FindAsync();
 
             //Teardown
-            await todoStoreNetwork.RemoveAsync(todoStoreNetwork.Where(e => e.Name.StartsWith("Name")));
+            await todoStoreAuto.RemoveAsync(todoStoreAuto.Where(e => e.Name.StartsWith("Name")));
 
             // Assert
             Assert.AreEqual(countOfEntities, savedToDos.Entities.Count);

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -6703,7 +6703,7 @@ namespace Kinvey.Tests
                 Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
                 Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
                 Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
-                Assert.AreEqual(0, pendingWriteActions.Count);
+                Assert.AreEqual(3, pendingWriteActions.Count);
                 Assert.AreEqual(0, savedToDos.Errors[0].Index);
                 Assert.AreEqual(1, savedToDos.Errors[1].Index);
                 Assert.AreEqual(2, savedToDos.Errors[2].Index);
@@ -7521,6 +7521,341 @@ namespace Kinvey.Tests
             Assert.AreEqual(2, networkEntities2.Count);
             Assert.AreEqual(newItem1.Name, networkEntities2.FirstOrDefault(e => e.ID == newItem1.ID).Name);
             Assert.AreEqual(newItem1.Details, networkEntities2.FirstOrDefault(e=> e.ID == newItem1.ID).Details);
+        }
+
+        [TestMethod]
+        public async Task TestPushNewItemsConnectionIssueAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(6);
+            }
+
+            // Arrange
+            var user = await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var autoToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var syncToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+            var networkToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            SetRootUrlToKinveyClient(unreachableUrl);
+            var savedToDos = await autoToDoStore.SaveAsync(toDos);
+            SetRootUrlToKinveyClient(kinveyUrl);
+
+            var pushResponse = await autoToDoStore.PushAsync();
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDosNetwork = await networkToDoStore.FindAsync();
+
+            // Teardown
+            await networkToDoStore.RemoveAsync(existingToDosNetwork[0].ID);
+            await networkToDoStore.RemoveAsync(existingToDosNetwork[1].ID);
+
+            // Assert
+            Assert.AreEqual(2, pushResponse.PushCount);
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value));
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value));
+
+            Assert.AreEqual(0, pendingWriteActions.Count);
+
+            Assert.AreEqual(2, existingToDosNetwork.Count);
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.ID == pushResponse.PushEntities[0].ID));
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.ID == pushResponse.PushEntities[1].ID));
+        }
+
+        [TestMethod]
+        public async Task TestPushNewItemsExistingItemsConnectionIssueAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(11);
+            }
+
+            // Arrange
+            var user = await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var autoToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var syncToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+            var networkToDoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+               
+            };
+
+            var toDo1 = new ToDo { Name = "Name1", Details = "Details1", Value = 1 };
+            toDos.Add(toDo1);
+
+            var toDo2 = new ToDo { Name = "Name2", Details = "Details2", Value = 2 };
+            toDo2 = await autoToDoStore.SaveAsync(toDo2);
+            toDo2.Name = "Name22";
+            toDo2.Details = "Details22";
+            toDo2.Value = 22;
+            toDos.Add(toDo2);
+
+            var toDo3 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
+            toDos.Add(toDo3);
+
+            var toDo4 = new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name4", Details = "Details4", Value = 4 };
+            toDos.Add(toDo4);
+
+            // Act
+            SetRootUrlToKinveyClient(unreachableUrl);
+            var savedToDos = await autoToDoStore.SaveAsync(toDos);
+            SetRootUrlToKinveyClient(kinveyUrl);
+
+            var pushResponse = await autoToDoStore.PushAsync();
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDosNetwork = await networkToDoStore.FindAsync();
+
+            // Teardown
+            await networkToDoStore.RemoveAsync(pushResponse.PushEntities[0].ID);
+            await networkToDoStore.RemoveAsync(pushResponse.PushEntities[1].ID);
+            await networkToDoStore.RemoveAsync(pushResponse.PushEntities[2].ID);
+            await networkToDoStore.RemoveAsync(pushResponse.PushEntities[3].ID);
+
+            // Assert
+            Assert.AreEqual(4, pushResponse.PushCount);
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value));
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value));
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value));
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[3].Name) && e.Details.Equals(toDos[3].Details) && e.Value == toDos[3].Value));
+
+            Assert.AreEqual(0, pendingWriteActions.Count);
+
+            Assert.AreEqual(4, existingToDosNetwork.Count);
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.ID == pushResponse.PushEntities[0].ID));
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.ID == pushResponse.PushEntities[1].ID));
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.ID == pushResponse.PushEntities[2].ID));
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.ID == pushResponse.PushEntities[3].ID));
+        }
+
+        //[TestMethod]
+        public async Task TestPushNewItemsInvalidPermissionsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            var todoSyncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+            var todoNetworkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK, kinveyClient);
+            var todoAutoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var savedToDos = await todoSyncStore.SaveAsync(toDos);
+
+            var pushResponse = await todoAutoStore.PushAsync();
+
+            //var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(collectionName).GetAll();
+            //var existingToDos = await todoSyncStore.FindAsync();
+
+            // Teardown
+            //await todoSyncStore.RemoveAsync(savedToDos.Entities[0].ID);
+            //await todoSyncStore.RemoveAsync(savedToDos.Entities[1].ID);
+
+            // Assert
+            Assert.AreEqual(2, pushResponse.PushCount);
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value));
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value));
+
+            Assert.AreEqual(2, pushResponse.KinveyExceptions.Count);
+            Assert.IsTrue(!pushResponse.KinveyExceptions.Any(e => e.StatusCode != 401));
+
+
+            //Assert.AreEqual(2, pendingWriteActions.Count);
+            //var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
+            //Assert.IsNotNull(pendingWriteAction1);
+            //Assert.AreEqual("POST", pendingWriteAction1.action);
+            //var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+            //Assert.IsNotNull(pendingWriteAction2);
+            //Assert.AreEqual("POST", pendingWriteAction2.action);
+
+            //Assert.AreEqual(2, existingToDos.Count);
+            //Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl == null && e.Kmd == null));
+            //Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
+        }
+
+        [TestMethod]
+        public async Task TestPushNewItemsWithErrorsAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+                builder.setBaseURL("http://localhost:8080");
+                builder.SetApiVersion("5");
+
+                kinveyClient = builder.Build();
+
+                MockResponses(6);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoAutoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+                var todoSyncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+                var todoNetworkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo { Name = "Name1", Details = "Details1", Value = 1, GeoLoc = "[200,200]" },
+                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details2", Value = 2 },
+                    new ToDo { Name = "Name3", Details = "Details3", Value = 3 }
+                };
+
+                // Act
+                SetRootUrlToKinveyClient(unreachableUrl);
+                var savedToDos = await todoAutoStore.SaveAsync(toDos);
+                SetRootUrlToKinveyClient(kinveyUrl);
+
+                var pushResponse = await todoAutoStore.PushAsync();
+
+                var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+                var existingToDosLocal = await todoSyncStore.FindAsync();
+                var existingToDosNetwork = await todoNetworkStore.FindAsync();
+
+                // Teardown
+                await todoNetworkStore.RemoveAsync(savedToDos.Entities[2].ID);
+
+                // Assert
+                Assert.AreEqual(3, pushResponse.PushCount);
+                Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value));
+                Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value));
+                Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value));
+
+                Assert.AreEqual(2, pushResponse.KinveyExceptions.Count);
+                Assert.IsTrue(!pushResponse.KinveyExceptions.Any(e => e.StatusCode != 400));
+
+                Assert.AreEqual(2, pendingWriteActions.Count);
+                var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
+                Assert.IsNotNull(pendingWriteAction1);
+                Assert.AreEqual("POST", pendingWriteAction1.action);
+                var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+                Assert.IsNotNull(pendingWriteAction2);
+                Assert.AreEqual("POST", pendingWriteAction2.action);
+
+                Assert.AreEqual(3, existingToDosLocal.Count);
+                Assert.IsNotNull(existingToDosLocal.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl == null && e.Kmd == null));
+                Assert.IsNotNull(existingToDosLocal.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
+                Assert.IsNotNull(existingToDosLocal.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value && e.Acl != null && e.Kmd != null && !string.IsNullOrEmpty(e.Kmd.entityCreationTime) && !string.IsNullOrEmpty(e.Kmd.lastModifiedTime)));
+
+                Assert.AreEqual(1, existingToDosNetwork.Count);
+                Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value));
+            }
+        }
+
+        [TestMethod]
+        public async Task TestPushNewSeparateItemsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(6);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoAutoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var todoSyncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+            var todoNetworkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK, kinveyClient);
+
+            var toDo1 = new ToDo { Name = "Name1", Details = "Details1", Value = 1 };
+            var toDo2 = new ToDo { Name = "Name2", Details = "Details2", Value = 2 };
+
+            // Act
+            SetRootUrlToKinveyClient(unreachableUrl);
+            toDo1 = await todoAutoStore.SaveAsync(toDo1);
+            toDo2 = await todoAutoStore.SaveAsync(toDo2);
+            SetRootUrlToKinveyClient(kinveyUrl);
+
+            var pushResponse = await todoAutoStore.PushAsync();
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDos = await todoNetworkStore.FindAsync();
+
+            // Teardown
+            await todoNetworkStore.RemoveAsync(toDo1.ID);
+            await todoNetworkStore.RemoveAsync(toDo2.ID);
+
+            // Assert
+            Assert.AreEqual(2, pushResponse.PushCount);
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDo1.Name) && e.Details.Equals(toDo1.Details) && e.Value == toDo1.Value));
+            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDo2.Name) && e.Details.Equals(toDo2.Details) && e.Value == toDo2.Value));
+            Assert.AreEqual(0, pushResponse.KinveyExceptions.Count);
+
+            Assert.AreEqual(0, pushResponse.KinveyExceptions.Count);
+
+            Assert.AreEqual(0, pendingWriteActions.Count);
+
+            Assert.AreEqual(2, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDo1.Name) && e.Details.Equals(toDo1.Details) && e.Value == toDo1.Value && e.Acl != null && e.Kmd != null && !string.IsNullOrEmpty(e.Kmd.entityCreationTime) && !string.IsNullOrEmpty(e.Kmd.lastModifiedTime)));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDo2.Name) && e.Details.Equals(toDo2.Details) && e.Value == toDo2.Value && e.Acl != null && e.Kmd != null && !string.IsNullOrEmpty(e.Kmd.entityCreationTime) && !string.IsNullOrEmpty(e.Kmd.lastModifiedTime)));
         }
 
         #endregion
@@ -9189,6 +9524,83 @@ namespace Kinvey.Tests
             Assert.AreEqual(3, firstResponse.PullResponse.PullCount);
             Assert.AreEqual(1, secondResponse.PullResponse.PullCount);
             Assert.AreEqual(1, deleteResponse.count);
+        }
+
+        [TestMethod]
+        public async Task TestSyncNewItemsWithErrorsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(7);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoAutoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
+            var todoSyncStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.SYNC, kinveyClient);
+            var todoNetworkStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2, GeoLoc = "[200,200]" },
+                new ToDo { Name = "Name3", Details = "Details3", Value = 3 }
+            };
+
+            // Act
+            SetRootUrlToKinveyClient(unreachableUrl);
+            var savedToDos = await todoAutoStore.SaveAsync(toDos);
+            SetRootUrlToKinveyClient(kinveyUrl);
+
+            var syncResponse = await todoAutoStore.SyncAsync();
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDosNetwork = await todoNetworkStore.FindAsync();
+            var existingToDosLocal = await todoSyncStore.FindAsync();
+
+            // Teardown
+            await todoNetworkStore.RemoveAsync(savedToDos.Entities[0].ID);
+            await todoNetworkStore.RemoveAsync(savedToDos.Entities[2].ID);
+
+            // Assert
+            Assert.AreEqual(3, syncResponse.PushResponse.PushCount);
+            Assert.IsNotNull(syncResponse.PushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value));
+            Assert.IsNotNull(syncResponse.PushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value));
+            Assert.IsNotNull(syncResponse.PushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value));
+
+            Assert.AreEqual(1, syncResponse.PullResponse.KinveyExceptions.Count);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_PULL_ONLY_ON_CLEAN_SYNC_QUEUE, syncResponse.PullResponse.KinveyExceptions[0].ErrorCode);
+            Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_NETWORK, syncResponse.PullResponse.KinveyExceptions[0].ErrorCategory);
+
+            Assert.AreEqual(1, syncResponse.PushResponse.KinveyExceptions.Count);
+            Assert.AreEqual(400, syncResponse.PushResponse.KinveyExceptions[0].StatusCode);
+
+            Assert.AreEqual(1, pendingWriteActions.Count);
+            var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
+            Assert.IsNotNull(pendingWriteAction1);
+            Assert.AreEqual("POST", pendingWriteAction1.action);
+
+            Assert.AreEqual(2, existingToDosNetwork.Count);
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value));
+            Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value));
+
+            Assert.AreEqual(3, existingToDosLocal.Count);
+            Assert.IsNotNull(existingToDosLocal.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl != null && e.Kmd != null && !string.IsNullOrEmpty(e.Kmd.entityCreationTime) && !string.IsNullOrEmpty(e.Kmd.lastModifiedTime)));
+            Assert.IsNotNull(existingToDosLocal.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
+            Assert.IsNotNull(existingToDosLocal.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value && e.Acl != null && e.Kmd != null && !string.IsNullOrEmpty(e.Kmd.entityCreationTime) && !string.IsNullOrEmpty(e.Kmd.lastModifiedTime)));
         }
 
         #endregion Sync

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -7840,8 +7840,8 @@ namespace Kinvey.Tests
             var existingToDos = await todoNetworkStore.FindAsync();
 
             // Teardown
-            await todoNetworkStore.RemoveAsync(toDo1.ID);
-            await todoNetworkStore.RemoveAsync(toDo2.ID);
+            await todoNetworkStore.RemoveAsync(existingToDos[0].ID);
+            await todoNetworkStore.RemoveAsync(existingToDos[1].ID);
 
             // Assert
             Assert.AreEqual(2, pushResponse.PushCount);
@@ -9572,8 +9572,8 @@ namespace Kinvey.Tests
             var existingToDosLocal = await todoSyncStore.FindAsync();
 
             // Teardown
-            await todoNetworkStore.RemoveAsync(savedToDos.Entities[0].ID);
-            await todoNetworkStore.RemoveAsync(savedToDos.Entities[2].ID);
+            await todoNetworkStore.RemoveAsync(existingToDosNetwork[0].ID);
+            await todoNetworkStore.RemoveAsync(existingToDosNetwork[1].ID);
 
             // Assert
             Assert.AreEqual(3, syncResponse.PushResponse.PushCount);

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -25,16 +25,6 @@ namespace Kinvey.Tests
         public override void Setup()
         {
             base.Setup();
-
-            Client.Builder builder = ClientBuilder
-                .SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            kinveyClient = builder.Build();
         }
 
         private void SetRootUrlToKinveyClient(string url)
@@ -49,6 +39,7 @@ namespace Kinvey.Tests
         public void TestCollectionWithDefaultParameters()
         {
             // Arrange
+            kinveyClient = BuildClient();
 
             // Act
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(toDosCollection);
@@ -63,6 +54,7 @@ namespace Kinvey.Tests
         public void TestCollectionWithParameters()
         {
             // Arrange
+            kinveyClient = BuildClient();
 
             // Act
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.AUTO, kinveyClient);
@@ -82,6 +74,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -144,6 +138,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDeleteItemsFromBackendAfterLocalDeletionConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -218,6 +214,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNoItemsToBeDeletedConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -276,6 +274,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -351,6 +351,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDeleteItemsFromLocalStorageAfterNetworkDeletionConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -429,6 +431,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryStringValueStartsWithExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -493,6 +497,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -585,6 +591,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryBoolValueExplicitEqualsExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -678,6 +686,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryBoolValueImplicitEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -770,6 +780,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueGreaterThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -868,6 +880,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueGreaterThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -966,6 +980,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueLessThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1065,6 +1081,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueLessThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1164,6 +1182,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueGreaterThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1263,6 +1283,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueGreaterThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1363,6 +1385,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueLessThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1463,6 +1487,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueLessThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1562,6 +1588,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueEqualsExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1661,6 +1689,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalAndExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1760,6 +1790,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalAndWithOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1861,6 +1893,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1961,6 +1995,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalOrWithAndExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -2061,6 +2097,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesStartsWithAndEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -2136,6 +2174,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -2211,6 +2251,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesDifferentEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -2287,6 +2329,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesFluentSyntaxEqualExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -2364,6 +2408,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesWithLogicalAndExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -2440,6 +2486,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesWithLogicalOrExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -2516,6 +2564,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryWhereClauseIsAbsentInQueryUsingSelectClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2581,6 +2631,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryWhereClauseIsAbsentInQueryUsingOrderClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2646,6 +2698,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryWhereClauseIsAbsentInQueryUsingTakeClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2711,6 +2765,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNullQueryAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2774,6 +2830,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNotSupportedExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2839,6 +2897,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNotSupportedStringExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2910,6 +2970,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByIdConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -2986,6 +3048,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByIdNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(4);
@@ -3038,6 +3102,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByIdNotExistingIdConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(2);
@@ -3079,6 +3145,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByIdDeleteItemsFromLocalStorageAfterNetworkDeletionConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3156,6 +3224,8 @@ namespace Kinvey.Tests
         public async Task TestRemoveByIdAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3, kinveyClient);
@@ -3191,6 +3261,8 @@ namespace Kinvey.Tests
         public async Task TestFindNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9, kinveyClient);
@@ -3257,6 +3329,8 @@ namespace Kinvey.Tests
         public async Task TestFindWithQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -3316,6 +3390,8 @@ namespace Kinvey.Tests
         public async Task TestFindWithSkipLimitQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -3375,6 +3451,8 @@ namespace Kinvey.Tests
         public async Task TestFindWithDeltaSetTurnOnNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(12, kinveyClient);
@@ -3450,6 +3528,8 @@ namespace Kinvey.Tests
         public async Task TestFindDescendingOrderNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -3505,6 +3585,8 @@ namespace Kinvey.Tests
         public async Task TestFindDeletingItemNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5, kinveyClient);
@@ -3551,6 +3633,8 @@ namespace Kinvey.Tests
         public async Task TestFindInvalidQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5, kinveyClient);
@@ -3601,6 +3685,8 @@ namespace Kinvey.Tests
         public async Task TestFindInvalidPermissionsNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(2, kinveyClient);
@@ -3628,6 +3714,8 @@ namespace Kinvey.Tests
         public async Task TestFindNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -3686,6 +3774,8 @@ namespace Kinvey.Tests
         public async Task TestFindNetworkConnectionEliminatedAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -3757,6 +3847,8 @@ namespace Kinvey.Tests
         public async Task TestFindWithQueryNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -3818,6 +3910,8 @@ namespace Kinvey.Tests
         public async Task TestFindSkip1Take1NetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -3879,6 +3973,8 @@ namespace Kinvey.Tests
         public async Task TestFindDescendingOrderNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -3939,6 +4035,8 @@ namespace Kinvey.Tests
         public async Task TestFindWithDeltaSetTurnOnNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -3990,6 +4088,8 @@ namespace Kinvey.Tests
         public async Task TestFindDeletedItemNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7, kinveyClient);
@@ -4055,6 +4155,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -4103,6 +4205,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQueryNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -4154,6 +4258,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQueryTake1NetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -4199,6 +4305,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQueryTake1NetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -4247,6 +4355,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQuerySkip1NetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -4292,6 +4402,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQuerySkip1NetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -4340,6 +4452,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQuerySkip1Take1NetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -4394,6 +4508,8 @@ namespace Kinvey.Tests
         public async Task TestFindByQuerySkip1Take1NetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -4455,6 +4571,8 @@ namespace Kinvey.Tests
         public async Task TestFindByIDExistingItemNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -4509,6 +4627,8 @@ namespace Kinvey.Tests
         public async Task TestFindByIDNotExistingItemNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(4, kinveyClient);
@@ -4563,6 +4683,8 @@ namespace Kinvey.Tests
         public async Task TestFindByIDInvalidPermissionsNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(2, kinveyClient);
@@ -4590,6 +4712,8 @@ namespace Kinvey.Tests
         public async Task TestFindByIDExistingItemNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -4646,6 +4770,8 @@ namespace Kinvey.Tests
         public async Task TestFindByIDDeletedItemNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -4729,6 +4855,8 @@ namespace Kinvey.Tests
         public async Task TestFindByIDNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(4, kinveyClient);
@@ -4766,6 +4894,8 @@ namespace Kinvey.Tests
         public async Task TestFindByIDNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -4810,6 +4940,8 @@ namespace Kinvey.Tests
         public async Task TestGetSumNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -4862,6 +4994,8 @@ namespace Kinvey.Tests
         public async Task TestGetSumNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -4917,6 +5051,8 @@ namespace Kinvey.Tests
         public async Task TestGetMinNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -4967,6 +5103,8 @@ namespace Kinvey.Tests
         public async Task TestGetMinNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -5020,6 +5158,8 @@ namespace Kinvey.Tests
         public async Task TestGetMaxNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -5070,6 +5210,8 @@ namespace Kinvey.Tests
         public async Task TestGetMaxNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -5123,6 +5265,8 @@ namespace Kinvey.Tests
         public async Task TestGetAverageNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10, kinveyClient);
@@ -5181,6 +5325,8 @@ namespace Kinvey.Tests
         public async Task TestGetAverageNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -5246,6 +5392,8 @@ namespace Kinvey.Tests
         public async Task TestSaveCreatingItemWithoutProvidedIdNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(4, kinveyClient);
@@ -5292,6 +5440,8 @@ namespace Kinvey.Tests
         public async Task TestSaveCreatingItemWithProvidedIdNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(4, kinveyClient);
@@ -5342,6 +5492,8 @@ namespace Kinvey.Tests
         public async Task TestSaveUpdatingItemWithExistingIdNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5, kinveyClient);
@@ -5384,6 +5536,8 @@ namespace Kinvey.Tests
         public async Task TestSaveDataNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -5425,6 +5579,8 @@ namespace Kinvey.Tests
         public async Task TestSaveInvalidPermissionsNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(2, kinveyClient);
@@ -5459,6 +5615,8 @@ namespace Kinvey.Tests
         public async Task TestSaveDataAndPushNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -5520,6 +5678,8 @@ namespace Kinvey.Tests
         public async Task TestSaveUpdatingDataAndPushNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5, kinveyClient);
@@ -5587,6 +5747,8 @@ namespace Kinvey.Tests
         public async Task TestSaveAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(4, kinveyClient);
@@ -5630,16 +5792,7 @@ namespace Kinvey.Tests
         public async Task TestSaveCreateVersion5ConnectionAvailableAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5693,16 +5846,7 @@ namespace Kinvey.Tests
         public async Task TestSaveCreateVersion5ConnectionIssueAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5756,16 +5900,7 @@ namespace Kinvey.Tests
         public async Task TestSaveUpdateVersion5ConnectionAvailableAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5820,16 +5955,7 @@ namespace Kinvey.Tests
         public async Task TestSaveUpdateVersion5ConnectionIssueAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5885,16 +6011,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertNewItemsConnectionAvailableAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5949,16 +6066,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertNewItemsConnectionIssueAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6018,16 +6126,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertExistingItemsConnectionAvailableAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6082,16 +6181,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertNewItemsExistingItemsConnectionAvailableAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6174,16 +6264,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertNewItemsExistingItemsConnectionIssueAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6273,16 +6354,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertEmptyArrayAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6314,16 +6386,7 @@ namespace Kinvey.Tests
         public async Task TestSaveInvalidPermissionsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6378,16 +6441,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertCount101Async()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6424,16 +6478,8 @@ namespace Kinvey.Tests
         {
             // Setup
             const int countOfEntities = 100;
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
 
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6471,16 +6517,8 @@ namespace Kinvey.Tests
         {
             // Setup
             const int countOfEntities = 100;
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
 
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6523,16 +6561,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("4");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("4");
 
             if (MockData)
             {
@@ -6569,11 +6598,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(2);
 
@@ -6607,16 +6632,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertNewItemsWithErrorsConnectionAvailableAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6677,11 +6693,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(6);
 
@@ -6750,11 +6762,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(8);
 
@@ -6819,16 +6827,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertThrowingLocalExceptionAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6866,6 +6865,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountAllItemsNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9, kinveyClient);
@@ -6924,6 +6925,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountByQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -6979,6 +6982,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountInvalidQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5, kinveyClient);
@@ -7029,6 +7034,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountAllItemsNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -7089,6 +7096,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountInvalidPermissionsNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(2, kinveyClient);
@@ -7116,6 +7125,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -7168,6 +7179,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -7223,6 +7236,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountWithQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -7277,6 +7292,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountWithQueryNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -7338,6 +7355,8 @@ namespace Kinvey.Tests
         public async Task TestPushCreatedDataNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -7387,6 +7406,8 @@ namespace Kinvey.Tests
         public async Task TestPushUpdatedDataNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -7446,6 +7467,8 @@ namespace Kinvey.Tests
         public async Task TestPushDeletedDataNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9, kinveyClient);
@@ -7513,6 +7536,8 @@ namespace Kinvey.Tests
         public async Task TestPushCreatedDataNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -7569,6 +7594,8 @@ namespace Kinvey.Tests
         public async Task TestPushRecreatedDataNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9, kinveyClient);
@@ -7627,16 +7654,7 @@ namespace Kinvey.Tests
         public async Task TestPushNewItemsConnectionIssueAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -7686,16 +7704,7 @@ namespace Kinvey.Tests
         public async Task TestPushNewItemsExistingItemsConnectionIssueAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -7766,16 +7775,7 @@ namespace Kinvey.Tests
         public async Task TestPushNewItemsInvalidPermissionsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -7835,11 +7835,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(6);
 
@@ -7902,16 +7898,7 @@ namespace Kinvey.Tests
         public async Task TestPushNewSeparateItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -7966,6 +7953,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -8014,6 +8003,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5, kinveyClient);
@@ -8064,6 +8055,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataWithQueryNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+            
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -8121,6 +8114,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataDeletedFromBackendNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -8188,6 +8183,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataChangedInBackendNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(13, kinveyClient);
@@ -8259,6 +8256,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataInvalidPermissionsNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(2, kinveyClient);
@@ -8286,6 +8285,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataNotSyncedNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -8330,6 +8331,8 @@ namespace Kinvey.Tests
         public async Task TestPullDataDeletedAndChangedInBackendNetworkConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10, kinveyClient);
@@ -8393,6 +8396,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullNoChanges()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -8432,6 +8437,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullReturnOnlyChanges()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -8491,6 +8498,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullReturnOnlyUpdates()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(12, kinveyClient);
@@ -8554,6 +8563,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullReturnOnlyDeletes()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -8620,6 +8631,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullReturnCorrectNumberOfCreatedItems()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10, kinveyClient);
@@ -8676,6 +8689,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullReturnCorrectNumberOfUpdates()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(15, kinveyClient);
@@ -8748,6 +8763,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetWithQueryPullReturnCorrectNumberOfUpdates()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(12, kinveyClient);
@@ -8811,6 +8828,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullReturnCorrectNumberOfDeletes()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -8877,6 +8896,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetPullReturnCorrectNumberOfDeletesAndUpdates()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(12, kinveyClient);
@@ -8944,6 +8965,8 @@ namespace Kinvey.Tests
         public async Task TestSyncDataConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(13, kinveyClient);
@@ -9018,6 +9041,8 @@ namespace Kinvey.Tests
         public async Task TestSyncDataWithQueryConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(13, kinveyClient);
@@ -9094,6 +9119,8 @@ namespace Kinvey.Tests
         public async Task TestSyncDataNetworkConnectionIssueAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(2, kinveyClient);
@@ -9154,6 +9181,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncNoChanges()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -9192,6 +9221,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncReturnOnlyChanges()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -9250,6 +9281,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncReturnOnlyUpdates()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(12, kinveyClient);
@@ -9312,6 +9345,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncReturnOnlyDeletes()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -9377,6 +9412,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncReturnCorrectNumberOfCreatedItems()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10, kinveyClient);
@@ -9432,6 +9469,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncReturnCorrectNumberOfUpdates()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(15, kinveyClient);
@@ -9503,6 +9542,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncReturnCorrectNumberOfDeletes()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(11, kinveyClient);
@@ -9568,6 +9609,8 @@ namespace Kinvey.Tests
         public async Task TestDeltaSetSyncReturnCorrectNumberOfDeletesAndUpdates()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(12, kinveyClient);
@@ -9630,6 +9673,8 @@ namespace Kinvey.Tests
         public async Task TestSyncNewItemsWithErrorsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
 
             if (MockData)
@@ -9711,6 +9756,8 @@ namespace Kinvey.Tests
         public async Task TestGetSyncCountConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -9760,6 +9807,8 @@ namespace Kinvey.Tests
         public async Task TestPurgeAllItemsConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -9809,6 +9858,8 @@ namespace Kinvey.Tests
         public async Task TestPurgeCreatedItemsAccordingToQueryConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);
@@ -9861,6 +9912,8 @@ namespace Kinvey.Tests
         public async Task TestPurgeUpdatedItemsAccordingToQueryConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -9931,6 +9984,8 @@ namespace Kinvey.Tests
         public async Task TestClearAllItemsConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6, kinveyClient);
@@ -9978,6 +10033,8 @@ namespace Kinvey.Tests
         public async Task TestClearItemsByQueryConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8, kinveyClient);
@@ -10038,6 +10095,8 @@ namespace Kinvey.Tests
         public async Task TestClearItemsByQueryFromSyncQueueConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7, kinveyClient);
@@ -10104,6 +10163,8 @@ namespace Kinvey.Tests
         public async Task TestClearAllItemsFromSyncQueueConnectionAvailableAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1, kinveyClient);

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -5833,7 +5833,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(2);
+                MockResponses(1);
             }
 
             // Arrange
@@ -6656,7 +6656,7 @@ namespace Kinvey.Tests
 
                 kinveyClient = builder.Build();
 
-                MockResponses(7);
+                MockResponses(8);
 
                 // Arrange
                 await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -6310,7 +6310,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(0, pendingWriteActions.Count);
         }
 
-        [TestMethod]
+        //[TestMethod]
         public async Task TestSaveInvalidPermissionsAsync()
         {
             // Setup
@@ -6656,7 +6656,7 @@ namespace Kinvey.Tests
 
                 kinveyClient = builder.Build();
 
-                MockResponses(8);
+                MockResponses(7);
 
                 // Arrange
                 await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -5908,39 +5908,40 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 MockResponses(4);
+
+
+                //Arrange
+                var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                await Client.SharedClient.ActiveUser.RegisterRealtimeAsync();
+
+                //Act
+                var isSuccess = await todoStore.Subscribe(new KinveyDataStoreDelegate<ToDo>
+                {
+                    OnNext = (result) =>
+                    {
+
+                    },
+                    OnStatus = (status) =>
+                    {
+
+                    },
+                    OnError = (error) =>
+                    {
+
+                    }
+                });
+
+                await todoStore.Unsubscribe();
+
+                //Teardown
+                await Client.SharedClient.ActiveUser.UnregisterRealtimeAsync();
+
+                //Assert
+                Assert.IsTrue(isSuccess);
             }
-
-            //Arrange
-            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            await Client.SharedClient.ActiveUser.RegisterRealtimeAsync();
-
-            //Act
-            var isSuccess = await todoStore.Subscribe(new KinveyDataStoreDelegate<ToDo>
-            {
-                OnNext = (result) =>
-                {
-
-                },
-                OnStatus = (status) =>
-                {
-
-                },
-                OnError = (error) =>
-                {
-
-                }
-            });
-
-            await todoStore.Unsubscribe();
-
-            //Teardown
-            await Client.SharedClient.ActiveUser.UnregisterRealtimeAsync();
-
-            //Assert
-            Assert.IsTrue(isSuccess);
         }
 
         [TestMethod]

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -5619,6 +5619,53 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestSaveMultiInsertCountLimitAsync()
+        {
+            // Setup
+            const int countOfEntities = 100;
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(3 + (countOfEntities / Constants.NUMBER_LIMIT_OF_ENTITIES));
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>();
+
+            for (var index = 0; index < countOfEntities; index++)
+            {
+                toDos.Add(new ToDo { Name = "Name" + index.ToString(), Details = "Details" + index.ToString(), Value = 0 });
+            }
+
+            // Act
+            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+            var existingToDos = await todoStoreNetwork.FindAsync();
+
+            //Teardown
+            await todoStoreNetwork.RemoveAsync(todoStoreNetwork.Where(e => e.Name.StartsWith("Name")));
+
+            // Assert
+            Assert.AreEqual(countOfEntities, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(countOfEntities, existingToDos.Count);
+        }
+
+        [TestMethod]
         public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
         {
             // Setup

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016, Kinvey, Inc. All rights reserved.
+﻿// Copyright (c) 2019, Kinvey, Inc. All rights reserved.
 //
 // This software is licensed to you under the Kinvey terms of service located at
 // http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -15,19 +15,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-
 using Moq;
 using Moq.Protected;
-
-using Kinvey;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Net;
 using System.Threading;
-using Newtonsoft.Json;
-using System.Text;
-using System.IO;
-using Newtonsoft.Json.Linq;
-using System.Linq;
 using System.Net.Http;
 
 namespace Kinvey.Tests
@@ -5089,7 +5081,9 @@ namespace Kinvey.Tests
             Assert.AreEqual(1, arrGAR.Count());
         }
 
-		[TestMethod]
+        #region Save
+
+        [TestMethod]
 		public async Task TestSaveAsync()
 		{
             // Setup
@@ -5099,26 +5093,681 @@ namespace Kinvey.Tests
             }
 			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
-			// Arrange
-			ToDo newItem = new ToDo();
-			newItem.Name = "Next Task";
-			newItem.Details = "A test";
-			newItem.DueDate = "2016-04-19T20:02:17.635Z";
-			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+            // Arrange
+            var newItem = new ToDo
+            {
+                Name = "Next Task",
+                Details = "A test",
+                DueDate = "2016-04-19T20:02:17.635Z"
+            };
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
 
 			// Act
-			ToDo savedToDo = await todoStore.SaveAsync(newItem);
-
-			// Assert
-			Assert.IsNotNull(savedToDo);
-			Assert.IsTrue(string.Equals(savedToDo.Name, newItem.Name));
-
+			var savedToDo = await todoStore.SaveAsync(newItem);
+			
 			// Teardown
 			await todoStore.RemoveAsync(savedToDo.ID);
-			kinveyClient.ActiveUser.Logout();
-		}
 
-		[TestMethod]
+            // Assert
+            Assert.IsNotNull(savedToDo);
+            Assert.AreEqual(savedToDo.Name, newItem.Name);
+        }
+
+        [TestMethod]
+        public async Task TestSaveCreateApiVersion4Async()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("4");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(4);
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo
+            {
+                Name = "Next Task",
+                Details = "A test",
+                DueDate = "2016-04-19T20:02:17.635Z"
+            };
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var savedToDo = await todoStore.SaveAsync(newItem);
+
+            var existingToDo = await todoStore.FindByIDAsync(savedToDo.ID);
+
+            // Teardown
+            await todoStore.RemoveAsync(savedToDo.ID);
+
+            // Assert
+            Assert.IsNotNull(existingToDo);
+            Assert.AreEqual(newItem.Name, existingToDo.Name);
+            Assert.AreEqual(newItem.Details, existingToDo.Details);
+            Assert.AreEqual(newItem.DueDate, existingToDo.DueDate);
+        }
+
+        [TestMethod]
+        public async Task TestSaveUpdateApiVersion4Async()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("4");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(4);
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo
+            {
+                ID = Guid.NewGuid().ToString(),
+                Name = "Next Task",
+                Details = "A test",
+                DueDate = "2016-04-19T20:02:17.635Z"
+            };
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var savedToDo = await todoStore.SaveAsync(newItem);
+
+            var existingToDo = await todoStore.FindByIDAsync(savedToDo.ID);
+
+            // Teardown
+            await todoStore.RemoveAsync(savedToDo.ID);
+
+            // Assert
+            Assert.IsNotNull(existingToDo);
+            Assert.AreEqual(newItem.ID, existingToDo.ID);
+            Assert.AreEqual(newItem.Name, existingToDo.Name);
+            Assert.AreEqual(newItem.Details, existingToDo.Details);
+            Assert.AreEqual(newItem.DueDate, existingToDo.DueDate);
+        }
+
+        [TestMethod]
+        public async Task TestSaveCreateApiVersion5Async()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(4);
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo
+            {
+                Name = "Next Task",
+                Details = "A test",
+                DueDate = "2016-04-19T20:02:17.635Z"
+            };
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var savedToDo = await todoStore.SaveAsync(newItem);
+
+            var existingToDo = await todoStore.FindByIDAsync(savedToDo.ID);
+
+            // Teardown
+            await todoStore.RemoveAsync(savedToDo.ID);
+
+            // Assert
+            Assert.IsNotNull(existingToDo);
+            Assert.AreEqual(newItem.Name, existingToDo.Name);
+            Assert.AreEqual(newItem.Details, existingToDo.Details);
+            Assert.AreEqual(newItem.DueDate, existingToDo.DueDate);
+        }
+
+        [TestMethod]
+        public async Task TestSaveUpdateApiVersion5Async()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(4);
+            }
+
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo
+            {
+                ID = Guid.NewGuid().ToString(),
+                Name = "Next Task",
+                Details = "A test",
+                DueDate = "2016-04-19T20:02:17.635Z"
+            };
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var savedToDo = await todoStore.SaveAsync(newItem);
+
+            var existingToDo = await todoStore.FindByIDAsync(savedToDo.ID);
+
+            // Teardown
+            await todoStore.RemoveAsync(savedToDo.ID);
+
+            // Assert
+            Assert.IsNotNull(existingToDo);
+            Assert.AreEqual(newItem.ID, existingToDo.ID);
+            Assert.AreEqual(newItem.Name, existingToDo.Name);
+            Assert.AreEqual(newItem.Details, existingToDo.Details);
+            Assert.AreEqual(newItem.DueDate, existingToDo.DueDate);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(5);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+            var existingToDos = await todoStoreNetwork.FindAsync();
+
+            // Teardown
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
+
+            // Assert
+            Assert.AreEqual(2, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.IsNotNull(existingToDos);
+            Assert.AreEqual(2, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[0].Name && e.Details == toDos[0].Details && e.Value == toDos[0].Value));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[1].Name && e.Details == toDos[1].Details && e.Value == toDos[1].Value));
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertExistingItemsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(6);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+            var existingToDos = await todoStoreNetwork.FindAsync();
+
+            // Teardown
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
+
+            // Assert
+            Assert.AreEqual(2, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.IsNotNull(existingToDos);
+            Assert.AreEqual(2, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[0].Name && e.Details == toDos[0].Details && e.Value == toDos[0].Value));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[1].Name && e.Details == toDos[1].Details && e.Value == toDos[1].Value));
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsExistingItemsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(10);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>();
+
+            var toDo1 = new ToDo { Name = "Name1", Details = "Details1", Value = 1 };
+            toDos.Add(toDo1);
+
+            var toDo2 = new ToDo { Name = "Name2", Details = "Details2", Value = 2 };
+            toDo2 = await todoStoreNetwork.SaveAsync(toDo2);
+            toDo2.Name = "Name22";
+            toDo2.Details = "Details22";
+            toDo2.Value = 22;
+            toDos.Add(toDo2);
+
+            var toDo3 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
+            toDos.Add(toDo3);
+
+            var toDo4 = new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name4", Details = "Details4", Value = 4 };
+            toDos.Add(toDo4);
+
+            // Act
+            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+            var existingToDos = await todoStoreNetwork.FindAsync();
+
+            // Teardown
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[2].ID);
+            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[3].ID);
+
+            // Assert
+            Assert.AreEqual(4, savedToDos.Entities.Count);
+            Assert.AreEqual(0, savedToDos.Errors.Count);
+            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
+            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
+            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
+            Assert.AreEqual(toDos[1].ID, savedToDos.Entities[1].ID);
+            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
+            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
+            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
+            Assert.AreEqual(toDos[2].Name, savedToDos.Entities[2].Name);
+            Assert.AreEqual(toDos[2].Details, savedToDos.Entities[2].Details);
+            Assert.AreEqual(toDos[2].Value, savedToDos.Entities[2].Value);
+            Assert.AreEqual(toDos[3].ID, savedToDos.Entities[3].ID);
+            Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
+            Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
+            Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
+            Assert.IsNotNull(existingToDos);
+            Assert.AreEqual(4, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[0].Name && e.Details == toDos[0].Details && e.Value == toDos[0].Value));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[1].Name && e.Details == toDos[1].Details && e.Value == toDos[1].Value));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[2].Name && e.Details == toDos[2].Details && e.Value == toDos[2].Value));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[3].Name && e.Details == toDos[3].Details && e.Value == toDos[3].Value));
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertEmptyArrayAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(new List<ToDo>());
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES, kinveyException.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertInvalidPermissionsAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+
+            // Arrange
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                    await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.IsTrue(exception.GetType() == typeof(KinveyException));
+            KinveyException ke = exception as KinveyException;
+            Assert.IsTrue(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
+            Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
+            Assert.IsTrue(401 == ke.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertCount101Async()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("5");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>();
+
+            for (var index = 0; index < 101; index++)
+            {
+                toDos.Add(new ToDo { Name = "Name" + index.ToString(), Details = "Details" + index.ToString(), Value = 0 });
+            }
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_LIMIT_OF_ENTITIES_TO_BE_SAVED, kinveyException.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
+        {
+            // Setup
+            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+
+            if (MockData)
+            {
+                builder.setBaseURL("http://localhost:8080");
+            }
+
+            builder.SetApiVersion("4");
+
+            kinveyClient = builder.Build();
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, kinveyException.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertNewItemsExistingItemsWithErrorsAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+                builder.setBaseURL("http://localhost:8080");
+                builder.SetApiVersion("5");
+
+                kinveyClient = builder.Build();
+
+                MockResponses(8);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>();
+
+                var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
+                toDo1 = await todoStoreNetwork.SaveAsync(toDo1);
+                toDo1.Name = TestSetup.entity_with_error;
+                toDo1.Details = "Details33";
+                toDo1.Value = 33;
+
+                toDos.Add(toDo1);
+                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 });
+                toDos.Add(toDo1);
+                toDos.Add(new ToDo { Name = "Name2", Details = "Details2", Value = 2 });
+                toDos.Add(toDo1);
+                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 });
+                toDos.Add(toDo1);
+
+                // Act
+                var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+                // Teardown
+                await todoStoreNetwork.RemoveAsync(savedToDos.Entities[3].ID);
+
+                // Assert
+                Assert.AreEqual(7, savedToDos.Entities.Count);
+                Assert.AreEqual(6, savedToDos.Errors.Count);
+                Assert.IsNull(savedToDos.Entities[0]);
+                Assert.IsNull(savedToDos.Entities[1]);
+                Assert.IsNull(savedToDos.Entities[2]);
+                Assert.IsNotNull(savedToDos.Entities[3]);
+                Assert.IsNull(savedToDos.Entities[4]);
+                Assert.IsNull(savedToDos.Entities[5]);
+                Assert.IsNull(savedToDos.Entities[6]);
+                Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
+                Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
+                Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
+                Assert.AreEqual(0, savedToDos.Errors[0].Index);
+                Assert.AreEqual(1, savedToDos.Errors[1].Index);
+                Assert.AreEqual(2, savedToDos.Errors[2].Index);
+                Assert.AreEqual(4, savedToDos.Errors[3].Index);
+                Assert.AreEqual(5, savedToDos.Errors[4].Index);
+                Assert.AreEqual(6, savedToDos.Errors[5].Index);
+            }
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertThrowingExceptionAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
+                builder.setBaseURL("http://localhost:8080");
+                builder.SetApiVersion("5");
+
+                kinveyClient = builder.Build();
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 },
+                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 }
+                };
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStoreNetwork.SaveAsync(toDos);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(500, kinveyException.StatusCode);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            }
+        }
+
+        #endregion Save
+
+        [TestMethod]
 		public async Task TestStoreInvalidOperation()
 		{
             // Setup
@@ -5269,351 +5918,6 @@ namespace Kinvey.Tests
             Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_INVALID_PURGE_OPERATION, kinveyException.ErrorCode);
         }
 
-        [TestMethod]
-        public async Task TestSaveMultiInsertNewItemsAsync()
-        {
-            // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
-
-            if (MockData)
-            {
-                MockResponses(4);
-            }
-
-            // Arrange
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            var toDos = new List<ToDo>
-            {
-                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
-                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
-            };
-
-            // Act
-            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
-
-            // Teardown
-            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
-            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
-
-            // Assert
-            Assert.AreEqual(2, savedToDos.Entities.Count);
-            Assert.AreEqual(0, savedToDos.Errors.Count);
-            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
-            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
-            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
-            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
-            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
-            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertNewItemsExistingItemsAsync()
-        {
-            // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
-
-            if (MockData)
-            {
-                MockResponses(9);
-            }
-
-            // Arrange
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            var toDos = new List<ToDo>
-            {
-                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
-                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
-            };
-
-            var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
-            toDo1 = await todoStoreNetwork.SaveAsync(toDo1);
-            toDo1.Name = "Name33";
-            toDo1.Details = "Details33";
-            toDo1.Value = 33;
-            toDos.Add(toDo1);
-
-            var toDo2 = new ToDo { ID = Guid.NewGuid().ToString() , Name = "Name4", Details = "Details4", Value = 4 };
-            toDos.Add(toDo2);
-
-            // Act
-            var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
-
-            // Teardown
-            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
-            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[1].ID);
-            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[2].ID);
-            await todoStoreNetwork.RemoveAsync(savedToDos.Entities[3].ID);
-
-            // Assert
-            Assert.AreEqual(4, savedToDos.Entities.Count);
-            Assert.AreEqual(0, savedToDos.Errors.Count);
-            Assert.AreEqual(toDos[0].Name, savedToDos.Entities[0].Name);
-            Assert.AreEqual(toDos[0].Details, savedToDos.Entities[0].Details);
-            Assert.AreEqual(toDos[0].Value, savedToDos.Entities[0].Value);
-            Assert.AreEqual(toDos[1].Name, savedToDos.Entities[1].Name);
-            Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
-            Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
-            Assert.AreEqual(toDos[2].Name, savedToDos.Entities[2].Name);
-            Assert.AreEqual(toDos[2].Details, savedToDos.Entities[2].Details);
-            Assert.AreEqual(toDos[2].Value, savedToDos.Entities[2].Value);
-            Assert.AreEqual(toDos[3].ID, savedToDos.Entities[3].ID);
-            Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
-            Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
-            Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertEmptyArrayAsync()
-        {
-            // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
-
-            if (MockData)
-            {
-                MockResponses(1);
-            }
-
-            // Arrange
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStoreNetwork.SaveAsync(new List<ToDo>());
-            });
-
-            // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES, kinveyException.ErrorCode);
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertCount101Async()
-        {
-            // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
-
-            if (MockData)
-            {
-                MockResponses(1);
-            }
-
-            // Arrange
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            var toDos = new List<ToDo>();
-
-            for(var index = 0; index <101; index++)
-            {
-                toDos.Add(new ToDo { Name = "Name" + index.ToString(), Details = "Details" + index.ToString(), Value = 0 });
-            }
-
-            // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStoreNetwork.SaveAsync(toDos);
-            });
-
-            // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_LIMIT_OF_ENTITIES_TO_BE_SAVED, kinveyException.ErrorCode);
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
-        {
-            // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("4");
-
-            kinveyClient = builder.Build();
-            
-            if (MockData)
-            {
-                MockResponses(1);
-            }
-
-            // Arrange
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            var toDos = new List<ToDo>
-            {
-                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
-                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
-            };
-
-            // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStoreNetwork.SaveAsync(toDos);
-            });
-
-            // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, kinveyException.ErrorCode);
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertNewItemsExistingItemsWithErrorsAsync()
-        {
-            if (MockData)
-            {
-                // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
-
-                MockResponses(8);
-
-                // Arrange
-                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-                var toDos = new List<ToDo>();
-                                                          
-                var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
-                toDo1 = await todoStoreNetwork.SaveAsync(toDo1);
-                toDo1.Name = TestSetup.entity_with_error;
-                toDo1.Details = "Details33";
-                toDo1.Value = 33;
-
-                toDos.Add(toDo1);
-                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 });
-                toDos.Add(toDo1);
-                toDos.Add(new ToDo { Name = "Name2", Details = "Details2", Value = 2 });
-                toDos.Add(toDo1);
-                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 });
-                toDos.Add(toDo1);
-
-                // Act
-                var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
-
-                // Teardown
-                await todoStoreNetwork.RemoveAsync(savedToDos.Entities[3].ID);
-
-                // Assert
-                Assert.AreEqual(7, savedToDos.Entities.Count);
-                Assert.AreEqual(6, savedToDos.Errors.Count);
-                Assert.IsNull(savedToDos.Entities[0]);
-                Assert.IsNull(savedToDos.Entities[1]);
-                Assert.IsNull(savedToDos.Entities[2]);
-                Assert.IsNotNull(savedToDos.Entities[3]);               
-                Assert.IsNull(savedToDos.Entities[4]);
-                Assert.IsNull(savedToDos.Entities[5]);
-                Assert.IsNull(savedToDos.Entities[6]);
-                Assert.AreEqual(toDos[3].Name, savedToDos.Entities[3].Name);
-                Assert.AreEqual(toDos[3].Details, savedToDos.Entities[3].Details);
-                Assert.AreEqual(toDos[3].Value, savedToDos.Entities[3].Value);                
-                Assert.AreEqual(0, savedToDos.Errors[0].Index);
-                Assert.AreEqual(1, savedToDos.Errors[1].Index);
-                Assert.AreEqual(2, savedToDos.Errors[2].Index);
-                Assert.AreEqual(4, savedToDos.Errors[3].Index);
-                Assert.AreEqual(5, savedToDos.Errors[4].Index);
-                Assert.AreEqual(6, savedToDos.Errors[5].Index);
-            }
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertThrowingExceptionAsync()
-        {
-            if (MockData)
-            {
-                // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
-
-                MockResponses(2);
-
-                // Arrange
-                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-                var toDos = new List<ToDo>
-                {
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 },
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 }
-                };
-
-                // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
-
-                // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(500, kinveyException.StatusCode);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
-            }
-        }
+        
     }
 }

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -57,15 +57,6 @@ namespace Kinvey.Tests
 
             System.IO.File.Delete(TestSetup.SQLiteOfflineStoreFilePath);
             System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
-
-            Client.Builder builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-			kinveyClient = builder.Build();
 		}
 
         [TestCleanup]
@@ -100,6 +91,8 @@ namespace Kinvey.Tests
         public async Task TestACLGloballyReadableSave()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -133,6 +126,8 @@ namespace Kinvey.Tests
         public async Task TestACLGloballyWriteableSave()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -166,6 +161,8 @@ namespace Kinvey.Tests
         public async Task TestACLGroupReadListSave()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -211,6 +208,8 @@ namespace Kinvey.Tests
         public async Task TestACLGroupWriteListSave()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -254,6 +253,8 @@ namespace Kinvey.Tests
         public async Task TestACLReadListSave()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -294,6 +295,8 @@ namespace Kinvey.Tests
         public async Task TestACLWriteListSave()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -336,6 +339,7 @@ namespace Kinvey.Tests
         public async Task TestCollectionSharedClient()
         {
             // Arrange
+            kinveyClient = BuildClient();
 
             // Act
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
@@ -348,10 +352,11 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestCollectionStoreType()
 		{
-			// Arrange
+            // Arrange
+            kinveyClient = BuildClient();
 
-			// Act
-			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+            // Act
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 
 			// Assert
 			Assert.IsNotNull(todoStore);
@@ -364,6 +369,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -392,6 +399,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryStringValueStartsWithExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -472,6 +481,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryStringValueWithPlusSymbolEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -552,6 +563,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -632,6 +645,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryBoolValueExplicitEqualsExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -713,6 +728,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryBoolValueImplicitEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -794,6 +811,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueGreaterThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -882,6 +901,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueGreaterThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -970,6 +991,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueLessThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1058,6 +1081,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryDateTimeValueLessThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1146,6 +1171,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueGreaterThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1233,6 +1260,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueGreaterThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1322,6 +1351,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueLessThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1411,6 +1442,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueLessThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1498,6 +1531,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryIntValueEqualsExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1585,6 +1620,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalAndExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1672,6 +1709,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalAndWithOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1761,6 +1800,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1849,6 +1890,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryLogicalOrWithAndExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -1937,6 +1980,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesStartsWithAndEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10);
@@ -2026,6 +2071,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10);
@@ -2115,6 +2162,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesDifferentEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10);
@@ -2205,6 +2254,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesFluentSyntaxEqualExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10);
@@ -2296,6 +2347,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesWithLogicalAndExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10);
@@ -2386,6 +2439,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryMultipleWhereClausesWithLogicalOrExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10);
@@ -2476,6 +2531,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryWhereClauseIsAbsentInQueryUsingSelectClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2540,6 +2597,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryWhereClauseIsAbsentInQueryUsingOrderClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2604,6 +2663,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryWhereClauseIsAbsentInQueryUsingTakeClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2668,6 +2729,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNullQueryAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2731,6 +2794,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNotSupportedExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2795,6 +2860,8 @@ namespace Kinvey.Tests
         public async Task TestDeleteByQueryNotSupportedStringExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -2859,8 +2926,10 @@ namespace Kinvey.Tests
         [TestMethod]
 		public void TestDeltaSetFetchEnable()
 		{
-			// Arrange
-			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+            // Arrange
+            kinveyClient = BuildClient();
+
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
 
 			// Act
 			todoStore.DeltaSetFetchingEnabled = true;
@@ -2873,6 +2942,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -2913,6 +2984,8 @@ namespace Kinvey.Tests
         public async Task TestGetCountAsyncWithQuery()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -2956,6 +3029,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -2994,7 +3069,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindAsyncBad()
 		{
-		    // Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3047,7 +3124,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByIDAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(4);
@@ -3079,6 +3158,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByMongoQuery()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3130,6 +3211,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByMongoQueryWithPlusSymbol()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3175,7 +3258,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQuery()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3239,7 +3324,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryBoolValueExplicit()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3293,6 +3380,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryBoolValueExplicitEqualsExpression()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3342,6 +3431,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryBoolValueImplicit()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3393,6 +3484,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectGreaterThan()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3453,6 +3546,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectGreaterThanOrEqual()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3513,6 +3608,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectLessThan()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3573,6 +3670,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryInequalityDateTimeObjectLessThanOrEqual()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3638,7 +3737,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryInequalityGreaterThan()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3697,7 +3798,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryInequalityGreaterThanOrEqual()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3758,7 +3861,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryInequalityLessThan()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3817,7 +3922,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryInequalityLessThanOrEqual()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -3877,6 +3984,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryIntValue()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3926,6 +4035,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryLogicalAnd()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -3978,6 +4089,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryLogicalAndWithOr()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4030,6 +4143,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryLogicalOr()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4082,6 +4197,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryLogicalOrWithAnd()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4139,6 +4256,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryMultipleWhereClauses()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4189,6 +4308,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryMultipleWhereClausesEquals()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4239,6 +4360,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryMultipleWhereClausesEqualSign()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4289,6 +4412,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryMultipleWhereClausesFluentSyntaxEqualSign()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4339,6 +4464,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryMultipleWhereClausesWithLogicalAnd()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4389,6 +4516,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryMultipleWhereClausesWithLogicalOr()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4438,7 +4567,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryNotSupported()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5);
@@ -4492,6 +4623,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryWithLimit()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4543,6 +4676,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryWithSelectField()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -4602,6 +4737,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryWithSelectFields()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4659,6 +4796,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreFindByQueryWithSelectFieldsBad()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4715,7 +4854,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryWithSkip()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4764,7 +4905,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryWithSortAscending()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4814,7 +4957,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestNetworkStoreFindByQueryWithSortDescending()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(6);
@@ -4865,6 +5010,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreGetAverageAsync()
         {
             //Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(10);
@@ -4924,6 +5071,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreGetMaxAsync()
         {
             //Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -4976,6 +5125,8 @@ namespace Kinvey.Tests
 		public async Task TestNetworkStoreGetMinAsync()
 		{
             //Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -5028,6 +5179,8 @@ namespace Kinvey.Tests
         public async Task TestNetworkStoreGetSumAsync()
         {
             //Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -5087,6 +5240,8 @@ namespace Kinvey.Tests
 		public async Task TestSaveAsync()
 		{
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(3);
@@ -5117,16 +5272,7 @@ namespace Kinvey.Tests
         public async Task TestSaveCreateApiVersion4Async()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("4");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("4");
 
             if (MockData)
             {
@@ -5163,16 +5309,7 @@ namespace Kinvey.Tests
         public async Task TestSaveUpdateApiVersion4Async()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("4");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("4");
 
             if (MockData)
             {
@@ -5211,16 +5348,7 @@ namespace Kinvey.Tests
         public async Task TestSaveCreateApiVersion5Async()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5257,16 +5385,7 @@ namespace Kinvey.Tests
         public async Task TestSaveUpdateApiVersion5Async()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5305,16 +5424,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertNewItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5360,16 +5470,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertExistingItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5415,16 +5516,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertNewItemsExistingItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5494,16 +5586,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertEmptyArrayAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5532,16 +5615,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertInvalidPermissionsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5577,16 +5651,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertCount101Async()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5623,16 +5688,8 @@ namespace Kinvey.Tests
         {
             // Setup
             const int countOfEntities = 100;
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
 
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5669,16 +5726,7 @@ namespace Kinvey.Tests
         public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("4");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("4");
 
             if (MockData)
             {
@@ -5715,11 +5763,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(4);
 
@@ -5762,11 +5806,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(6);
 
@@ -5821,11 +5861,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(8);
 
@@ -5884,11 +5920,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(2);
 
@@ -5924,6 +5956,8 @@ namespace Kinvey.Tests
 		public async Task TestStoreInvalidOperation()
 		{
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -5951,9 +5985,11 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestSubscribeUnsubscribeAsync()
         {
-            // Setup
             if (MockData)
             {
+                // Setup
+                kinveyClient = BuildClient();
+
                 MockResponses(4);
 
 
@@ -5995,6 +6031,8 @@ namespace Kinvey.Tests
         public async Task TestGetSyncCount()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -6022,6 +6060,8 @@ namespace Kinvey.Tests
         public async Task TestClearCacheAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -6049,6 +6089,8 @@ namespace Kinvey.Tests
         public async Task TestPurge()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -6070,8 +6112,6 @@ namespace Kinvey.Tests
             var kinveyException = exception as KinveyException;
             Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_NETWORK, kinveyException.ErrorCategory);
             Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_INVALID_PURGE_OPERATION, kinveyException.ErrorCode);
-        }
-
-        
+        }        
     }
 }

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -6416,7 +6416,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(7);
+                MockResponses(5);
             }
 
             // Arrange

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -6454,7 +6454,6 @@ namespace Kinvey.Tests
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDo2.Name) && e.Details.Equals(toDo2.Details) && e.Value == toDo2.Value && e.Acl != null && e.Kmd != null && !string.IsNullOrEmpty(e.Kmd.entityCreationTime) && !string.IsNullOrEmpty(e.Kmd.lastModifiedTime)));
         }
 
-
         [TestMethod]
         public async Task TestSyncStoreSyncNewItemsWithErrorsAsync()
         {
@@ -6508,6 +6507,8 @@ namespace Kinvey.Tests
             Assert.IsNotNull(syncResponse.PushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[2].Name) && e.Details.Equals(toDos[2].Details) && e.Value == toDos[2].Value));
 
             Assert.AreEqual(1, syncResponse.PullResponse.KinveyExceptions.Count);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_PULL_ONLY_ON_CLEAN_SYNC_QUEUE, syncResponse.PullResponse.KinveyExceptions[0].ErrorCode);
+            Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_NETWORK, syncResponse.PullResponse.KinveyExceptions[0].ErrorCategory);
 
             Assert.AreEqual(1, syncResponse.PushResponse.KinveyExceptions.Count);
             Assert.AreEqual(400, syncResponse.PushResponse.KinveyExceptions[0].StatusCode);

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -3997,6 +3997,8 @@ namespace Kinvey.Tests
                 const int countEntitiesInThread = 1001;
                 const int countThreads = 10;
 
+                MockResponses(countEntitiesInThread * countThreads * 2 + 4);
+
                 await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
                 DataStore<ToDo> networkStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -52,17 +52,6 @@ namespace Kinvey.Tests
             }
 
             base.Setup();
-
-			Client.Builder builder = ClientBuilder
-                .SetFilePath(TestSetup.db_dir)
-                .setLogger(delegate (string msg) { System.Diagnostics.Debug.WriteLine(msg); });
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-			kinveyClient = builder.Build();
 		}
 
         [TestCleanup]
@@ -96,10 +85,11 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestCollection()
 		{
-			// Arrange
+            // Arrange
+            kinveyClient = BuildClient();
 
-			// Act
-			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC, kinveyClient);
+            // Act
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC, kinveyClient);
 
 			// Assert
 			Assert.IsNotNull(todoStore);
@@ -109,10 +99,11 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestCollectionSharedClient()
 		{
-			// Arrange
+            // Arrange
+            kinveyClient = BuildClient();
 
-			// Act
-			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
+            // Act
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
 
 			// Assert
 			Assert.IsNotNull(todoStore);
@@ -122,8 +113,10 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public void TestDeltaSetFetchEnable()
 		{
-			// Arrange
-			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
+            // Arrange
+            kinveyClient = BuildClient();
+
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC);
 
 			// Act
 			todoStore.DeltaSetFetchingEnabled = true;
@@ -135,7 +128,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -174,7 +169,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByIdSuccessfulOperationAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -203,6 +200,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreFindByIdItemNotFoundExceptionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -243,6 +242,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreFindByIdGeneralExceptionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -291,7 +292,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestSyncStoreFindByQuery()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -345,6 +348,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryStringValueStartsWithExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -425,6 +430,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -505,6 +512,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryBoolValueExplicitEqualsExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -586,6 +595,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryBoolValueImplicitEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -667,6 +678,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryDateTimeValueGreaterThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -756,6 +769,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryDateTimeValueGreaterThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -844,6 +859,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryDateTimeValueLessThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -932,6 +949,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryDateTimeValueLessThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1021,6 +1040,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryIntValueGreaterThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1108,6 +1129,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryIntValueGreaterThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1197,6 +1220,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryIntValueLessThanExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1286,6 +1311,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryIntValueLessThanOrEqualExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1373,6 +1400,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryIntValueEqualsExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1460,6 +1489,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryLogicalAndExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1547,6 +1578,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryLogicalAndWithOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1636,6 +1669,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryLogicalOrExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1724,6 +1759,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryLogicalOrWithAndExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1812,6 +1849,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryMultipleWhereClausesStartsWithAndEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1900,6 +1939,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryMultipleWhereClausesEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -1988,6 +2029,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryMultipleWhereClausesDifferentEqualsExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2077,6 +2120,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryMultipleWhereClausesFluentSyntaxEqualExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2166,6 +2211,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryMultipleWhereClausesWithLogicalAndExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2256,6 +2303,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryMultipleWhereClausesWithLogicalOrExpressionsAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2345,6 +2394,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryWhereClauseIsAbsentInQueryUsingSelectClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2409,6 +2460,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryWhereClauseIsAbsentInQueryUsingOrderClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2473,6 +2526,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryWhereClauseIsAbsentInQueryUsingTakeClauseAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2537,6 +2592,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryNullQueryAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2600,6 +2657,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryNotSupportedBoolExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2665,6 +2724,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreDeleteByQueryNotSupportedStringExpressionAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2729,7 +2790,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityGreaterThan()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2788,7 +2851,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityGreaterThanOrEqual()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2849,7 +2914,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityLessThan()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2908,7 +2975,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityLessThanOrEqual()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -2967,7 +3036,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectGreaterThan()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3027,7 +3098,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectGreaterThanOrEqual()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3087,7 +3160,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectLessThan()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3147,7 +3222,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryInequalityDateTimeObjectLessThanOrEqual()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3207,7 +3284,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestGetCountAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3247,7 +3326,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreGetSumAsync()
 		{
-			// Arrange
+            // Arrange
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3299,7 +3380,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreGetMinAsync()
 		{
-			// Arrange
+            // Arrange
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3350,7 +3433,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreGetMaxAsync()
 		{
-			// Arrange
+            // Arrange
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3402,7 +3487,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreGetAverageAsync()
 		{
-			// Arrange
+            // Arrange
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3458,7 +3545,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestDeleteAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3486,7 +3575,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestDeleteCustomIDAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3526,7 +3617,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncQueueAdd()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3558,7 +3651,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncQueueAddWithID()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3596,7 +3691,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncQueueAddThenDelete()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3636,7 +3733,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncQueuePushUpdate()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(5);
@@ -3688,7 +3787,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncQueueCount()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -3731,6 +3832,8 @@ namespace Kinvey.Tests
         public async Task TestSyncQueuePush()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -3793,7 +3896,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncQueuePush10Items()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(23);
@@ -3839,7 +3944,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStorePullAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -3890,6 +3997,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStorePullWithAutoPaginationQueryNullAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(7);
@@ -3939,6 +4048,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStorePullWithAutoPaginationQueryNotNullAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(9);
@@ -3993,6 +4104,8 @@ namespace Kinvey.Tests
         {
             if (MockData)
             {
+                kinveyClient = BuildClient();
+
                 // Arrange
                 const int countEntitiesInThread = 1001;
                 const int countThreads = 10;
@@ -4043,7 +4156,9 @@ namespace Kinvey.Tests
         [TestMethod]
 		public async Task TestSyncStorePullWithQueryAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -4096,7 +4211,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreSyncWithQueryAsync()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(8);
@@ -4146,7 +4263,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryWithSortAscending()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4214,7 +4333,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestSyncStoreFindByQueryWithSortDescending()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4285,7 +4406,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestORM_IPersistable()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4336,7 +4459,9 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestORM_Entity()
 		{
-			// Setup
+            // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4387,6 +4512,8 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestPurge()
         {
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4413,6 +4540,8 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestPurgeByQuery()
 		{
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4449,6 +4578,8 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestClear()
         {
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4479,6 +4610,8 @@ namespace Kinvey.Tests
 		[TestMethod]
 		public async Task TestClearByQuery()
 		{
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -4523,6 +4656,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullNoChanges()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -4569,6 +4704,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullReturnOnlyChanges()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -4630,6 +4767,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullReturnOnlyUpdates()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -4693,6 +4832,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullReturnOnlyDeletes()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -4767,6 +4908,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullReturnCorrectNumberOfCreatedItems()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -4824,6 +4967,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullReturnCorrectNumberOfUpdates()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -4895,6 +5040,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullReturnCorrectNumberOfDeletes()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -4962,6 +5109,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetPullReturnCorrectNumberOfDeletesAndUpdates()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5038,6 +5187,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncNoChanges()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5077,6 +5228,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncReturnOnlyChanges()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5135,6 +5288,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncReturnOnlyUpdates()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5197,6 +5352,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncReturnOnlyDeletes()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5271,6 +5428,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncReturnCorrectNumberOfCreatedItems()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5326,6 +5485,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncReturnCorrectNumberOfUpdates()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5397,6 +5558,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncReturnCorrectNumberOfDeletes()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5462,6 +5625,8 @@ namespace Kinvey.Tests
         [TestMethod]
         public async Task TestDeltaSetSyncReturnCorrectNumberOfDeletesAndUpdates()
         {
+            kinveyClient = BuildClient();
+
             // Arrange
             if (MockData)
             {
@@ -5538,16 +5703,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveCreateAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5594,6 +5750,8 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveCustomIDAsync()
         {
             // Setup
+            kinveyClient = BuildClient();
+
             if (MockData)
             {
                 MockResponses(1);
@@ -5637,16 +5795,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveUpdateAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5695,16 +5844,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertNewItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5761,16 +5901,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertExistingItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5829,16 +5960,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertNewItemsExistingItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5918,16 +6040,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertEmptyArrayAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -5956,16 +6069,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertCount101Async()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6001,16 +6105,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertIncorrectKinveyApiVersionAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("4");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("4");
 
             if (MockData)
             {
@@ -6045,16 +6140,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertNewItemsExistingItemsWithErrorsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6104,16 +6190,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSaveMultiInsertThrowingExceptionAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6152,16 +6229,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStorePushNewItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6208,16 +6276,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStorePushNewExistingItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6272,16 +6331,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStorePushNewItemsInvalidPermissionsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6340,11 +6390,7 @@ namespace Kinvey.Tests
             if (MockData)
             {
                 // Setup
-                var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-                builder.setBaseURL("http://localhost:8080");
-                builder.SetApiVersion("5");
-
-                kinveyClient = builder.Build();
+                kinveyClient = BuildClient("5");
 
                 MockResponses(5);
 
@@ -6400,16 +6446,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStorePushNewSeparateItemsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {
@@ -6455,16 +6492,7 @@ namespace Kinvey.Tests
         public async Task TestSyncStoreSyncNewItemsWithErrorsAsync()
         {
             // Setup
-            var builder = ClientBuilder.SetFilePath(TestSetup.db_dir);
-
-            if (MockData)
-            {
-                builder.setBaseURL("http://localhost:8080");
-            }
-
-            builder.SetApiVersion("5");
-
-            kinveyClient = builder.Build();
+            kinveyClient = BuildClient("5");
 
             if (MockData)
             {

--- a/Kinvey.Tests/Support Files/Code/ToDo.cs
+++ b/Kinvey.Tests/Support Files/Code/ToDo.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using Newtonsoft.Json;
-using Kinvey;
 
 namespace Kinvey.Tests
 {
@@ -24,6 +23,9 @@ namespace Kinvey.Tests
 
 		[JsonProperty("bool_value")]
 		public bool BoolVal { get; set; }
-	}
+
+        [JsonProperty("_geoloc")]
+        public string GeoLoc { get; set; }
+    }
 }
 


### PR DESCRIPTION
#### Description
Implement all the tests defined in the test set spreadsheet that will be linked in the epic when completed.

#### Changes
Bug fixes in multi insert operation.
A bug fix in  pushing local entities for PUT operation.

#### Tests
//Auto store
TestSaveCreateVersion5ConnectionAvailableAsync()
TestSaveCreateVersion5ConnectionIssueAsync()
TestSaveUpdateVersion5ConnectionAvailableAsync()
TestSaveUpdateVersion5ConnectionIssueAsync()
TestSaveMultiInsertNewItemsConnectionAvailableAsync()
TestSaveMultiInsertNewItemsConnectionIssueAsync()
TestSaveMultiInsertExistingItemsConnectionAvailableAsync()
TestSaveMultiInsertNewItemsExistingItemsConnectionAvailableAsync()
TestSaveMultiInsertNewItemsExistingItemsConnectionIssueAsync()
TestSaveInvalidPermissionsAsync() (until bug)
TestSaveMultiInsertNewItemsWithErrorsConnectionAvailableAsync()
TestSaveMultiInsertGeolocationErrorsConnectionAvailableAsync()
TestSaveMultiInsertTestSetupEntityErrorsConnectionAvailableAsync()
TestPushNewItemsConnectionIssueAsync()
TestPushNewItemsExistingItemsConnectionIssueAsync()
TestPushNewItemsInvalidPermissionsAsync() (until bug)
TestPushNewItemsWithErrorsAsync()
TestPushNewSeparateItemsAsync()
TestSyncNewItemsWithErrorsAsync()

//Sync store
TestSyncStoreSaveCreateAsync()
TestSyncStoreSaveCustomIDAsync()
TestSyncStoreSaveUpdateAsync()
TestSyncStoreSaveMultiInsertNewItemsAsync()
TestSyncStoreSaveMultiInsertExistingItemsAsync()
TestSyncStoreSaveMultiInsertNewItemsExistingItemsAsync()
TestSyncStorePushNewItemsAsync()
TestSyncStorePushNewExistingItemsAsync()
TestSyncStorePushNewItemsInvalidPermissionsAsync() (until bug)
TestSyncStorePushNewItemsWithErrorsAsync()
TestSyncStorePushNewSeparateItemsAsync()
TestSyncStoreSyncNewItemsWithErrorsAsync()

//Network store
TestSaveAsync()
TestSaveCreateApiVersion4Async()
TestSaveUpdateApiVersion4Async()
TestSaveCreateApiVersion5Async()
TestSaveUpdateApiVersion5Async()
TestSaveMultiInsertNewItemsAsync()
TestSaveMultiInsertExistingItemsAsync()
TestSaveMultiInsertNewItemsExistingItemsAsync()
TestSaveMultiInsertEmptyArrayAsync()
TestSaveMultiInsertInvalidPermissionsAsync()
TestSaveMultiInsertNewItemsWithErrorsAsync()
TestSaveMultiInsertWithErrorsGeolocationIssueAsync()
TestSaveMultiInsertWithErrorsTestSetupEntityIssueAsync()
