### PR TITLE
MLIBZ-2992: Add mocks for data store 'Find' operations (.NET)

### DIFF
--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -12,7 +12,6 @@
             public const string ContractsCollection = "contracts";
         }
 
-
         public static class Exceptions
         {
             public const string GeneralExceptionTitle = "General exception";

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -12,6 +12,7 @@
             public const string ContractsCollection = "contracts";
         }
 
+
         public static class Exceptions
         {
             public const string GeneralExceptionTitle = "General exception";

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -1279,11 +1279,13 @@ namespace Kinvey.Tests
                                                     if (id.Equals(TestSetup.id_for_400_error_response_fake))
                                                     {
                                                         MockBadRequest(context);
+                                                        break;
                                                     }
 
                                                     if (id.Equals(TestSetup.id_for_500_error_response_fake))
                                                     {
                                                         MockInternal(context);
+                                                        break;
                                                     }
 
                                                     var item = items.Find((obj) => id.Equals(obj["_id"].Value<string>()));
@@ -1291,6 +1293,7 @@ namespace Kinvey.Tests
                                                     if(item == null)
                                                     {
                                                         MockNotFound(context);
+                                                        break;
                                                     }
 
                                                     Write(context, item);

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -315,18 +315,25 @@ namespace Kinvey.Tests
             }
         }
 
-        protected static void MockNotFound(HttpListenerContext context)
+        protected static void MockBadRequest(HttpListenerContext context, string message = "Bad request")
+        {
+            var response = context.Response;
+            response.StatusCode = 400;
+            Write(context, message);
+        }
+
+        protected static void MockNotFound(HttpListenerContext context, string message = "Not Found")
         {
             var response = context.Response;
             response.StatusCode = 404;
-            Write(context, "Not Found");
+            Write(context, message);
         }
 
-        protected static void MockInternal(HttpListenerContext context)
+        protected static void MockInternal(HttpListenerContext context, string message = "The Kinvey server encountered an unexpected error. Please retry your request.")
         {
             var response = context.Response;
             response.StatusCode = 500;
-            Write(context, "The Kinvey server encountered an unexpected error. Please retry your request.");
+            Write(context, message);
         }
 
         private static bool Filter(JObject item, string key, JToken jToken)
@@ -426,17 +433,13 @@ namespace Kinvey.Tests
         {
             if (obj["_geoloc"] != null && !IsValidGeolocation(obj["_geoloc"].ToString()))
             {
-                var response = context.Response;
-                response.StatusCode = 400;
-                Write(context, "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90");
+                MockBadRequest(context, "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90");
                 return;
             }
 
             if (obj["name"] != null && obj["name"].ToString().Equals(TestSetup.entity_with_error))
             {
-                var response = context.Response;
-                response.StatusCode = 400;
-                Write(context, "Error.");
+                MockBadRequest(context);
                 return;
             }
 
@@ -453,9 +456,7 @@ namespace Kinvey.Tests
 
             if (jObjects.Count == 0)
             {
-                var response = context.Response;
-                response.StatusCode = 400;
-                Write(context, "Request body cannot be an empty array");
+                MockBadRequest(context, "Request body cannot be an empty array");
                 return;
             }
 
@@ -660,10 +661,8 @@ namespace Kinvey.Tests
 
             if (obj["_geoloc"] != null && !IsValidGeolocation(obj["_geoloc"].ToString()))
             {                   
-                    var response = context.Response;
-                    response.StatusCode = 400;
-                    Write(context, "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90");
-                    return;                
+                MockBadRequest(context, "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90");
+                return;                
             }
 
             var item = items[index];
@@ -1277,7 +1276,23 @@ namespace Kinvey.Tests
                                                 break;
                                             case "GET":
                                                 {
+                                                    if (id.Equals(TestSetup.id_for_400_error_response_fake))
+                                                    {
+                                                        MockBadRequest(context);
+                                                    }
+
+                                                    if (id.Equals(TestSetup.id_for_500_error_response_fake))
+                                                    {
+                                                        MockInternal(context);
+                                                    }
+
                                                     var item = items.Find((obj) => id.Equals(obj["_id"].Value<string>()));
+
+                                                    if(item == null)
+                                                    {
+                                                        MockNotFound(context);
+                                                    }
+
                                                     Write(context, item);
                                                 }
                                                 break;

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -3025,6 +3025,10 @@ namespace Kinvey.Tests
             Assert.AreEqual(1u, count);
         }
 
+        #region Find
+
+        #region Positive tests
+
         [TestMethod]
         public async Task TestNetworkStoreFindAsync()
         {
@@ -5005,6 +5009,135 @@ namespace Kinvey.Tests
 			Assert.AreEqual(2, listToDo.Count);
 			Assert.IsTrue(String.Compare(newItem1.Name, listToDo.First().Name) == 0);
 		}
+
+        #endregion Positive tests
+
+        #region Negative tests
+
+        [TestMethod]
+        public async Task TestNetworkStoreFindByID400ErrorResponseAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient();
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStore.FindByIDAsync(TestSetup.id_for_400_error_response_fake);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(400, kinveyException.StatusCode);
+            }
+        }
+
+        [TestMethod]
+        public async Task TestNetworkStoreFindByID401ErrorResponseAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStore.FindByIDAsync(Guid.NewGuid().ToString());
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.AreEqual(401, kinveyException.StatusCode);
+
+        }
+
+        [TestMethod]
+        public async Task TestNetworkStoreFindByID404ErrorResponseAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStore.FindByIDAsync(Guid.NewGuid().ToString());
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.AreEqual(404, kinveyException.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task TestNetworkStoreFindByID500ErrorResponseAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient();
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStore.FindByIDAsync(TestSetup.id_for_500_error_response_fake);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(500, kinveyException.StatusCode);
+            }
+        }
+
+        #endregion Negative tests
+
+        #endregion Find
 
         [TestMethod]
         public async Task TestNetworkStoreGetAverageAsync()

--- a/Kinvey.Tests/Support Files/Code/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/Code/TestSetup.cs
@@ -38,5 +38,7 @@ namespace Kinvey.Tests
         public static string SQLiteOfflineStoreFilePath = Path.Combine(db_dir, "kinveyOffline.sqlite");
         public static string SQLiteCredentialStoreFilePath = Path.Combine(db_dir, "kinvey_tokens.sqlite");
 
-	}
+        public const string id_for_400_error_response_fake = "612d66fc-c975-4729-afe1-e8f7750782a5";
+        public const string id_for_500_error_response_fake = "9a547181-63f9-4f7e-b789-d8c4f07889b8";
+    }
 }


### PR DESCRIPTION
#### Description
Simulating various 4xx/5xx responses that we get from the backend, to ensure that we correctly handle these backend errors. 

#### Changes
No Changes

#### Tests
TestNetworkStoreFindByID400ErrorResponseAsync()
TestNetworkStoreFindByID401ErrorResponseAsync()
TestNetworkStoreFindByID404ErrorResponseAsync()
TestNetworkStoreFindByID500ErrorResponseAsync()


