### PR TITLE
MLIBZ-2994: Add mocks for data store 'Save/Remove' operations (.NET)

### DIFF
--- a/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.Android/Kinvey.TestLocalLibApp.Android.csproj
+++ b/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.Android/Kinvey.TestLocalLibApp.Android.csproj
@@ -52,7 +52,7 @@
     <PackageReference Include="Xamarin.Firebase.Messaging">
       <Version>60.1142.1</Version>
     </PackageReference>
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.1.0.618606" />
     <PackageReference Include="Xamarin.Android.Support.Design" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="28.0.0.1" />
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.1" />

--- a/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.UWP/Kinvey.TestLocalLibApp.UWP.csproj
+++ b/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.UWP/Kinvey.TestLocalLibApp.UWP.csproj
@@ -144,7 +144,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.1.0.618606" />
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.8" />
   </ItemGroup>
   <ItemGroup>

--- a/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.iOS/Kinvey.TestLocalLibApp.iOS.csproj
+++ b/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.iOS/Kinvey.TestLocalLibApp.iOS.csproj
@@ -153,7 +153,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.1.0.618606" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>

--- a/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.csproj
+++ b/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp/Kinvey.TestLocalLibApp.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Xam.Plugin.Connectivity" Version="3.2.0" />
-    <PackageReference Include="Xamarin.Forms" Version="3.6.0.344457" />
+    <PackageReference Include="Xamarin.Forms" Version="4.1.0.618606" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -444,7 +444,7 @@ namespace Kinvey.Tests
                 return;
             }
 
-            if (obj["name"] != null && obj["name"].ToString().Equals(TestSetup.entity_with_error))
+            if (obj["name"] != null && obj["name"].ToString().Equals(TestSetup.entity_name_for_400_response_error))
             {
                 MockBadRequest(context);
                 return;
@@ -483,7 +483,7 @@ namespace Kinvey.Tests
 
             for(var index = 0; index < jObjects.Count; index ++)
             {
-                if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_with_error))
+                if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_name_for_400_response_error))
                 {
                     jObjectsToSave.Add(null);
 
@@ -496,24 +496,23 @@ namespace Kinvey.Tests
 
                     jObjectErrors.Add(jObjectError);
                 }
-                else
+                else if (jObjects[index]["_geoloc"] != null && !IsValidGeolocation(jObjects[index]["_geoloc"].ToString()))
                 {
-                    if (jObjects[index]["_geoloc"] != null && !IsValidGeolocation(jObjects[index]["_geoloc"].ToString()))
+                    jObjectsToSave.Add(null);
+
+                    var jObjectError = new JObject
                     {
-                        jObjectsToSave.Add(null);
+                        ["index"] = index,
+                        ["code"] = 1,
+                        ["errmsg"] = "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90"
+                    };
 
-                        var jObjectError = new JObject
-                        {
-                            ["index"] = index,
-                            ["code"] = 1,
-                            ["errmsg"] = "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90"
-                        };
+                    jObjectErrors.Add(jObjectError);
 
-                        jObjectErrors.Add(jObjectError);
-
-                        continue;
-                    }
-
+                    continue;
+                }
+                else
+                {                    
                     PopulateEntity(jObjects[index], client);
                     items.Add(jObjects[index]);
                     jObjectsToSave.Add(jObjects[index]);
@@ -666,7 +665,7 @@ namespace Kinvey.Tests
                 return;
             }
 
-            if (obj["name"] != null && obj["name"].ToString().Equals(TestSetup.entity_with_error))
+            if (obj["name"] != null && obj["name"].ToString().Equals(TestSetup.entity_name_for_400_response_error))
             {
                 MockInternal(context);
                 return;

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -450,6 +450,12 @@ namespace Kinvey.Tests
                 return;
             }
 
+            if (obj["_id"] != null && obj["_id"].ToString().Equals(TestSetup.id_for_500_error_response_fake))
+            {
+                MockInternal(context);
+                return;
+            }
+
             PopulateEntity(obj, client);
             items.Add(obj);
             Write(context, obj);

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -824,6 +824,18 @@ namespace Kinvey.Tests
 
         protected static void MockAppDataDelete(HttpListenerContext context, List<JObject> items, List<JObject> deletedItems, string id)
         {
+            if (id.Equals(TestSetup.id_for_400_error_response_fake))
+            {
+                MockBadRequest(context);
+                return;
+            }
+
+            if (id.Equals(TestSetup.id_for_500_error_response_fake))
+            {
+                MockInternal(context);
+                return;
+            }
+
             var todoIndex = items.FindIndex((obj) => id.Equals(obj["_id"].Value<string>()));
             var jsonObject = new JObject();
             if (todoIndex != -1)
@@ -836,7 +848,8 @@ namespace Kinvey.Tests
             }
             else
             {
-                jsonObject["count"] = 0;
+                MockNotFound(context);
+                return;
             }
             Write(context, jsonObject);
         }

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -450,6 +450,12 @@ namespace Kinvey.Tests
                 return;
             }
 
+            if (obj["_id"] != null && obj["_id"].ToString().Equals(TestSetup.id_for_400_error_response_fake))
+            {
+                MockBadRequest(context);
+                return;
+            }
+
             if (obj["_id"] != null && obj["_id"].ToString().Equals(TestSetup.id_for_500_error_response_fake))
             {
                 MockInternal(context);
@@ -495,6 +501,21 @@ namespace Kinvey.Tests
                     };
 
                     jObjectErrors.Add(jObjectError);
+                }
+                else if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_name_for_500_response_error))
+                {
+                    jObjectsToSave.Add(null);
+
+                    var jObjectError = new JObject
+                    {
+                        ["index"] = index,
+                        ["code"] = 1,
+                        ["errmsg"] = "Error"
+                    };
+
+                    jObjectErrors.Add(jObjectError);
+
+                    continue;
                 }
                 else if (jObjects[index]["_geoloc"] != null && !IsValidGeolocation(jObjects[index]["_geoloc"].ToString()))
                 {

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -6774,8 +6774,8 @@ namespace Kinvey.Tests
 
                 var toDos = new List<ToDo>
                 {
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 },
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 }
+                    new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details1", Value = 1 },
+                    new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details3", Value = 3 }
                 };
 
                 // Act
@@ -6940,16 +6940,16 @@ namespace Kinvey.Tests
 
                 var toDo1 = new ToDo { Name = "Name3", Details = "Details3", Value = 3 };
                 toDo1 = await toDoAutoStore.SaveAsync(toDo1);
-                toDo1.Name = TestSetup.entity_with_error;
+                toDo1.Name = TestSetup.entity_name_for_400_response_error;
                 toDo1.Details = "Details33";
                 toDo1.Value = 33;
 
                 toDos.Add(toDo1);
-                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details1", Value = 1 });
+                toDos.Add(new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details1", Value = 1 });
                 toDos.Add(toDo1);
                 toDos.Add(new ToDo { Name = "Name2", Details = "Details2", Value = 2 });
                 toDos.Add(toDo1);
-                toDos.Add(new ToDo { Name = TestSetup.entity_with_error, Details = "Details3", Value = 3 });
+                toDos.Add(new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details3", Value = 3 });
                 toDos.Add(toDo1);
 
                 // Act
@@ -8202,7 +8202,7 @@ namespace Kinvey.Tests
                 var toDos = new List<ToDo>
                 {
                     new ToDo { Name = "Name1", Details = "Details1", Value = 1, GeoLoc = "[200,200]" },
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details2", Value = 2 },
+                    new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details2", Value = 2 },
                     new ToDo { Name = "Name3", Details = "Details3", Value = 3 }
                 };
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -3309,18 +3309,11 @@ namespace Kinvey.Tests
             }
 
             // Assert                      
-            if (MockData)
-            {
-                Assert.IsNotNull(kinveyDeleteResponse);
-                Assert.AreEqual(0, kinveyDeleteResponse.count);
-            }
-            else
-            {
-                Assert.IsNull(kinveyDeleteResponse);
-                Assert.IsNotNull(exception);
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
-            }
+            Assert.IsNull(kinveyDeleteResponse);
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
+            Assert.AreEqual(404, exception.StatusCode);
         }
 
         [TestMethod]
@@ -3389,17 +3382,10 @@ namespace Kinvey.Tests
             Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_CACHE, syncStoreException.ErrorCategory);
             Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_CACHE_FIND_BY_ID_NOT_FOUND, syncStoreException.ErrorCode);
 
-            if (MockData)
-            {
-                Assert.IsNotNull(kinveyDeleteResponse2);
-                Assert.AreEqual(0, kinveyDeleteResponse2.count);
-            }
-            else
-            {
-                Assert.IsNotNull(exception);
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
-            }           
+            Assert.IsNotNull(exception);
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, exception.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, exception.ErrorCode);
+            Assert.AreEqual(404, exception.StatusCode);
         }
 
         [TestMethod]
@@ -8232,7 +8218,7 @@ namespace Kinvey.Tests
                 var existingToDosNetwork = await todoNetworkStore.FindAsync();
 
                 // Teardown
-                await todoNetworkStore.RemoveAsync(savedToDos.Entities[2].ID);
+                await todoNetworkStore.RemoveAsync(pushResponse.PushEntities[0].ID);
 
                 // Assert
                 Assert.AreEqual(3, pushResponse.PushCount);

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -5372,40 +5372,10 @@ namespace Kinvey.Tests
 
         #region Single insert
 
-        [TestMethod]
-		public async Task TestSaveAsync()
-		{
-            // Setup
-            kinveyClient = BuildClient();
-
-            if (MockData)
-            {
-                MockResponses(3);
-            }
-			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            // Arrange
-            var newItem = new ToDo
-            {
-                Name = "Next Task",
-                Details = "A test",
-                DueDate = "2016-04-19T20:02:17.635Z"
-            };
-            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
-
-			// Act
-			var savedToDo = await todoStore.SaveAsync(newItem);
-			
-			// Teardown
-			await todoStore.RemoveAsync(savedToDo.ID);
-
-            // Assert
-            Assert.IsNotNull(savedToDo);
-            Assert.AreEqual(savedToDo.Name, newItem.Name);
-        }
+        #region Positive tests
 
         [TestMethod]
-        public async Task TestSave400ErrorResponseAsync()
+        public async Task TestSaveAsync()
         {
             // Setup
             kinveyClient = BuildClient();
@@ -5417,91 +5387,23 @@ namespace Kinvey.Tests
             await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
             // Arrange
-            var newItem = new ToDo { Name = "Name1", Details = "Details1", Value = 1, GeoLoc = "[200,200]" };
-
+            var newItem = new ToDo
+            {
+                Name = "Next Task",
+                Details = "A test",
+                DueDate = "2016-04-19T20:02:17.635Z"
+            };
             var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
 
             // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                var savedToDo = await todoStore.SaveAsync(newItem);
-            });
+            var savedToDo = await todoStore.SaveAsync(newItem);
 
-            var toDosNetwork = await todoStore.FindAsync();
+            // Teardown
+            await todoStore.RemoveAsync(savedToDo.ID);
 
             // Assert
-            Assert.IsNotNull(toDosNetwork);
-            Assert.AreEqual(0, toDosNetwork.Count);
-
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
-            Assert.AreEqual(400, kinveyException.StatusCode);
-        }
-
-        [TestMethod]
-        public async Task TestSave401ErrorResponseAsync()
-        {
-            // Setup
-            kinveyClient = BuildClient();
-
-            if (MockData)
-            {
-                MockResponses(2);
-            }
-            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
-
-            // Arrange
-            var newItem = new ToDo { Name = "Name1", Details = "Details1", Value = 1 };
-
-            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
-
-            // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                var savedToDo = await todoStore.SaveAsync(newItem);
-            });
-
-            // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
-            Assert.AreEqual(401, kinveyException.StatusCode);
-        }
-
-        [TestMethod]
-        public async Task TestSave500ErrorResponseAsync()
-        {
-            if (MockData)
-            {
-                // Setup
-                kinveyClient = BuildClient();
-
-                MockResponses(2);
-
-                // Arrange
-                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-                var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
-
-                var newItem = new ToDo { ID = TestSetup.id_for_500_error_response_fake, Name = "Name1",
-                    Details = "Details1", Value = 1 };
-
-                // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStore.SaveAsync(newItem);
-                });
-
-                // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
-                Assert.AreEqual(500, kinveyException.StatusCode);
-            }
+            Assert.IsNotNull(savedToDo);
+            Assert.AreEqual(savedToDo.Name, newItem.Name);
         }
 
         [TestMethod]
@@ -5658,6 +5560,117 @@ namespace Kinvey.Tests
             Assert.AreEqual(newItem.Details, existingToDos[0].Details);
             Assert.AreEqual(newItem.DueDate, existingToDos[0].DueDate);
         }
+
+        #endregion Positive tests
+
+        #region Negative tests
+
+        [TestMethod]
+        public async Task TestSave400ErrorResponseAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient();
+
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo { Name = "Name1", Details = "Details1", Value = 1, GeoLoc = "[200,200]" };
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                var savedToDo = await todoStore.SaveAsync(newItem);
+            });
+
+            var toDosNetwork = await todoStore.FindAsync();
+
+            // Assert
+            Assert.IsNotNull(toDosNetwork);
+            Assert.AreEqual(0, toDosNetwork.Count);
+
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.AreEqual(400, kinveyException.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task TestSave401ErrorResponseAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo { Name = "Name1", Details = "Details1", Value = 1 };
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                var savedToDo = await todoStore.SaveAsync(newItem);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.AreEqual(401, kinveyException.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task TestSave500ErrorResponseAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient();
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+                var newItem = new ToDo
+                {
+                    ID = TestSetup.id_for_500_error_response_fake,
+                    Name = "Name1",
+                    Details = "Details1",
+                    Value = 1
+                };
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStore.SaveAsync(newItem);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(500, kinveyException.StatusCode);
+            }
+        }
+
+        #endregion Negative tests
 
         #endregion Single insert
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -5370,6 +5370,8 @@ namespace Kinvey.Tests
 
         #region Save
 
+        #region Single insert
+
         [TestMethod]
 		public async Task TestSaveAsync()
 		{
@@ -5400,6 +5402,106 @@ namespace Kinvey.Tests
             // Assert
             Assert.IsNotNull(savedToDo);
             Assert.AreEqual(savedToDo.Name, newItem.Name);
+        }
+
+        [TestMethod]
+        public async Task TestSave400ErrorResponseAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient();
+
+            if (MockData)
+            {
+                MockResponses(3);
+            }
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo { Name = "Name1", Details = "Details1", Value = 1, GeoLoc = "[200,200]" };
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                var savedToDo = await todoStore.SaveAsync(newItem);
+            });
+
+            var toDosNetwork = await todoStore.FindAsync();
+
+            // Assert
+            Assert.IsNotNull(toDosNetwork);
+            Assert.AreEqual(0, toDosNetwork.Count);
+
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.AreEqual(400, kinveyException.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task TestSave401ErrorResponseAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient();
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            // Arrange
+            var newItem = new ToDo { Name = "Name1", Details = "Details1", Value = 1 };
+
+            var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                var savedToDo = await todoStore.SaveAsync(newItem);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.AreEqual(401, kinveyException.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task TestSave500ErrorResponseAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient();
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+                var newItem = new ToDo { ID = TestSetup.id_for_500_error_response_fake, Name = "Name1",
+                    Details = "Details1", Value = 1 };
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStore.SaveAsync(newItem);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(500, kinveyException.StatusCode);
+            }
         }
 
         [TestMethod]
@@ -5556,6 +5658,10 @@ namespace Kinvey.Tests
             Assert.AreEqual(newItem.Details, existingToDos[0].Details);
             Assert.AreEqual(newItem.DueDate, existingToDos[0].DueDate);
         }
+
+        #endregion Single insert
+
+        #region Multi insert
 
         [TestMethod]
         public async Task TestSaveMultiInsertNewItemsAsync()
@@ -6010,6 +6116,8 @@ namespace Kinvey.Tests
                 Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
             }
         }
+
+        #endregion Multi insert
 
         #endregion Save
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -6246,6 +6246,96 @@ namespace Kinvey.Tests
             }
         }
 
+        [TestMethod]
+        public async Task TestSaveMultiInsertExisting400ErrorResponseInUpdateAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient("5");
+
+                MockResponses(3);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name1", Details = "Details1", Value = 1 },
+                    new ToDo { ID = TestSetup.id_for_400_error_response_fake, Name = "Name2", Details = "Details2", Value = 2 }
+                };
+
+                // Act
+                var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+                // Assert
+                Assert.AreEqual(1, savedToDos.Errors.Count);
+                Assert.AreEqual(1, savedToDos.Errors[0].Index);
+            }
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertExisting500ErrorResponseInMultiInsertAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient("5");
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo { Name = TestSetup.entity_name_for_500_response_error, Details = "Details1", Value = 1 },
+                    new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+                };
+
+                // Act
+                var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+                // Assert
+                Assert.AreEqual(1, savedToDos.Errors.Count);
+                Assert.AreEqual(0, savedToDos.Errors[0].Index);
+            }
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertExisting500ErrorResponseInUpdateAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient("5");
+
+                MockResponses(3);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo { ID = TestSetup.id_for_500_error_response_fake, Name = "Name1", Details = "Details1", Value = 1 },
+                    new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name2", Details = "Details2", Value = 2 }
+                };
+
+                // Act
+                var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
+
+                // Assert
+                Assert.AreEqual(1, savedToDos.Errors.Count);
+                Assert.AreEqual(0, savedToDos.Errors[0].Index);
+            }
+        }
+
         #endregion Positive tests
 
         #region Negative tests
@@ -6386,7 +6476,7 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowingExceptionAsync()
+        public async Task TestSaveMultiInsertThrowing400ErrorResponseInMultiInsertAsync()
         {
             if (MockData)
             {
@@ -6404,6 +6494,76 @@ namespace Kinvey.Tests
                 {
                     new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details1", Value = 1 },
                     new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details3", Value = 3 }
+                };
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStoreNetwork.SaveAsync(toDos);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            }
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertThrowing400ErrorResponseInUpdateAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient("5");
+
+                MockResponses(3);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo { ID = TestSetup.id_for_400_error_response_fake, Name = "Name1", Details = "Details1", Value = 1 },
+                    new ToDo { ID = TestSetup.id_for_400_error_response_fake, Name = "Name2", Details = "Details2", Value = 2 }
+                };
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStoreNetwork.SaveAsync(toDos);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            }
+        }
+  
+        [TestMethod]
+        public async Task TestSaveMultiInsertThrowing500ErrorResponseInMultiInsertAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient("5");
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo {  Name = TestSetup.entity_name_for_500_response_error, Details = "Details1", Value = 1 },
+                    new ToDo {  Name = TestSetup.entity_name_for_500_response_error, Details = "Details1", Value = 2 }
                 };
 
                 // Act
@@ -6451,36 +6611,6 @@ namespace Kinvey.Tests
                 var kinveyException = exception as KinveyException;
                 Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
                 Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
-            }
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertExisting500ErrorResponseInUpdateAsync()
-        {
-            if (MockData)
-            {
-                // Setup
-                kinveyClient = BuildClient("5");
-
-                MockResponses(3);
-
-                // Arrange
-                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-                var toDos = new List<ToDo>
-                {
-                    new ToDo { ID = TestSetup.id_for_500_error_response_fake, Name = "Name1", Details = "Details1", Value = 1 },
-                    new ToDo { ID = Guid.NewGuid().ToString(), Name = "Name2", Details = "Details2", Value = 2 }
-                };
-
-                // Act
-                var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
-
-                // Assert
-                Assert.AreEqual(1, savedToDos.Errors.Count);
-                Assert.AreEqual(0, savedToDos.Errors[0].Index);
             }
         }
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -88,6 +88,8 @@ namespace Kinvey.Tests
 			System.IO.File.Delete(TestSetup.SQLiteCredentialStoreFilePath);
 		}
 
+        #region ACL settings
+
         [TestMethod]
         public async Task TestACLGloballyReadableSave()
         {
@@ -336,6 +338,10 @@ namespace Kinvey.Tests
             kinveyClient.ActiveUser.Logout();
         }
 
+        #endregion ACL settings
+
+        #region Client settings
+
         [TestMethod]
         public async Task TestCollectionSharedClient()
         {
@@ -349,7 +355,7 @@ namespace Kinvey.Tests
             Assert.IsNotNull(todoStore);
             Assert.IsTrue(string.Equals(todoStore.CollectionName, collectionName));
         }
-
+        
         [TestMethod]
 		public async Task TestCollectionStoreType()
 		{
@@ -365,6 +371,61 @@ namespace Kinvey.Tests
 			Assert.AreEqual(todoStore.StoreType, DataStoreType.NETWORK);
 
 		}
+
+        #endregion Client settings
+
+        #region DeltaSetFetching
+
+        [TestMethod]
+        public void TestDeltaSetFetchEnable()
+        {
+            // Arrange
+            kinveyClient = BuildClient();
+
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
+
+            // Act
+            todoStore.DeltaSetFetchingEnabled = true;
+
+            // Assert
+            Assert.IsTrue(todoStore.DeltaSetFetchingEnabled);
+        }
+
+        #endregion DeltaSetFetching
+
+        #region Pull, Push, Sync
+
+        [TestMethod]
+        public async Task TestStoreInvalidOperation()
+        {
+            // Setup
+            kinveyClient = BuildClient();
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.PullAsync();
+            });
+
+            await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.PushAsync();
+            });
+
+            await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
+            {
+                await todoStore.SyncAsync();
+            });
+        }
+
+        #endregion Pull, Push, Sync
 
         #region Delete
 
@@ -3120,20 +3181,7 @@ namespace Kinvey.Tests
 
         #endregion Delete
 
-        [TestMethod]
-		public void TestDeltaSetFetchEnable()
-		{
-            // Arrange
-            kinveyClient = BuildClient();
-
-            DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK);
-
-			// Act
-			todoStore.DeltaSetFetchingEnabled = true;
-
-			// Assert
-			Assert.IsTrue(todoStore.DeltaSetFetchingEnabled);
-		}
+        #region GetCount
 
         [TestMethod]
         public async Task TestGetCountAsync()
@@ -3221,7 +3269,9 @@ namespace Kinvey.Tests
             // Assert
             Assert.AreEqual(1u, count);
         }
-        
+
+        #endregion GetCount
+
         #region Find
 
         #region Positive tests
@@ -5335,6 +5385,8 @@ namespace Kinvey.Tests
 
         #endregion Find
 
+        #region GroupAndAggregate
+
         [TestMethod]
         public async Task TestNetworkStoreGetAverageAsync()
         {
@@ -5562,6 +5614,8 @@ namespace Kinvey.Tests
             Assert.AreEqual(55, sum);
             Assert.AreEqual(1, arrGAR.Count());
         }
+
+        #endregion GroupAndAggregate
 
         #region Save
 
@@ -6371,35 +6425,7 @@ namespace Kinvey.Tests
 
         #endregion Save
 
-        [TestMethod]
-		public async Task TestStoreInvalidOperation()
-		{
-            // Setup
-            kinveyClient = BuildClient();
-
-            if (MockData)
-            {
-                MockResponses(1);
-            }
-			await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-			DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
-			{
-				await todoStore.PullAsync();
-			});
-
-            await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
-			{
-				await todoStore.PushAsync();
-			});
-
-            await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
-			{
-				await todoStore.SyncAsync();
-			});
-		}
+        #region Subscribe Unsubscribe
 
         [TestMethod]
         public async Task TestSubscribeUnsubscribeAsync()
@@ -6446,6 +6472,10 @@ namespace Kinvey.Tests
             }
         }
 
+        #endregion Subscribe Unsubscribe
+
+        #region GetSyncCount
+
         [TestMethod]
         public async Task TestGetSyncCount()
         {
@@ -6474,6 +6504,10 @@ namespace Kinvey.Tests
             Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_NETWORK, kinveyException.ErrorCategory);
             Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_INVALID_SYNC_COUNT_OPERATION, kinveyException.ErrorCode);
         }
+
+        #endregion GetSyncCount
+
+        #region ClearCache
 
         [TestMethod]
         public async Task TestClearCacheAsync()
@@ -6504,6 +6538,10 @@ namespace Kinvey.Tests
             Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_INVALID_CLEAR_CACHE_OPERATION, kinveyException.ErrorCode);
         }
 
+        #endregion ClearCache
+
+        #region Purge
+
         [TestMethod]
         public async Task TestPurge()
         {
@@ -6531,6 +6569,8 @@ namespace Kinvey.Tests
             var kinveyException = exception as KinveyException;
             Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_NETWORK, kinveyException.ErrorCategory);
             Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_INVALID_PURGE_OPERATION, kinveyException.ErrorCode);
-        }        
+        }
+
+        #endregion Purge
     }
 }

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -5676,6 +5676,8 @@ namespace Kinvey.Tests
 
         #region Multi insert
 
+        #region Positive tests
+
         [TestMethod]
         public async Task TestSaveMultiInsertNewItemsAsync()
         {
@@ -5764,7 +5766,7 @@ namespace Kinvey.Tests
             Assert.AreEqual(toDos[1].Value, savedToDos.Entities[1].Value);
             Assert.IsNotNull(existingToDos);
             Assert.AreEqual(2, existingToDos.Count);
-            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == toDos[0].ID &&  e.Name == toDos[0].Name && e.Details == toDos[0].Details && e.Value == toDos[0].Value));
+            Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == toDos[0].ID && e.Name == toDos[0].Name && e.Details == toDos[0].Details && e.Value == toDos[0].Value));
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == toDos[1].ID && e.Name == toDos[1].Name && e.Details == toDos[1].Details && e.Value == toDos[1].Value));
         }
 
@@ -5836,106 +5838,6 @@ namespace Kinvey.Tests
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == toDos[1].ID && e.Name == toDos[1].Name && e.Details == toDos[1].Details && e.Value == toDos[1].Value));
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.Name == toDos[2].Name && e.Details == toDos[2].Details && e.Value == toDos[2].Value));
             Assert.IsNotNull(existingToDos.FirstOrDefault(e => e.ID == toDos[3].ID && e.Name == toDos[3].Name && e.Details == toDos[3].Details && e.Value == toDos[3].Value));
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertEmptyArrayAsync()
-        {
-            // Setup
-            kinveyClient = BuildClient("5");
-
-            if (MockData)
-            {
-                MockResponses(1);
-            }
-
-            // Arrange
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStoreNetwork.SaveAsync(new List<ToDo>());
-            });
-
-            // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES, kinveyException.ErrorCode);
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertInvalidPermissionsAsync()
-        {
-            // Setup
-            kinveyClient = BuildClient("5");
-
-            if (MockData)
-            {
-                MockResponses(2);
-            }
-
-            // Arrange
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
-
-            var toDos = new List<ToDo>
-            {
-                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
-                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
-            };
-
-            // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                    await todoStoreNetwork.SaveAsync(toDos);
-            });
-
-            // Assert
-            Assert.IsTrue(exception.GetType() == typeof(KinveyException));
-            KinveyException ke = exception as KinveyException;
-            Assert.IsTrue(ke.ErrorCategory == EnumErrorCategory.ERROR_BACKEND);
-            Assert.IsTrue(ke.ErrorCode == EnumErrorCode.ERROR_JSON_RESPONSE);
-            Assert.IsTrue(401 == ke.StatusCode);
-        }
-
-        [TestMethod]
-        public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
-        {
-            // Setup
-            kinveyClient = BuildClient("4");
-
-            if (MockData)
-            {
-                MockResponses(1);
-            }
-
-            // Arrange
-            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
-
-            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
-
-            var toDos = new List<ToDo>
-            {
-                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
-                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
-            };
-
-            // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStoreNetwork.SaveAsync(toDos);
-            });
-
-            // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, kinveyException.ErrorCode);
         }
 
         [TestMethod]
@@ -6095,6 +5997,110 @@ namespace Kinvey.Tests
             }
         }
 
+        #endregion Positive tests
+
+        #region Negative tests
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertEmptyArrayAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient("5");
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(new List<ToDo>());
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_EMPTY_ARRAY_OF_ENTITIES, kinveyException.ErrorCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertInvalidPermissionsAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient("5");
+
+            if (MockData)
+            {
+                MockResponses(2);
+            }
+
+            // Arrange
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            await User.LoginAsync(TestSetup.user_without_permissions, TestSetup.pass_for_user_without_permissions, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.IsTrue(401 == kinveyException.StatusCode);
+        }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsertIncorrectKinveyApiVersionAsync()
+        {
+            // Setup
+            kinveyClient = BuildClient("4");
+
+            if (MockData)
+            {
+                MockResponses(1);
+            }
+
+            // Arrange
+            await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+            var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+            var toDos = new List<ToDo>
+            {
+                new ToDo { Name = "Name1", Details = "Details1", Value = 1 },
+                new ToDo { Name = "Name2", Details = "Details2", Value = 2 }
+            };
+
+            // Act
+            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+            {
+                await todoStoreNetwork.SaveAsync(toDos);
+            });
+
+            // Assert
+            Assert.AreEqual(typeof(KinveyException), exception.GetType());
+            var kinveyException = exception as KinveyException;
+            Assert.AreEqual(EnumErrorCategory.ERROR_GENERAL, kinveyException.ErrorCategory);
+            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_NOT_COMPATIBLE_KINVEY_API_VERSION, kinveyException.ErrorCode);
+        }
+
         [TestMethod]
         public async Task TestSaveMultiInsertThrowingExceptionAsync()
         {
@@ -6129,6 +6135,42 @@ namespace Kinvey.Tests
                 Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
             }
         }
+
+        [TestMethod]
+        public async Task TestSaveMultiInsert500ErrorResponseAsync()
+        {
+            if (MockData)
+            {
+                // Setup
+                kinveyClient = BuildClient("5");
+
+                MockResponses(2);
+
+                // Arrange
+                await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
+
+                var todoStoreNetwork = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
+
+                var toDos = new List<ToDo>
+                {
+                    new ToDo { ID = TestSetup.id_for_500_error_response_fake, Name = "Name1", Details = "Details1", Value = 1 },
+                };
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await todoStoreNetwork.SaveAsync(toDos);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            }
+        }
+
+        #endregion Negative tests
 
         #endregion Multi insert
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -6359,13 +6359,12 @@ namespace Kinvey.Tests
                 // Setup
                 kinveyClient = BuildClient("5");
 
-                MockResponses(3);
+                MockResponses(2);
 
                 // Arrange
                 await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
 
                 var todoSyncStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC, kinveyClient);
-                var todoNetworkStore = DataStore<ToDo>.Collection(collectionName, DataStoreType.NETWORK, kinveyClient);
 
                 var toDos = new List<ToDo>
                 {
@@ -6383,7 +6382,7 @@ namespace Kinvey.Tests
                 var existingToDos = await todoSyncStore.FindAsync();
 
                 // Teardown
-                await todoNetworkStore.RemoveAsync(savedToDos.Entities[2].ID);
+                await todoSyncStore.RemoveAsync(savedToDos.Entities[2].ID);
 
                 // Assert
                 Assert.AreEqual(3, pushResponse.PushCount);

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -6369,7 +6369,7 @@ namespace Kinvey.Tests
                 var toDos = new List<ToDo>
                 {
                     new ToDo { Name = "Name1", Details = "Details1", Value = 1, GeoLoc = "[200,200]" },
-                    new ToDo { Name = TestSetup.entity_with_error, Details = "Details2", Value = 2 },
+                    new ToDo { Name = TestSetup.entity_name_for_400_response_error, Details = "Details2", Value = 2 },
                     new ToDo { Name = "Name3", Details = "Details3", Value = 3 }
                 };
 

--- a/Kinvey.Tests/Support Files/Code/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/Code/TestSetup.cs
@@ -35,7 +35,8 @@ namespace Kinvey.Tests
         public const string auth_token_corrupted_for_401_response_fake = "f7991119-f9e6-4c6e-9b38-9659c2b06cea";
         public const string refresh_token_for_401_response_fake = "0f550503-f033-44ee-8c2d-ae8f9773b70a";
 
-        public const string entity_with_error = "Entity with error";
+        public const string entity_name_for_400_response_error = "Entity name for 400 response error";
+        public const string entity_name_for_500_response_error = "Entity name for 500 response error";
 
         public const string mic_id_fake = "ade8db71f61c46a69c91910d8fbf3994";
 

--- a/test-ios-app/test-ios-app.csproj
+++ b/test-ios-app/test-ios-app.csproj
@@ -495,6 +495,8 @@
     <ProjectReference Include="..\Kinvey.iOS\Kinvey.iOS.csproj">
       <Project>{54C9E523-785C-48CF-B77C-B28842DC0ABF}</Project>
       <Name>Kinvey.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />

--- a/testiosapp2/testiosapp2.csproj
+++ b/testiosapp2/testiosapp2.csproj
@@ -131,6 +131,8 @@
     <ProjectReference Include="..\Kinvey.iOS\Kinvey.iOS.csproj">
       <Project>{54C9E523-785C-48CF-B77C-B28842DC0ABF}</Project>
       <Name>Kinvey.iOS</Name>
+      <IsAppExtension>false</IsAppExtension>
+      <IsWatchApp>false</IsWatchApp>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />


### PR DESCRIPTION
#### Description
Simulating various 4xx/5xx responses that we get from the backend, to ensure that we correctly handle these backend errors.

#### Changes
No Changes

#### Tests
TestDelete400ErrorResponseAsync()
TestDelete401ErrorResponseAsync()
TestDelete404ErrorResponseAsync()
TestDelete500ErrorResponseAsync()
TestDeleteByQuery401ErrorResponseAsync()
TestSave400ErrorResponseAsync()
TestSave401ErrorResponseAsync()
TestSave500ErrorResponseAsync()
TestSaveMultiInsertExisting400ErrorResponseInUpdateAsync()
TestSaveMultiInsertExisting500ErrorResponseInMultiInsertAsync()
TestSaveMultiInsertExisting500ErrorResponseInUpdateAsync()
TestSaveMultiInsertInvalidPermissionsForUpdateAsync()
TestSaveMultiInsertThrowing400ErrorResponseInMultiInsertAsync()
TestSaveMultiInsertThrowing400ErrorResponseInUpdateAsync()
TestSaveMultiInsertThrowing500ErrorResponseInMultiInsertAsync()
TestSaveMultiInsertThrowing500ErrorResponseInUpdateAsync()
