### PR TITLE
MLIBZ-2821: Provide more descriptive message for response body parsing errors

### DIFF
--- a/Kinvey.Shared/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Shared/Core/AbstractKinveyClientRequest.cs
@@ -563,26 +563,33 @@ namespace Kinvey
             {
                 return default(T);
             }
+
+            string json = null;
             try
             {
                 var task = response.Content.ReadAsStringAsync();
                 task.Wait();
-                return JsonConvert.DeserializeObject<T>(task.Result);
+                json = task.Result;
+                return JsonConvert.DeserializeObject<T>(json);
             }
-			catch(JsonException ex){
-                throw new KinveyException(EnumErrorCategory.ERROR_DATASTORE_NETWORK, EnumErrorCode.ERROR_JSON_PARSE, ex.Message)
+            catch (JsonException ex)
+            {
+                throw new KinveyException(EnumErrorCategory.ERROR_DATASTORE_NETWORK, EnumErrorCode.ERROR_JSON_PARSE,
+                    HelperMethods.GetCustomParsingJsonErrorMessage(json, response.RequestMessage.RequestUri.ToString(), typeof(T).FullName),
+                    null,
+                    ex)
                 {
                     RequestID = HelperMethods.getRequestID(response)
                 };
-			}
-            catch(ArgumentException ex)
+            }
+            catch (ArgumentException ex)
             {
-				Logger.Log (ex.Message);  
+                Logger.Log(ex.Message);
                 return default(T);
             }
             catch (NullReferenceException ex)
             {
-				Logger.Log (ex.Message);
+                Logger.Log(ex.Message);
                 return default(T);
             }
 
@@ -679,9 +686,10 @@ namespace Kinvey
                 }
 			}
 
+            string json = null;
 			try
 			{
-                var json = await response.Content.ReadAsStringAsync();
+                json = await response.Content.ReadAsStringAsync();
                 var result = JsonConvert.DeserializeObject<T>(json);
 
                 RequestStartTime = HelperMethods.GetRequestStartTime(response);
@@ -693,7 +701,8 @@ namespace Kinvey
                 KinveyException kinveyException = new KinveyException(
                     EnumErrorCategory.ERROR_DATASTORE_NETWORK,
                     EnumErrorCode.ERROR_JSON_PARSE,
-                    ex.Message,
+                    HelperMethods.GetCustomParsingJsonErrorMessage(json, response.RequestMessage.RequestUri.ToString(), typeof(T).FullName),
+                    null,
                     ex
                 ) {
                     RequestID = HelperMethods.getRequestID(response)

--- a/Kinvey.Shared/Troubleshooting/KinveyException.cs
+++ b/Kinvey.Shared/Troubleshooting/KinveyException.cs
@@ -114,18 +114,39 @@ namespace Kinvey
 		/// <value>The status code.</value>
 		public int StatusCode { get; set; }
 
-		#endregion
+        #endregion
 
-		#region Constructors
+        #region Constructors
 
-		/// <summary>
-		/// Initializes a new instance of the <see cref="KinveyXamarin.KinveyException"/> class.
-		/// </summary>
-		/// <param name="errorCategory">The <see cref="KinveyXamarin.EnumErrorCategory"/>  of the exception.</param>
-		/// <param name="errorCode">The <see cref="KinveyXamarin.EnumErrorCode"/>  of the exception.</param>
-		/// <param name="info">Additional information about the exception, if available.</param>
-		/// <param name="innerException">[optional] Inner exception thrown, if available.</param>
-		public KinveyException(EnumErrorCategory errorCategory, EnumErrorCode errorCode, string info, Exception innerException = null)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KinveyException"/> class.
+        /// </summary>
+        /// <param name="errorCategory">The <see cref="EnumErrorCategory"/>  of the exception.</param>
+        /// <param name="errorCode">The <see cref="EnumErrorCode"/>  of the exception.</param>
+        /// <param name="message">The message of the exception.</param>
+        /// <param name="info">Additional information about the exception.</param>
+        /// <param name="innerException">[optional] Inner exception thrown, if available.</param>
+        public KinveyException(EnumErrorCategory errorCategory, EnumErrorCode errorCode, string message, string info, Exception innerException = null)
+            : base(message, innerException)
+        {
+            this.errorCategory = errorCategory;
+            this.errorCode = errorCode;
+            this.info = info;
+
+            Tuple<string, string, string> errorInfo = InfoFromErrorCode(errorCategory, errorCode);
+            this.error = errorInfo.Item1;
+            this.debug = errorInfo.Item2;
+            this.description = errorInfo.Item3;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="KinveyException"/> class.
+        /// </summary>
+        /// <param name="errorCategory">The <see cref="EnumErrorCategory"/>  of the exception.</param>
+        /// <param name="errorCode">The <see cref="EnumErrorCode"/>  of the exception.</param>
+        /// <param name="info">Additional information about the exception.</param>
+        /// <param name="innerException">[optional] Inner exception thrown, if available.</param>
+        public KinveyException(EnumErrorCategory errorCategory, EnumErrorCode errorCode, string info, Exception innerException = null)
 			: base(MessageFromErrorCode(errorCategory, errorCode), innerException)
 		{
 			this.errorCategory = errorCategory;

--- a/Kinvey.Shared/Utils/HelperMethods.cs
+++ b/Kinvey.Shared/Utils/HelperMethods.cs
@@ -114,7 +114,7 @@ namespace Kinvey
 
         internal static string GetCustomParsingJsonErrorMessage(string json, string requestUri, string typeName)
         {
-            string jTokenType = string.Empty;
+            var jTokenType = "unknown json format";
 
             try
             {
@@ -123,11 +123,6 @@ namespace Kinvey
             catch (JsonReaderException)
             {
 
-            }
-
-            if (string.IsNullOrEmpty(jTokenType))
-            {
-                jTokenType = "unknown json format";
             }
 
             return $"Received {jTokenType} for API call {requestUri}, but expected {typeName}.";

--- a/Kinvey.Shared/Utils/HelperMethods.cs
+++ b/Kinvey.Shared/Utils/HelperMethods.cs
@@ -11,6 +11,8 @@
 // Unauthorized reproduction, transmission or distribution of this file and its
 // contents is a violation of applicable laws.
 
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -108,6 +110,27 @@ namespace Kinvey
         internal static bool IsLessThan(string checkingValue, int comparingValue)
         {
             return !int.TryParse(checkingValue, out int checkingValueNumber) || checkingValueNumber < comparingValue;
+        }
+
+        internal static string GetCustomParsingJsonErrorMessage(string json, string requestUri, string typeName)
+        {
+            string jTokenType = string.Empty;
+
+            try
+            {
+                jTokenType = JToken.Parse(json).Type.ToString();
+            }
+            catch (JsonReaderException)
+            {
+
+            }
+
+            if (string.IsNullOrEmpty(jTokenType))
+            {
+                jTokenType = "unknown json format";
+            }
+
+            return $"Received {jTokenType} for API call {requestUri}, but expected {typeName}.";
         }
     }
 }

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -261,6 +261,11 @@ namespace Kinvey.Tests
                             ["authtoken"] = TestSetup.auth_token_corrupted_for_401_response_fake
                         };
                     }
+                    else if (user["username"].ToString().Equals(TestSetup.user_with_invalid_json_response) && user["password"].ToString().Equals(TestSetup.pass_for_user_with_invalid_json_response))
+                    {
+                        Write(context, "Unknown json format");
+                        return;
+                    }
                     else
                     {
                         user["_kmd"] = new JObject
@@ -1133,6 +1138,19 @@ namespace Kinvey.Tests
                         },
                     };
 
+                    var userWithInvalidJsonResponseId = Guid.NewGuid().ToString();
+                    users[userWithInvalidJsonResponseId] = new JObject
+                    {
+                        ["_id"] = userWithInvalidJsonResponseId,
+                        ["username"] = TestSetup.user_with_invalid_json_response,
+                        ["password"] = TestSetup.pass_for_user_with_invalid_json_response,
+                        ["email"] = $"{Guid.NewGuid().ToString()}@kinvey.com",
+                        ["_acl"] = new JObject()
+                        {
+                            ["creator"] = userWithInvalidJsonResponseId,
+                        },
+                    };
+
                     #endregion Existing users
 
                     #region Social networks users
@@ -1394,6 +1412,9 @@ namespace Kinvey.Tests
                                 break;
                             case "/user/_kid_/_lookup":
                                 MockUserLookup(context, users.Values);
+                                break;
+                            case "/fake_request":
+                                Write(context, "[]");
                                 break;
                             case "/user/_kid_/login":
                                 MockUserLogin(context, users.Values, signedUsers);

--- a/Kinvey.Tests/Support Files/Code/FakeRequest.cs
+++ b/Kinvey.Tests/Support Files/Code/FakeRequest.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Kinvey.Tests
+{
+    public class FakeRequest : AbstractKinveyClientRequest<ToDo>
+    {
+        private const string REST_PATH = "fake_request";
+
+        public FakeRequest(AbstractClient client, Dictionary<string, string> urlProperties) :
+        base(client, "POST", REST_PATH, null, urlProperties)
+        {
+
+        }
+    }
+}

--- a/Kinvey.Tests/Support Files/Code/TestSetup.cs
+++ b/Kinvey.Tests/Support Files/Code/TestSetup.cs
@@ -18,6 +18,9 @@ namespace Kinvey.Tests
         public const string user_with_corrupted_auth_token = "userwithcorruptedauthtoken";
         public const string pass_for_user_with_corrupted_auth_token = "userwithcorruptedauthtoken";
 
+        public const string user_with_invalid_json_response = "userwithinvalidjsonresponse";
+        public const string pass_for_user_with_invalid_json_response = "userwithinvalidjsonresponse";
+
         public const string app_key = "kid_Zy0JOYPKkZ";
 		public const string app_secret = "d83de70e64d540e49acd6cfce31415df";
 

--- a/Kinvey.Tests/UserTests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserTests/UserIntegrationTests.cs
@@ -161,6 +161,29 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
+        public async Task TestLoginUserPassParsingJsonErrorAsync()
+        {            
+            if (MockData)
+            {
+                // Arrange
+                MockResponses(1);
+
+                // Act
+                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
+                {
+                    await User.LoginAsync(TestSetup.user_with_invalid_json_response, TestSetup.pass_for_user_with_invalid_json_response, kinveyClient);
+                });
+
+                // Assert
+                Assert.AreEqual(typeof(KinveyException), exception.GetType());
+                var kinveyException = exception as KinveyException;
+                Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_NETWORK, kinveyException.ErrorCategory);
+                Assert.AreEqual(EnumErrorCode.ERROR_JSON_PARSE, kinveyException.ErrorCode);
+                Assert.AreEqual("Received unknown json format for API call http://localhost:8080/user/_kid_/login, but expected Kinvey.KinveyAuthResponse.", kinveyException.Message);
+            }
+        }
+
+        [TestMethod]
         public async Task TestLoginFacebookAsync()
         {
             // Arrange


### PR DESCRIPTION
#### Description
A request from support to be more detailed in our error messaging around parsing errors in responses from the backend. If we fail to process a response from the backend because we cannot correctly parse the response body, let's return a more descriptive error message, rather than the generic error message currently returned.

An example of a more descriptive error message given by support is:

"Received an array for API call {endpoint}, but expected an object".

#### Changes
Handling JsonException for all network requests.

#### Tests
TestLoginUserPassParsingJsonErrorAsync()
TestNetworkStoreParsingJsonErrorAsync()
TestNetworkStoreParsingJsonErrorSync()
