### PR TITLE
MLIBZ-3111: Auto data store type. Adding entities to the pending actions.

### DIFF
--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -115,29 +115,28 @@ namespace Kinvey
                         throw new KinveyException(EnumErrorCategory.ERROR_DATASTORE_CACHE, EnumErrorCode.ERROR_DATASTORE_CACHE_MULTIPLE_SAVE, string.Empty);
                     }
 
-                    Exception exception = null;
+                    HttpRequestException httpRequestException = null;
+                    KinveyException kinveyException = null;
                     try
                     {
                         // network
                         kinveyDataStoreNetworkResponse = await HandleNetworkRequestAsync(entities);
                     }
-                    catch (HttpRequestException httpRequestException)
+                    catch (HttpRequestException httpRequestEx)
                     {
-                        exception = httpRequestException;
+                        httpRequestException = httpRequestEx;
                     }
-                    catch (KinveyException kinveyException)
+                    catch (KinveyException kinveyEx)
                     {
-                        exception = kinveyException;
+                        kinveyException = kinveyEx;
                     }
 
-                    if (exception != null)
+                    if (httpRequestException != null || kinveyException != null)
                     {
                         foreach (var pendingAction in pendingWriteActions)
                         {
                             SyncQueue.Enqueue(pendingAction);
                         }
-
-                        var kinveyException = exception as KinveyException;
 
                         if (kinveyException != null)
                         {

--- a/Kinvey.Core/Store/MultiInsertRequest.cs
+++ b/Kinvey.Core/Store/MultiInsertRequest.cs
@@ -115,7 +115,7 @@ namespace Kinvey
                         throw new KinveyException(EnumErrorCategory.ERROR_DATASTORE_CACHE, EnumErrorCode.ERROR_DATASTORE_CACHE_MULTIPLE_SAVE, string.Empty);
                     }
 
-                    HttpRequestException exception = null;
+                    Exception exception = null;
                     try
                     {
                         // network
@@ -125,13 +125,24 @@ namespace Kinvey
                     {
                         exception = httpRequestException;
                     }
+                    catch (KinveyException kinveyException)
+                    {
+                        exception = kinveyException;
+                    }
 
                     if (exception != null)
                     {
                         foreach (var pendingAction in pendingWriteActions)
                         {
                             SyncQueue.Enqueue(pendingAction);
-                        }                       
+                        }
+
+                        var kinveyException = exception as KinveyException;
+
+                        if (kinveyException != null)
+                        {
+                            throw kinveyException;
+                        }
                     }
                     else 
                     {

--- a/Kinvey.Core/Store/RemoveRequest.cs
+++ b/Kinvey.Core/Store/RemoveRequest.cs
@@ -108,27 +108,26 @@ namespace Kinvey
 
                         var deleteRequest = Client.NetworkFactory.buildDeleteRequest<KinveyDeleteResponse>(Collection, entityID);
 
-                        Exception exception = null;
+                        HttpRequestException httpRequestException = null;
+                        KinveyException kinveyException = null;
                         try
                         { 
                             // network
                             kdr = await deleteRequest.ExecuteAsync();
                         }
-                        catch (HttpRequestException httpRequestException)
+                        catch (HttpRequestException httpRequestEx)
                         {
-                            exception = httpRequestException;
+                            httpRequestException = httpRequestEx;
                         }
-                        catch (KinveyException kinveyException)
+                        catch (KinveyException kinveyEx)
                         {
-                            exception = kinveyException;
+                            kinveyException = kinveyEx;
                         }
 
-                        if (exception != null)
+                        if (httpRequestException != null || kinveyException != null)
                         {
                             var pendingAction = PendingWriteAction.buildFromRequest(deleteRequest);
                             SyncQueue.Enqueue(pendingAction);
-
-                            var kinveyException = exception as KinveyException;
 
                             if (kinveyException != null)
                             {
@@ -142,22 +141,23 @@ namespace Kinvey
                         kdr = Cache.DeleteByQuery(_query);
 
                         // network
-                        Exception exception = null;
+                        HttpRequestException httpRequestException = null;
+                        KinveyException kinveyException = null;
                         try
                         { 
                             var mongoQuery = KinveyMongoQueryBuilder.GetQueryForRemoveOperation<T>(_query);
                             kdr = await Client.NetworkFactory.buildDeleteRequestWithQuery<KinveyDeleteResponse>(Collection, mongoQuery).ExecuteAsync();
                         }
-                        catch (HttpRequestException httpRequestException)
+                        catch (HttpRequestException httpRequestEx)
                         {
-                            exception = httpRequestException;
+                            httpRequestException = httpRequestEx;
                         }
-                        catch (KinveyException kinveyException)
+                        catch (KinveyException kinveyEx)
                         {
-                            exception = kinveyException;
+                            kinveyException = kinveyEx;
                         }
 
-                        if (exception != null)
+                        if (httpRequestException != null || kinveyException != null)
                         {
                             foreach (var id in kdr.IDs)
                             {
@@ -166,8 +166,6 @@ namespace Kinvey
                                 var pendingAction = PendingWriteAction.buildFromRequest(request);
                                 SyncQueue.Enqueue(pendingAction);
                             }
-
-                            var kinveyException = exception as KinveyException;
 
                             if (kinveyException != null)
                             {

--- a/Kinvey.Core/Store/SaveRequest.cs
+++ b/Kinvey.Core/Store/SaveRequest.cs
@@ -115,22 +115,23 @@ namespace Kinvey
                         savedEntity = Cache.Update(entity);
 					}
 
-                    Exception exception = null;
+                    HttpRequestException httpRequestException = null;
+                    KinveyException kinveyException = null;
                     try
                     {
                         // network save
                         savedEntity = await request.ExecuteAsync();
                     }
-                    catch (HttpRequestException httpRequestException)
+                    catch (HttpRequestException httpRequestEx)
                     {
-                        exception = httpRequestException;
+                        httpRequestException = httpRequestEx;
                     }
-                    catch (KinveyException kinveyException)
+                    catch (KinveyException kinveyEx)
                     {
-                        exception = kinveyException;
+                        kinveyException = kinveyEx;
                     }
 
-                    if (exception != null)
+                    if (httpRequestException != null || kinveyException != null)
                     {
                         // if the network request fails, save data to sync queue
                         var localPendingAction = PendingWriteAction.buildFromRequest(request);
@@ -140,8 +141,6 @@ namespace Kinvey
                         }
 
                         SyncQueue.Enqueue(localPendingAction);
-
-                        var kinveyException = exception as KinveyException;
 
                         if (kinveyException != null)
                         {

--- a/Kinvey.Core/Store/SaveRequest.cs
+++ b/Kinvey.Core/Store/SaveRequest.cs
@@ -115,7 +115,7 @@ namespace Kinvey
                         savedEntity = Cache.Update(entity);
 					}
 
-                    HttpRequestException exception = null;
+                    Exception exception = null;
                     try
                     {
                         // network save
@@ -125,7 +125,11 @@ namespace Kinvey
                     {
                         exception = httpRequestException;
                     }
-                    
+                    catch (KinveyException kinveyException)
+                    {
+                        exception = kinveyException;
+                    }
+
                     if (exception != null)
                     {
                         // if the network request fails, save data to sync queue
@@ -136,6 +140,13 @@ namespace Kinvey
                         }
 
                         SyncQueue.Enqueue(localPendingAction);
+
+                        var kinveyException = exception as KinveyException;
+
+                        if (kinveyException != null)
+                        {
+                            throw kinveyException;
+                        }
                     }
                     else if (tempIdLocalThenNetwork != null)
 					{

--- a/Kinvey.Core/Store/SaveRequest.cs
+++ b/Kinvey.Core/Store/SaveRequest.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2016, Kinvey, Inc. All rights reserved.
+﻿// Copyright (c) 2019, Kinvey, Inc. All rights reserved.
 //
 // This software is licensed to you under the Kinvey terms of service located at
 // http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -6313,13 +6313,17 @@ namespace Kinvey.Tests
             Assert.AreEqual(toDos[1].Details, savedToDos.Entities[1].Details);
             Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
             Assert.IsNull(savedToDos.Entities[1].Acl);
+
             Assert.AreEqual(2, pendingWriteActions.Count);
             var pendingWriteAction1 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[0].ID);
             Assert.IsNotNull(pendingWriteAction1);
             Assert.AreEqual("POST", pendingWriteAction1.action);
+            Assert.AreEqual(toDosCollection, pendingWriteAction1.collection);
             var pendingWriteAction2 = pendingWriteActions.FirstOrDefault(e => e.entityId == savedToDos.Entities[1].ID);
             Assert.IsNotNull(pendingWriteAction2);
             Assert.AreEqual("POST", pendingWriteAction2.action);
+            Assert.AreEqual(toDosCollection, pendingWriteAction2.collection);
+
             Assert.AreEqual(2, existingToDos.Count);
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[0].ID));
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == savedToDos.Entities[1].ID));
@@ -6638,11 +6642,10 @@ namespace Kinvey.Tests
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[0].Name) && e.Details.Equals(toDos[0].Details) && e.Value == toDos[0].Value && e.Acl == null && e.Kmd == null));
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name.Equals(toDos[1].Name) && e.Details.Equals(toDos[1].Details) && e.Value == toDos[1].Value && e.Acl == null && e.Kmd == null));
 
-            //Assert.IsNotNull(pendingWriteActions);
-            //Assert.AreEqual(2, pendingWriteActions.Count);
-            //Assert.AreEqual(existingItemsCache[0].ID, pendingWriteActions[0].entityId);
-            //Assert.AreEqual("POST", pendingWriteActions[0].action);
-            //Assert.AreEqual(toDosCollection, pendingWriteActions[0].collection);
+            Assert.IsNotNull(pendingWriteActions);
+            Assert.AreEqual(2, pendingWriteActions.Count);
+            Assert.IsNotNull(pendingWriteActions.Where(e=> e.entityId == existingToDos[0].ID && e.collection.Equals(toDosCollection) && e.action.Equals("DELETE")));
+            Assert.IsNotNull(pendingWriteActions.Where(e => e.entityId == existingToDos[1].ID && e.collection.Equals(toDosCollection) && e.action.Equals("DELETE")));
         }
 
         [TestMethod]

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -406,7 +406,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(2, kinveyClient);
+                MockResponses(1, kinveyClient);
             }
 
             // Arrange
@@ -3178,7 +3178,6 @@ namespace Kinvey.Tests
             var ke = exception as KinveyException;
             Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, ke.ErrorCategory);
             Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, ke.ErrorCode);
-            Assert.AreEqual(404, ke.StatusCode);
 
             Assert.IsNotNull(pendingWriteActions);
             Assert.AreEqual(0, pendingWriteActions.Count);
@@ -3248,7 +3247,7 @@ namespace Kinvey.Tests
 
             if (MockData)
             {
-                MockResponses(2, kinveyClient);
+                MockResponses(1, kinveyClient);
             }
 
             // Arrange
@@ -5751,6 +5750,7 @@ namespace Kinvey.Tests
             Assert.IsNotNull(localEntities);
             Assert.IsNotNull(pendingWriteActions);
             Assert.AreEqual(1, localEntities.Count);
+            Assert.AreEqual(fc1.ID, localEntities[0].ID);
             Assert.AreEqual(fc1.Question, localEntities[0].Question);
             Assert.AreEqual(fc1.Answer, localEntities[0].Answer);
             Assert.AreEqual(1, pendingWriteActions.Count);
@@ -5803,6 +5803,10 @@ namespace Kinvey.Tests
             Assert.AreEqual(1, pendingWriteActions.Count);
             Assert.IsNotNull(existingItemsCache);
             Assert.AreEqual(1, existingItemsCache.Count);
+            Assert.AreEqual(newItem.Name, existingItemsCache[0].Name);
+            Assert.AreEqual(newItem.Details, existingItemsCache[0].Details);
+            Assert.AreEqual(newItem.DueDate, existingItemsCache[0].DueDate);
+
             Assert.AreEqual(existingItemsCache[0].ID, pendingWriteActions[0].entityId);
             Assert.AreEqual("POST", pendingWriteActions[0].action);
             Assert.AreEqual(toDosCollection, pendingWriteActions[0].collection);
@@ -6644,8 +6648,8 @@ namespace Kinvey.Tests
 
             Assert.IsNotNull(pendingWriteActions);
             Assert.AreEqual(2, pendingWriteActions.Count);
-            Assert.IsNotNull(pendingWriteActions.Where(e=> e.entityId == existingToDos[0].ID && e.collection.Equals(toDosCollection) && e.action.Equals("DELETE")));
-            Assert.IsNotNull(pendingWriteActions.Where(e => e.entityId == existingToDos[1].ID && e.collection.Equals(toDosCollection) && e.action.Equals("DELETE")));
+            Assert.IsNotNull(pendingWriteActions.FirstOrDefault(e=> e.entityId == existingToDos[0].ID && e.collection.Equals(toDosCollection) && e.action.Equals("POST")));
+            Assert.IsNotNull(pendingWriteActions.FirstOrDefault(e => e.entityId == existingToDos[1].ID && e.collection.Equals(toDosCollection) && e.action.Equals("POST")));
         }
 
         [TestMethod]

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -5574,6 +5574,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(1, pendingWriteActions.Count);
             Assert.AreEqual(fc1.ID, pendingWriteActions[0].entityId);
             Assert.AreEqual("POST", pendingWriteActions[0].action);
+            Assert.AreEqual(flashCardCollection, pendingWriteActions[0].collection);
         }
 
         [TestMethod]
@@ -5622,6 +5623,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(1, existingItemsCache.Count);
             Assert.AreEqual(existingItemsCache[0].ID, pendingWriteActions[0].entityId);
             Assert.AreEqual("POST", pendingWriteActions[0].action);
+            Assert.AreEqual(toDosCollection, pendingWriteActions[0].collection);
         }
 
         [TestMethod]


### PR DESCRIPTION
#### Description
Adding entities to the pending actions for Auto data store type if any Kinvey  or Network connection exception occurs.
 
#### Changes
Internal implementation in Save and Remove operations of the data store.

#### Tests
TestDeleteByQueryInvalidPermissionsConnectionAvailableAsync()
TestDeleteByQueryInvalidPermissionsNetworkConnectionIssueAsync()
TestDeleteByIdNotFoundConnectionAvailableAsync()
TestDeleteByIdNotFoundConnectionIssueAsync()
TestSaveInvalidPermissionsNetworkConnectionAvailableAsync()
TestSaveDataNetworkConnectionIssueAsync()
TestSaveMultiInsertInvalidPermissionsAsync()
TestSaveMultiInsertNewItemsConnectionIssueAsync()


