### PR TITLE
MLIBZ-2995: Add mocks for data store 'Pull/Push/Sync' operations (.NET)

### DIFF
--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -450,6 +450,12 @@ namespace Kinvey.Tests
                 return;
             }
 
+            if (obj["name"] != null && obj["name"].ToString().Equals(TestSetup.entity_name_for_500_response_error))
+            {
+                MockInternal(context);
+                return;
+            }
+
             if (obj["_id"] != null && obj["_id"].ToString().Equals(TestSetup.id_for_400_error_response_fake))
             {
                 MockBadRequest(context);
@@ -1306,6 +1312,12 @@ namespace Kinvey.Tests
                                     Write(context, jsonObject);
                                     break;
                                 }
+                            case "/appdata/_kid_/BadRequestErrorEntity":
+                                MockBadRequest(context);
+                                break;
+                            case "/appdata/_kid_/InternalServerErrorEntity":
+                                MockInternal(context);
+                                break;                                
                             case "/blob/_kid_/":
                                 MockBlob(context, blobs);
                                 break;

--- a/Kinvey.Tests/Support Files/Code/BadRequestErrorEntity.cs
+++ b/Kinvey.Tests/Support Files/Code/BadRequestErrorEntity.cs
@@ -1,0 +1,11 @@
+﻿using Newtonsoft.Json;
+
+namespace Kinvey.Tests
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class BadRequestErrorEntity : Entity
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}

--- a/Kinvey.Tests/Support Files/Code/InternalServerErrorEntity.cs
+++ b/Kinvey.Tests/Support Files/Code/InternalServerErrorEntity.cs
@@ -1,0 +1,14 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kinvey.Tests
+{
+    [JsonObject(MemberSerialization.OptIn)]
+    public class InternalServerErrorEntity : Entity
+    {
+        [JsonProperty("name")]
+        public string Name { get; set; }
+    }
+}


### PR DESCRIPTION
#### Description
Simulating various 4xx/5xx responses that we get from the backend, to ensure that we correctly handle these backend errors.

#### Changes
No changes

#### Tests
TestPush400ErrorResponseAsync()
TestPush401ErrorResponseAsync()
TestPush500ErrorResponseAsync()
TestPullDataNetwork400ErrorResponseAsync()
TestPullDataNetwork401ErrorResponseAsync()
TestPullDataNetwork500ErrorResponseAsync()
TestSyncPush400ErrorResponseAsync()
TestSyncPull400ErrorResponseAsync()
TestSyncPush401ErrorResponseAsync()
TestSyncPull401ErrorResponseAsync()
TestSyncPush500ErrorResponseAsync()
TestSyncPull500ErrorResponseAsync()
