### PR TITLE
MLIBZ-3070: Unauthorized response (401) issue

### DIFF
--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -464,7 +464,6 @@ namespace Kinvey
             RequestAuth.Authenticate(request);
             Logger.Log(request);
             var response = await httClient.SendAsync(request);
-            var content = await response.Content.ReadAsStringAsync();
             Logger.Log(response);
             var contentType = response.Headers
                                       .Where(x => x.Key.ToLower().Equals("content-type"))

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+﻿// Copyright (c) 2019, Kinvey, Inc. All rights reserved.
 //
 // This software is licensed to you under the Kinvey terms of service located at
 // http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -556,7 +556,7 @@ namespace Kinvey
                         else
                         {
                             //logout the current user
-                            Client.ActiveUser.Logout(); // TODO is this a potential deadlock?
+                            Client.ActiveUser.Logout(); 
                         }
                     }
                     else

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -494,63 +494,69 @@ namespace Kinvey
 			//process refresh token needed
 			if ((int)response.StatusCode == 401)
 			{
-				if (!hasRetried)
-				{
-					// Attempting retry - set flag to prevent additional attempts
-					hasRetried = true;
+                var json = await response.Content.ReadAsStringAsync();
+                var error = JsonConvert.DeserializeObject<ServerError>(json);
 
-					// Attempt to get the refresh token
-					Credential cred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
-					string refreshToken = null;
-					string redirectUri = null;
-                    string micClientId = null;
+                if (!error.Error.Equals(Constants.STR_ERROR_BACKEND_INSUFFICIENT_CREDENTIALS))
+                {
+                    if (!hasRetried)
+                    {
+                        // Attempting retry - set flag to prevent additional attempts
+                        hasRetried = true;
 
-					if (cred != null)
-					{
-						refreshToken = cred.RefreshToken;
-						redirectUri = cred.RedirectUri;
-                        micClientId = cred.MICClientID;
+                        // Attempt to get the refresh token
+                        Credential cred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
+                        string refreshToken = null;
+                        string redirectUri = null;
+                        string micClientId = null;
 
-						if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
-						{
-							//use the refresh token for a new access token
-                            JObject result = await Client.ActiveUser.UseRefreshToken(refreshToken, redirectUri, micClientId).ExecuteAsync();
+                        if (cred != null)
+                        {
+                            refreshToken = cred.RefreshToken;
+                            redirectUri = cred.RedirectUri;
+                            micClientId = cred.MICClientID;
 
-							// log out the current user without removing the user record from the credential store
-							Client.ActiveUser.LogoutSoft();
+                            if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
+                            {
+                                //use the refresh token for a new access token
+                                JObject result = await Client.ActiveUser.UseRefreshToken(refreshToken, redirectUri, micClientId).ExecuteAsync();
 
-							//login with the access token
-							Provider provider = new Provider();
-							provider.kinveyAuth = new MICCredential(result["access_token"].ToString());
-							User u = await User.LoginAsync(new ThirdPartyIdentity(provider), Client);
+                                // log out the current user without removing the user record from the credential store
+                                Client.ActiveUser.LogoutSoft();
 
-							//store the new refresh token
-							Credential currentCred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
-							currentCred.AccessToken = result["access_token"].ToString();
-                            currentCred.RefreshToken = result.GetValidValue("refresh_token");
-                            currentCred.RedirectUri = redirectUri;
-							Client.Store.Store(Client.ActiveUser.Id, Client.SSOGroupKey, currentCred);
+                                //login with the access token
+                                Provider provider = new Provider();
+                                provider.kinveyAuth = new MICCredential(result["access_token"].ToString());
+                                User u = await User.LoginAsync(new ThirdPartyIdentity(provider), Client);
 
-							// Retry the original request
-							RequestAuth = new KinveyAuthenticator(currentCred.AuthToken);
-							var retryResponse = await ExecuteUnparsedAsync();
-							return retryResponse;
-						}
-						else
-						{
-							//logout the current user
-							Client.ActiveUser.Logout(); // TODO is this a potential deadlock?
-						}
-					}
-					else
-					{
-						Client.ActiveUser.Logout();
-					}
-				}
-				else
-				{
-					Client.ActiveUser.Logout();
-				}
+                                //store the new refresh token
+                                Credential currentCred = Client.Store.Load(Client.ActiveUser.Id, Client.SSOGroupKey);
+                                currentCred.AccessToken = result["access_token"].ToString();
+                                currentCred.RefreshToken = result.GetValidValue("refresh_token");
+                                currentCred.RedirectUri = redirectUri;
+                                Client.Store.Store(Client.ActiveUser.Id, Client.SSOGroupKey, currentCred);
+
+                                // Retry the original request
+                                RequestAuth = new KinveyAuthenticator(currentCred.AuthToken);
+                                var retryResponse = await ExecuteUnparsedAsync();
+                                return retryResponse;
+                            }
+                            else
+                            {
+                                //logout the current user
+                                Client.ActiveUser.Logout(); // TODO is this a potential deadlock?
+                            }
+                        }
+                        else
+                        {
+                            Client.ActiveUser.Logout();
+                        }
+                    }
+                    else
+                    {
+                        Client.ActiveUser.Logout();
+                    }
+                }
 			}
 
             try

--- a/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Core/Core/AbstractKinveyClientRequest.cs
@@ -490,14 +490,21 @@ namespace Kinvey
 			{
                 lastResponseHeaders.Add(header);
 			}
-
-			//process refresh token needed
+			
 			if ((int)response.StatusCode == 401)
 			{
-                var json = await response.Content.ReadAsStringAsync();
-                var error = JsonConvert.DeserializeObject<ServerError>(json);
+                ServerError error = null;
+                try
+                {
+                    var json = await response.Content.ReadAsStringAsync();
+                    error = JsonConvert.DeserializeObject<ServerError>(json);
+                }
+                catch(Exception)
+                {
 
-                if (!error.Error.Equals(Constants.STR_ERROR_BACKEND_INSUFFICIENT_CREDENTIALS))
+                }
+
+                if (error != null && !error.Error.Equals(Constants.STR_ERROR_BACKEND_INSUFFICIENT_CREDENTIALS))
                 {
                     if (!hasRetried)
                     {
@@ -516,6 +523,7 @@ namespace Kinvey
                             redirectUri = cred.RedirectUri;
                             micClientId = cred.MICClientID;
 
+                            //process refresh token needed
                             if (!string.IsNullOrEmpty(refreshToken) && !refreshToken.ToLower().Equals("null"))
                             {
                                 //use the refresh token for a new access token

--- a/Kinvey.Core/Kinvey.Core.csproj
+++ b/Kinvey.Core/Kinvey.Core.csproj
@@ -34,6 +34,7 @@
     <Compile Include="Extensions\CustomExtension.cs" />
     <Compile Include="Model\Error.cs" />
     <Compile Include="Model\KinveyMultiInsertResponse.cs" />
+    <Compile Include="Model\ServerError.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Auth\Credential.cs" />
     <Compile Include="Auth\CredentialManager.cs" />

--- a/Kinvey.Core/Model/ServerError.cs
+++ b/Kinvey.Core/Model/ServerError.cs
@@ -1,0 +1,22 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Kinvey
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    internal class ServerError
+    {
+        [JsonProperty]
+        internal string Error { get; set; }
+
+        [JsonProperty]
+        internal string Description { get; set; }
+
+        [JsonProperty]
+        internal string Debug { get; set; }
+    }
+}

--- a/Kinvey.Core/Utils/KinveyConstants.cs
+++ b/Kinvey.Core/Utils/KinveyConstants.cs
@@ -111,6 +111,8 @@ namespace Kinvey
         internal const string STR_ERROR_BACKEND_RESULT_SET_SIZE_EXCEEDED = "ResultSetSizeExceeded";
         internal const string STR_ERROR_BACKEND_PARAMETER_VALUE_OUT_OF_RANGE = "ParameterValueOutOfRange";
 
+        internal const string STR_ERROR_BACKEND_INSUFFICIENT_CREDENTIALS = "InsufficientCredentials";
+
         #endregion
 
         //Limits

--- a/Kinvey.Shared/Kinvey.Shared.projitems
+++ b/Kinvey.Shared/Kinvey.Shared.projitems
@@ -140,6 +140,9 @@
 	<Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\Error.cs">
       <Link>Model\Error.cs</Link>
     </Compile>
+	<Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\ServerError.cs">
+      <Link>Model\ServerError.cs</Link>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)..\Kinvey.Core\Model\GroupAggregationResults.cs">
       <Link>Model\GroupAggregationResults.cs</Link>
     </Compile>

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -12,7 +12,6 @@
             public const string ContractsCollection = "contracts";
         }
 
-
         public static class Exceptions
         {
             public const string GeneralExceptionTitle = "General exception";

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -1141,7 +1141,7 @@ namespace Kinvey.Tests
                                 var error = new JObject
                                 {
                                     ["error"] = "InsufficientCredentials",
-                                    ["description"] = "The credentials used to authenticate this request are not authorized to run this operation. Please retry your request with appropriate credentials.",
+                                    ["description"] = "The credentials used to authenticate this request are not authorized to run this   operation. Please retry your request with appropriate credentials.",
                                     ["debug"] = "You do not have access to create entities in this collection",
                                 };
                                 Write(context, error);
@@ -1164,7 +1164,13 @@ namespace Kinvey.Tests
                             if (authorization.Contains(TestSetup.auth_token_for_401_response_fake, StringComparison.Ordinal))
                             {
                                 context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;
-                                Write(context, "Unauthorized");
+                                var error = new JObject
+                                {
+                                    ["error"] = "InvalidCredentials",
+                                    ["description"] = "Invalid credentials. Please retry your request with correct credentials.",
+                                    ["debug"] = "Error encountered authenticating against kinveyAuth: {\"error\":\"server_error\",\"error_description\":\"An unknown server error occurred.\",\"debug\":\"Access Token not found\"}",
+                                };
+                                Write(context, error);
                                 continue;
                             }
                         }

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -6393,7 +6393,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(0, pendingWriteActions.Count);
         }
 
-        //[TestMethod]
+        [TestMethod]
         public async Task TestSaveInvalidPermissionsAsync()
         {
             // Setup
@@ -6422,30 +6422,25 @@ namespace Kinvey.Tests
                 await todoAutoStore.SaveAsync(toDos);
             });
 
-            //var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            //var existingToDos = await todoSyncStore.FindAsync();
+
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDos = await todoSyncStore.FindAsync();
 
             //Teardown
-            //await todoSyncStore.RemoveAsync(todoSyncStore.Where(e=> e.Name.Equals("Name")));
+            await todoSyncStore.RemoveAsync(todoSyncStore.Where(e => e.Name.StartsWith("Name")));
 
             // Assert
-            Assert.IsTrue(exception.GetType() == typeof(KinveyException));
-            KinveyException ke = exception as KinveyException;
-            Assert.IsTrue(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
-            Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
-            Assert.IsTrue(401 == ke.StatusCode);
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(exception.GetType(), typeof(KinveyException));
+            var ke = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, ke.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, ke.ErrorCode);
 
-            //Assert.AreEqual(2, pendingWriteActions.Count);
-            //var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == existingToDos[0].ID);
-            //Assert.IsNotNull(pendingWriteAction1);
-            //Assert.AreEqual("POST", pendingWriteAction1.action);
-            //var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == existingToDos[1].ID);
-            //Assert.IsNotNull(pendingWriteAction2);
-            //Assert.AreEqual("POST", pendingWriteAction2.action);
+            Assert.AreEqual(2, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl == null && e.Kmd == null));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
 
-            //Assert.AreEqual(2, existingToDos.Count);
-            //Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl == null && e.Kmd == null));
-            //Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
+            Assert.AreEqual(0, pendingWriteActions.Count);
         }
 
         [TestMethod]
@@ -7782,7 +7777,7 @@ namespace Kinvey.Tests
             Assert.IsNotNull(existingToDosNetwork.FirstOrDefault(e => e.ID == pushResponse.PushEntities[3].ID));
         }
 
-        //[TestMethod]
+        [TestMethod]
         public async Task TestPushNewItemsInvalidPermissionsAsync()
         {
             // Setup
@@ -7790,7 +7785,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(3);
+                MockResponses(2);
             }
 
             // Arrange
@@ -7809,35 +7804,32 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoSyncStore.SaveAsync(toDos);
 
-            var pushResponse = await todoAutoStore.PushAsync();
+            var pushResponse = await todoSyncStore.PushAsync();
 
-            //var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(collectionName).GetAll();
-            //var existingToDos = await todoSyncStore.FindAsync();
+            var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
+            var existingToDos = await todoSyncStore.FindAsync();
 
             // Teardown
-            //await todoSyncStore.RemoveAsync(savedToDos.Entities[0].ID);
-            //await todoSyncStore.RemoveAsync(savedToDos.Entities[1].ID);
+            await todoSyncStore.RemoveAsync(todoNetworkStore.Where(e => e.Name.StartsWith("Name")));
 
             // Assert
+            Assert.AreEqual(1, pushResponse.KinveyExceptions.Count);
             Assert.AreEqual(2, pushResponse.PushCount);
-            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value));
-            Assert.IsNotNull(pushResponse.PushEntities.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value));
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, pushResponse.KinveyExceptions[0].ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, pushResponse.KinveyExceptions[0].ErrorCode);
+            Assert.AreEqual(401, pushResponse.KinveyExceptions[0].StatusCode);
 
-            Assert.AreEqual(2, pushResponse.KinveyExceptions.Count);
-            Assert.IsTrue(!pushResponse.KinveyExceptions.Any(e => e.StatusCode != 401));
+            Assert.AreEqual(2, existingToDos.Count);
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl == null && e.Kmd == null));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
 
-
-            //Assert.AreEqual(2, pendingWriteActions.Count);
-            //var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
-            //Assert.IsNotNull(pendingWriteAction1);
-            //Assert.AreEqual("POST", pendingWriteAction1.action);
-            //var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
-            //Assert.IsNotNull(pendingWriteAction2);
-            //Assert.AreEqual("POST", pendingWriteAction2.action);
-
-            //Assert.AreEqual(2, existingToDos.Count);
-            //Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl == null && e.Kmd == null));
-            //Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
+            Assert.AreEqual(2, pendingWriteActions.Count);
+            var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == existingToDos[0].ID);
+            Assert.IsNotNull(pendingWriteAction1);
+            Assert.AreEqual("POST", pendingWriteAction1.action);
+            var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == existingToDos[1].ID);
+            Assert.IsNotNull(pendingWriteAction2);
+            Assert.AreEqual("POST", pendingWriteAction2.action);
         }
 
         [TestMethod]

--- a/Kinvey.Tests/Support Files/Code/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/Code/TestSetup.cs
@@ -15,6 +15,9 @@ namespace Kinvey.Tests
         public const string user_without_permissions = "testuserwithoutpermissions";
         public const string pass_for_user_without_permissions = "testuserwithoutpermissions";
 
+        public const string user_with_corrupted_auth_token = "userwithcorruptedauthtoken";
+        public const string pass_for_user_with_corrupted_auth_token = "userwithcorruptedauthtoken";
+
         public const string app_key = "kid_Zy0JOYPKkZ";
 		public const string app_secret = "d83de70e64d540e49acd6cfce31415df";
 
@@ -28,6 +31,8 @@ namespace Kinvey.Tests
         public const string salesforce_access_token_fake = "8cd71dc8-846a-49f2-8cf1-c0598bbce5ec";
         public const string access_token_for_401_response_fake = "0065cb37-a1ed-4c8b-98fc-91c312683275";
         public const string auth_token_for_401_response_fake = "eda5d4bc-6a47-46d2-9637-07dec479bf9c";
+        public const string auth_token_insufficient_credentials_for_401_response_fake = "acc16614-35e0-4a98-b84a-c03dadfa8463";
+        public const string auth_token_corrupted_for_401_response_fake = "f7991119-f9e6-4c6e-9b38-9659c2b06cea";
         public const string refresh_token_for_401_response_fake = "0f550503-f033-44ee-8c2d-ae8f9773b70a";
 
         public const string entity_with_error = "Entity with error";


### PR DESCRIPTION
#### Description
The logic for handling 401 responses should be extended according to all possible cases.

#### Changes
AbstractKinveyClientRequest<T> class.

#### Tests
TestSaveInvalidPermissionsAsync()
TestPushNewItemsInvalidPermissionsAsync()
TestSyncStorePushNewItemsInvalidPermissionsAsync()
 TestActionWithCorruptedAuthTokenAsync()

