### PR TITLE
MLIBZ-3145: Failing in a batch of multi-insert requests

### DIFF
--- a/Kinvey.Shared/Store/MultiInsertRequest.cs
+++ b/Kinvey.Shared/Store/MultiInsertRequest.cs
@@ -362,19 +362,17 @@ namespace Kinvey
             }
             catch (KinveyException exception)
             {
-                if (exception.StatusCode == 500)
-                {
-                    response.Entities = new List<T>();
-                    response.Errors = new List<Error>();
-                    for (var index = 0; index < entities.Count(); index++)
-                    {
-                        response.Entities.Add(default(T));
-                        response.Errors.Add(new Error { Code = 0, Errmsg = exception.Message, Index = index });
-                    }
-                }
-                else
+                if (exception.StatusCode == 401)
                 {
                     throw;
+                }
+
+                response.Entities = new List<T>();
+                response.Errors = new List<Error>();
+                for (var index = 0; index < entities.Count(); index++)
+                {
+                    response.Entities.Add(default(T));
+                    response.Errors.Add(new Error { Code = 0, Errmsg = exception.Message, Index = index });
                 }
             }
 

--- a/Kinvey.TestApp.Shared/Constants.cs
+++ b/Kinvey.TestApp.Shared/Constants.cs
@@ -12,7 +12,6 @@
             public const string ContractsCollection = "contracts";
         }
 
-
         public static class Exceptions
         {
             public const string GeneralExceptionTitle = "General exception";


### PR DESCRIPTION
#### Description
In a batch of multi-insert requests, if a whole batch fails, the response to the whole operation is an error.

#### Changes
The logic of handling exceptions in the multi-insert operation.

#### Tests
TestSaveMultiInsert201CountWithErrorsAsync()
