### PR TITLE
MLIBZ-3164: Cleanup: Kinvey.Shared/Store project (Into next-v5) 

### DIFF
--- a/Kinvey.Shared/Store/ReadPolicy.cs
+++ b/Kinvey.Shared/Store/ReadPolicy.cs
@@ -11,6 +11,8 @@
 // Unauthorized reproduction, transmission or distribution of this file and its
 // contents is a violation of applicable laws.
 
+using System;
+
 namespace Kinvey
 {
     /// <summary>
@@ -26,10 +28,11 @@ namespace Kinvey
 		/// Executes the request from the cache every single time.
 		/// </summary>
 		FORCE_LOCAL,
-		/// <summary>
-		/// Attempts to get the response from the cache, if it's not present attempts to execute online.  If online is successful, the response will cached.
-		/// </summary>
-		BOTH,
+        /// <summary>
+        /// Attempts to get the response from the cache, if it's not present attempts to execute online.  If online is successful, the response will cached.
+        /// </summary>
+        [Obsolete("This enum value has been deprecated. Please use NETWORK_OTHERWISE_LOCAL instead.")]
+        BOTH,
         /// <summary>
 		/// Tries to get the most recent data from the backend first, if it fails it returns data from the local cache.
 		/// </summary>

--- a/Kinvey.Shared/Store/ReadRequest.cs
+++ b/Kinvey.Shared/Store/ReadRequest.cs
@@ -117,6 +117,7 @@ namespace Kinvey
         /// <param name="networkItems">Network items.</param>
         /// <param name="mongoQuery">Mongo query.</param>
 		/// <returns>The async task with the list of entities.</returns>
+        [Obsolete("This method has been deprecated.")]
 		protected async Task<List<T>> RetrieveDeltaSet(List<T> cacheItems, List<DeltaSetFetchInfo> networkItems, string mongoQuery)
 		{
 			List<T> listDeltaSetResults = new List<T>();

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -112,8 +112,8 @@ namespace Kinvey.Tests
             // Act            
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var networkEntities = await networkStore.FindAsync();
-            var localEntities = await syncStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem3.ID);
@@ -168,7 +168,7 @@ namespace Kinvey.Tests
             });
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await syncStore.FindAsync();
+            var existingToDos = await syncStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.AreEqual(typeof(KinveyException), exception.GetType());
@@ -225,15 +225,15 @@ namespace Kinvey.Tests
             KinveyException exception = null;
             try
             {
-                existingItem1 = await networkStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await networkStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
                 exception = kinveyException;
             }
 
-            var networkEntities = await networkStore.FindAsync();
-            var localEntities = await syncStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem2.ID);
@@ -302,8 +302,8 @@ namespace Kinvey.Tests
             // Act            
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var networkEntities = await networkStore.FindAsync();
-            var localEntities = await syncStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem1.ID);
@@ -368,8 +368,8 @@ namespace Kinvey.Tests
             var pushResult = await autoStore.PushAsync();
             var pendingWriteActions2 = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
-            var localEntities = await syncStore.FindAsync(query);
-            var networkEntities = await networkStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: query, ct: default);
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem3.ID);
@@ -430,7 +430,7 @@ namespace Kinvey.Tests
             SetRootUrlToKinveyClient(kinveyUrl);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await syncStore.FindAsync();
+            var existingToDos = await syncStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.IsNotNull(pendingWriteActions);
@@ -491,15 +491,15 @@ namespace Kinvey.Tests
             ToDo existingItem1InLocalStorage = null;
             try
             {
-                existingItem1InLocalStorage = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItem1InLocalStorage = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
                 syncStoreException = kinveyException;
             }
            
-            var networkEntities = await networkStore.FindAsync();
-            var localEntities = await syncStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem2.ID);
@@ -561,8 +561,8 @@ namespace Kinvey.Tests
             // Act
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var listToDoNetwork = await autoStore.FindAsync();
-            var listToDoCache = await syncStore.FindAsync();
+            var listToDoNetwork = await autoStore.FindAsync(query: null, ct: default);
+            var listToDoCache = await syncStore.FindAsync(query: null, ct: default);
 
             var existingItemInNetwork1 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem1.ID);
             var existingItemInNetwork2 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem2.ID);
@@ -637,8 +637,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -647,8 +647,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -657,8 +657,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -732,8 +732,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -742,8 +742,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -752,8 +752,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -826,8 +826,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -836,8 +836,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -846,8 +846,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -926,8 +926,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -936,8 +936,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -946,8 +946,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1026,8 +1026,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1036,8 +1036,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1046,8 +1046,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1127,8 +1127,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1137,8 +1137,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1147,8 +1147,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1228,8 +1228,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1238,8 +1238,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1248,8 +1248,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1329,8 +1329,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1339,8 +1339,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1349,8 +1349,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1431,8 +1431,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1441,8 +1441,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1451,8 +1451,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1533,8 +1533,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1543,8 +1543,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1553,8 +1553,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1634,8 +1634,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct:default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1644,8 +1644,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1654,8 +1654,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1735,8 +1735,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1745,8 +1745,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1755,8 +1755,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1836,8 +1836,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1846,8 +1846,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1856,8 +1856,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1939,8 +1939,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1949,8 +1949,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1959,8 +1959,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2041,8 +2041,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2051,8 +2051,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2061,8 +2061,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2143,8 +2143,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID);
-                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork1 = await autoStore.FindByIDAsync(savedItem1.ID, ct: default);
+                existingItemInCache1 = await syncStore.FindByIDAsync(savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2153,8 +2153,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID);
-                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID);
+                existingItemInNetwork2 = await autoStore.FindByIDAsync(savedItem2.ID, ct: default);
+                existingItemInCache2 = await syncStore.FindByIDAsync(savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2163,8 +2163,8 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID);
-                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID);
+                existingItemInNetwork3 = await autoStore.FindByIDAsync(savedItem3.ID, ct: default);
+                existingItemInCache3 = await syncStore.FindByIDAsync(savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2237,8 +2237,8 @@ namespace Kinvey.Tests
             // Act
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var listToDoNetwork = await networkStore.FindAsync();
-            var listToDoCache = await syncStore.FindAsync();
+            var listToDoNetwork = await networkStore.FindAsync(query: null, ct: default);
+            var listToDoCache = await syncStore.FindAsync(query: null, ct: default);
 
             var existingItemInNetwork1 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem1.ID);
             var existingItemInNetwork2 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem2.ID);
@@ -2314,8 +2314,8 @@ namespace Kinvey.Tests
             // Act
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var listToDoNetwork = await networkStore.FindAsync();
-            var listToDoCache = await syncStore.FindAsync();
+            var listToDoNetwork = await networkStore.FindAsync(query: null, ct: default);
+            var listToDoCache = await syncStore.FindAsync(query: null, ct: default);
 
             var existingItemInNetwork1 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem1.ID);
             var existingItemInNetwork2 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem2.ID);
@@ -2392,8 +2392,8 @@ namespace Kinvey.Tests
             // Act
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var listToDoNetwork = await networkStore.FindAsync();
-            var listToDoCache = await syncStore.FindAsync();
+            var listToDoNetwork = await networkStore.FindAsync(query: null, ct: default);
+            var listToDoCache = await syncStore.FindAsync(query: null, ct: default);
 
             var existingItemInNetwork1 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem1.ID);
             var existingItemInNetwork2 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem2.ID);
@@ -2470,8 +2470,8 @@ namespace Kinvey.Tests
             // Act
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var listToDoNetwork = await networkStore.FindAsync();
-            var listToDoCache = await syncStore.FindAsync();
+            var listToDoNetwork = await networkStore.FindAsync(query: null, ct: default);
+            var listToDoCache = await syncStore.FindAsync(query: null, ct: default);
 
             var existingItemInNetwork1 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem1.ID);
             var existingItemInNetwork2 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem2.ID);
@@ -2549,8 +2549,8 @@ namespace Kinvey.Tests
             // Act
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var listToDoNetwork = await networkStore.FindAsync();
-            var listToDoCache = await syncStore.FindAsync();
+            var listToDoNetwork = await networkStore.FindAsync(query: null, ct: default);
+            var listToDoCache = await syncStore.FindAsync(query: null, ct: default);
 
             var existingItemInNetwork1 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem1.ID);
             var existingItemInNetwork2 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem2.ID);
@@ -2627,8 +2627,8 @@ namespace Kinvey.Tests
             // Act
             var kinveyDeleteResponse = await autoStore.RemoveAsync(query);
 
-            var listToDoNetwork = await networkStore.FindAsync();
-            var listToDoCache = await syncStore.FindAsync();
+            var listToDoNetwork = await networkStore.FindAsync(query: null, ct: default);
+            var listToDoCache = await syncStore.FindAsync(query: null, ct: default);
 
             var existingItemInNetwork1 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem1.ID);
             var existingItemInNetwork2 = listToDoNetwork.FirstOrDefault(todo => todo.ID == savedItem2.ID);
@@ -3097,7 +3097,7 @@ namespace Kinvey.Tests
             ToDo existingItem1InNetwork = null;
             try
             {
-                existingItem1InNetwork = await networkStore.FindByIDAsync(savedItem1.ID);
+                existingItem1InNetwork = await networkStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -3108,7 +3108,7 @@ namespace Kinvey.Tests
             ToDo existingItem1InLocal = null;
             try
             {
-                existingItem1InLocal = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItem1InLocal = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -3169,7 +3169,7 @@ namespace Kinvey.Tests
             });
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await syncStore.FindAsync();
+            var existingToDos = await syncStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.AreEqual(typeof(KinveyException), exception.GetType());
@@ -3218,8 +3218,8 @@ namespace Kinvey.Tests
             var pushResult = await autoStore.PushAsync();
             var pendingWriteActions2 = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
-            var localEntity = await syncStore.FindByIDAsync(newItem1.ID);
-            var networkEntities = await networkStore.FindAsync();
+            var localEntity = await syncStore.FindByIDAsync(entityID: newItem1.ID, ct: default);
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             // Assert            
             Assert.IsNotNull(kinveyDeleteResponse);
@@ -3269,7 +3269,7 @@ namespace Kinvey.Tests
             SetRootUrlToKinveyClient(kinveyUrl);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await syncStore.FindAsync();
+            var existingToDos = await syncStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.IsNotNull(pendingWriteActions);
@@ -3364,7 +3364,7 @@ namespace Kinvey.Tests
             ToDo existingItem1InLocal = null;
             try
             {
-                existingItem1InLocal = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItem1InLocal = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -3466,14 +3466,14 @@ namespace Kinvey.Tests
             newItem2 = await networkStore.SaveAsync(newItem2);
             
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
 
-            var listToDoSync1 = await syncStore.FindAsync();
+            var listToDoSync1 = await syncStore.FindAsync(query: null, ct: default);
 
             newItem3 = await networkStore.SaveAsync(newItem3);
 
-            var listToDoAuto2 = await autoStore.FindAsync();
-            var listToDoSync2 = await syncStore.FindAsync();
+            var listToDoAuto2 = await autoStore.FindAsync(query: null, ct: default);
+            var listToDoSync2 = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -3537,8 +3537,8 @@ namespace Kinvey.Tests
             newItem3 = await networkStore.SaveAsync(newItem3);
 
             // Act          
-            var listToDoAuto = await autoStore.FindAsync(query);
-            var listToDoSync = await syncStore.FindAsync(query);
+            var listToDoAuto = await autoStore.FindAsync(query: query, ct: default);
+            var listToDoSync = await syncStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -3598,8 +3598,8 @@ namespace Kinvey.Tests
             newItem3 = await networkStore.SaveAsync(newItem3);
 
             // Act          
-            var listToDoAuto = await autoStore.FindAsync(query);
-            var listToDoSync = await syncStore.FindAsync(query);
+            var listToDoAuto = await autoStore.FindAsync(query: query, ct: default);
+            var listToDoSync = await syncStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -3658,19 +3658,19 @@ namespace Kinvey.Tests
             newItem2 = await networkStore.SaveAsync(newItem2);           
 
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
             newItem3 = await networkStore.SaveAsync(newItem3);
-            var listToDoAuto2 = await autoStore.FindAsync();
+            var listToDoAuto2 = await autoStore.FindAsync(query: null, ct: default);
 
             var queryCacheItems = kinveyClient.CacheManager.GetCache<QueryCacheItem>("QueryCacheItem");
             var queryCacheItemBefore = queryCacheItems.FindAll().FirstOrDefault();
 
             newItem4 = await networkStore.SaveAsync(newItem4);
 
-            var listToDoAuto3 = await autoStore.FindAsync();
+            var listToDoAuto3 = await autoStore.FindAsync(query: null, ct: default);
             var queryCacheItemAfter = queryCacheItems.FindAll().FirstOrDefault();
 
-            var listToDoSync = await syncStore.FindAsync();
+            var listToDoSync = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -3733,7 +3733,7 @@ namespace Kinvey.Tests
             var query = autoStore.OrderByDescending(task => task.Details);
 
             // Act          
-            var listToDoAuto = await autoStore.FindAsync(query);
+            var listToDoAuto = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -3783,7 +3783,7 @@ namespace Kinvey.Tests
             await autoStore.RemoveAsync(newItem1.ID);
 
             // Act          
-            var listToDoSync = await syncStore.FindAsync();
+            var listToDoSync = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(newItem2.ID);
@@ -3833,7 +3833,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await autoStore.FindAsync(query);
+                await autoStore.FindAsync(query: query, ct: default);
             });
 
             // Teardown
@@ -3866,7 +3866,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await autoStore.FindAsync();
+                await autoStore.FindAsync(query: null, ct: default);
             });
 
             // Assert
@@ -3916,12 +3916,12 @@ namespace Kinvey.Tests
             newItem2 = await networkStore.SaveAsync(newItem2);
 
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
 
             newItem3 = await networkStore.SaveAsync(newItem3);
 
             SetRootUrlToKinveyClient(unreachableUrl);           
-            var listToDoAuto2 = await autoStore.FindAsync();
+            var listToDoAuto2 = await autoStore.FindAsync(query: null, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
 
             // Teardown
@@ -3982,17 +3982,17 @@ namespace Kinvey.Tests
             newItem2 = await networkStore.SaveAsync(newItem2);
 
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
 
             newItem3 = await networkStore.SaveAsync(newItem3);
 
             SetRootUrlToKinveyClient(unreachableUrl);
-            var listToDoAuto2 = await autoStore.FindAsync();
+            var listToDoAuto2 = await autoStore.FindAsync(query: null, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
 
             newItem4 = await networkStore.SaveAsync(newItem4);
 
-            var listToDoAuto3 = await autoStore.FindAsync();
+            var listToDoAuto3 = await autoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -4054,10 +4054,10 @@ namespace Kinvey.Tests
             newItem3 = await networkStore.SaveAsync(newItem3);
 
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
 
             SetRootUrlToKinveyClient(unreachableUrl);
-            var listToDoAuto2 = await autoStore.FindAsync(query);
+            var listToDoAuto2 = await autoStore.FindAsync(query: query, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
 
             // Teardown
@@ -4117,10 +4117,10 @@ namespace Kinvey.Tests
             newItem3 = await networkStore.SaveAsync(newItem3);
 
             // Act
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
 
             SetRootUrlToKinveyClient(unreachableUrl);
-            var listToDoAuto2 = await autoStore.FindAsync(query);
+            var listToDoAuto2 = await autoStore.FindAsync(query: query, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
 
             // Teardown
@@ -4178,10 +4178,10 @@ namespace Kinvey.Tests
             var query = autoStore.OrderByDescending(task => task.Details);
 
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync(query);
+            var listToDoAuto1 = await autoStore.FindAsync(query: query, ct: default);
 
             SetRootUrlToKinveyClient(unreachableUrl);
-            var listToDoAuto2 = await autoStore.FindAsync(query);
+            var listToDoAuto2 = await autoStore.FindAsync(query: query, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
 
             // Teardown
@@ -4233,10 +4233,10 @@ namespace Kinvey.Tests
             newItem2 = await networkStore.SaveAsync(newItem2);
 
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
 
             SetRootUrlToKinveyClient(unreachableUrl);
-            var listToDoAuto2 = await autoStore.FindAsync();
+            var listToDoAuto2 = await autoStore.FindAsync(query: null, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
 
             // Teardown
@@ -4285,15 +4285,15 @@ namespace Kinvey.Tests
             newItem2 = await networkStore.SaveAsync(newItem2);
 
             // Act          
-            var listToDoAuto1 = await autoStore.FindAsync();
+            var listToDoAuto1 = await autoStore.FindAsync(query: null, ct: default);
             await networkStore.RemoveAsync(newItem1.ID);
-            var listToDoAuto2 = await autoStore.FindAsync();
+            var listToDoAuto2 = await autoStore.FindAsync(query: null, ct: default);
            
             KinveyException syncStoreException = null;
             ToDo existingToDo = null;
             try
             {
-                existingToDo = await syncStore.FindByIDAsync(newItem1.ID);
+                existingToDo = await syncStore.FindByIDAsync(entityID: newItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -4353,7 +4353,7 @@ namespace Kinvey.Tests
             newItem2 = await autoStore.SaveAsync(newItem2);
            
             // Act          
-            var listToDoNetwork = await autoStore.FindAsync(query);
+            var listToDoNetwork = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(newItem1.ID);
@@ -4406,7 +4406,7 @@ namespace Kinvey.Tests
             newItem2 = await syncStore.SaveAsync(newItem2);
            
             // Act          
-            var listToDoCache = await autoStore.FindAsync(query);
+            var listToDoCache = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(newItem1.ID);
@@ -4456,7 +4456,7 @@ namespace Kinvey.Tests
             newItem2 = await autoStore.SaveAsync(newItem2);
 
             //Act
-            var listToDoNetwork = await autoStore.FindAsync(query);
+            var listToDoNetwork = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(newItem1.ID);
@@ -4506,7 +4506,7 @@ namespace Kinvey.Tests
             newItem2 = await syncStore.SaveAsync(newItem2);
            
             //Act
-            var listToDoCache = await autoStore.FindAsync(query);
+            var listToDoCache = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(newItem1.ID);
@@ -4553,7 +4553,7 @@ namespace Kinvey.Tests
             newItem2 = await autoStore.SaveAsync(newItem2);
             
             //Act
-            var listToDoNetwork = await autoStore.FindAsync(query);
+            var listToDoNetwork = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(newItem1.ID);
@@ -4603,7 +4603,7 @@ namespace Kinvey.Tests
             newItem2 = await syncStore.SaveAsync(newItem2);
            
             //Act
-            var listToDoCache = await autoStore.FindAsync(query);
+            var listToDoCache = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(newItem1.ID);
@@ -4658,7 +4658,7 @@ namespace Kinvey.Tests
             newItem3 = await autoStore.SaveAsync(newItem3);
             
             // Act
-            var listToDoNetwork = await autoStore.FindAsync(query);
+            var listToDoNetwork = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(newItem1.ID);
@@ -4717,7 +4717,7 @@ namespace Kinvey.Tests
             newItem3 = await syncStore.SaveAsync(newItem3);
             
             // Act
-            var listToDoCache = await autoStore.FindAsync(query);
+            var listToDoCache = await autoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(newItem1.ID);
@@ -4769,8 +4769,8 @@ namespace Kinvey.Tests
             var savedItem2 = await networkStore.SaveAsync(newItem2);
 
             // Act
-            var existingItemInNetwork = await autoStore.FindByIDAsync(savedItem1.ID);
-            var existingItemInLocalStorage = await syncStore.FindByIDAsync(savedItem1.ID);
+            var existingItemInNetwork = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
+            var existingItemInLocalStorage = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem1.ID);
@@ -4821,7 +4821,7 @@ namespace Kinvey.Tests
             // Act
             try
             {
-                existingItem = await autoStore.FindByIDAsync(Guid.NewGuid().ToString());
+                existingItem = await autoStore.FindByIDAsync(entityID: Guid.NewGuid().ToString(), ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -4864,7 +4864,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await autoStore.FindByIDAsync(Guid.NewGuid().ToString());
+                await autoStore.FindByIDAsync(entityID: Guid.NewGuid().ToString(), ct: default);
             });
 
             // Assert
@@ -4909,10 +4909,10 @@ namespace Kinvey.Tests
             var savedItem2 = await networkStore.SaveAsync(newItem2);
 
             // Act            
-            var existingItemInNetwork = await autoStore.FindByIDAsync(savedItem1.ID);
+            var existingItemInNetwork = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
 
             SetRootUrlToKinveyClient(unreachableUrl);
-            var existingItemInLocalStorage = await autoStore.FindByIDAsync(savedItem1.ID);
+            var existingItemInLocalStorage = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
 
             // Teardown
@@ -4970,13 +4970,13 @@ namespace Kinvey.Tests
             var savedItem2 = await autoStore.SaveAsync(newItem2);
 
             // Act
-            var existingItemInLocalStorage1 = await syncStore.FindByIDAsync(savedItem1.ID);
+            var existingItemInLocalStorage1 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
 
             await autoStore.RemoveAsync(savedItem1.ID);
 
             try
             {
-                existingItemInNetwork = await autoStore.FindByIDAsync(savedItem1.ID);
+                existingItemInNetwork = await autoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -4987,7 +4987,7 @@ namespace Kinvey.Tests
             ToDo existingItemInLocalStorage2 = null;
             try
             {
-                existingItemInLocalStorage2 = await syncStore.FindByIDAsync(savedItem1.ID);
+                existingItemInLocalStorage2 = await syncStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -5043,7 +5043,7 @@ namespace Kinvey.Tests
             var savedItem = await autoStore.SaveAsync(newItem);
 
             // Act
-            var networkEntity = await autoStore.FindByIDAsync(savedItem.ID);
+            var networkEntity = await autoStore.FindByIDAsync(entityID: savedItem.ID, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(savedItem.ID);
@@ -5085,7 +5085,7 @@ namespace Kinvey.Tests
             var savedItem = await syncStore.SaveAsync(newItem);
 
             // Act
-            var cacheEntity = await autoStore.FindByIDAsync(savedItem.ID);
+            var cacheEntity = await autoStore.FindByIDAsync(entityID: savedItem.ID, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(savedItem.ID);
@@ -5144,7 +5144,7 @@ namespace Kinvey.Tests
             p3 = await autoStore.SaveAsync(p3);
             
             // Act
-            var networkResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_SUM, "", "Age", query);
+            var networkResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_SUM, groupField: "", aggregateField: "Age", query: query, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(p3.ID);
@@ -5201,7 +5201,7 @@ namespace Kinvey.Tests
             var query = autoStore.Where(x => x.LastName.Equals("Bluth"));
 
             // Act
-            var cacheResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_SUM, "", "Age", query);
+            var cacheResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_SUM, groupField: "", aggregateField: "Age", query: query, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(p3.ID);
@@ -5253,7 +5253,7 @@ namespace Kinvey.Tests
             p3 = await autoStore.SaveAsync(p3);
 
             // Act
-            var networkResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MIN, "", "Age", null);
+            var networkResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MIN, groupField: "", aggregateField: "Age", query: null, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(p3.ID);
@@ -5308,7 +5308,7 @@ namespace Kinvey.Tests
             p3 = await syncStore.SaveAsync(p3);
 
             // Act
-            var cacheResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MIN, "", "Age", null);
+            var cacheResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MIN, groupField: "", aggregateField: "Age", query: null, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(p3.ID);
@@ -5360,7 +5360,7 @@ namespace Kinvey.Tests
             p3 = await autoStore.SaveAsync(p3);
 
             // Act
-            var networkResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MAX, "", "Age", null);
+            var networkResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MAX, groupField: "", aggregateField: "Age", query : null, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(p3.ID);
@@ -5415,7 +5415,7 @@ namespace Kinvey.Tests
             p3 = await syncStore.SaveAsync(p3);
 
             // Act
-            var cacheResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MAX, "", "Age", null);
+            var cacheResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MAX, groupField: "", aggregateField: "Age", query: null, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(p3.ID);
@@ -5474,7 +5474,7 @@ namespace Kinvey.Tests
             p4 = await autoStore.SaveAsync(p4);
 
             // Act
-            var networkResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "Age", null);
+            var networkResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "Age", query: null, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(p4.ID);
@@ -5537,7 +5537,7 @@ namespace Kinvey.Tests
             p4 = await syncStore.SaveAsync(p4);
 
             // Act
-            var cacheResult = await autoStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "Age", null);
+            var cacheResult = await autoStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "Age", query: null, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(p4.ID);
@@ -5581,8 +5581,8 @@ namespace Kinvey.Tests
             // Act
             fc1 = await autoStore.SaveAsync(fc1);
 
-            var networkEntities = await networkStore.FindAsync();
-            var localEntities = await syncStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             foreach (var networkEntity in networkEntities)
@@ -5632,8 +5632,8 @@ namespace Kinvey.Tests
             // Act
             fc1 = await autoStore.SaveAsync(fc1);
 
-            var networkEntities = await networkStore.FindAsync();
-            var localEntities = await syncStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             foreach (var networkEntity in networkEntities)
@@ -5682,7 +5682,7 @@ namespace Kinvey.Tests
             fc1.Answer = "7!";
             fc1 = await autoStore.SaveAsync(fc1);
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             //Teardown
             foreach (var networkEntity in networkEntities)
@@ -5724,7 +5724,7 @@ namespace Kinvey.Tests
             SetRootUrlToKinveyClient(unreachableUrl);
 
             fc1 = await autoStore.SaveAsync(fc1);           
-            var localEntities = await autoStore.FindAsync();
+            var localEntities = await autoStore.FindAsync(query: null, ct: default);
 
             SetRootUrlToKinveyClient(kinveyUrl);
 
@@ -5774,7 +5774,7 @@ namespace Kinvey.Tests
             });
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingItemsCache = await syncStore.FindAsync();
+            var existingItemsCache = await syncStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.AreEqual(typeof(KinveyException), exception.GetType());
@@ -5830,7 +5830,7 @@ namespace Kinvey.Tests
             fc1 = await autoStore.SaveAsync(fc1);
             fc2 = await autoStore.SaveAsync(fc2);
             var pendingWriteActions1 = kinveyClient.CacheManager.GetSyncQueue(flashCardCollection).GetAll();
-            var localEntities = await autoStore.FindAsync();
+            var localEntities = await autoStore.FindAsync(query: null, ct: default);
 
             SetRootUrlToKinveyClient(kinveyUrl);
 
@@ -5838,7 +5838,7 @@ namespace Kinvey.Tests
 
             var pendingWriteActions2 = kinveyClient.CacheManager.GetSyncQueue(flashCardCollection).GetAll();
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             //Teardown
             foreach (var networkEntity in networkEntities)
@@ -5891,7 +5891,7 @@ namespace Kinvey.Tests
             fc1 = await autoStore.SaveAsync(fc1);
 
             var pendingWriteActions1 = kinveyClient.CacheManager.GetSyncQueue(flashCardCollection).GetAll();
-            var localEntities = await autoStore.FindAsync();
+            var localEntities = await autoStore.FindAsync(query: null, ct: default);
 
             SetRootUrlToKinveyClient(kinveyUrl);
 
@@ -5899,7 +5899,7 @@ namespace Kinvey.Tests
 
             var pendingWriteActions2 = kinveyClient.CacheManager.GetSyncQueue(flashCardCollection).GetAll();
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             //Teardown
             foreach (var networkEntity in networkEntities)
@@ -5955,8 +5955,8 @@ namespace Kinvey.Tests
             // Act
             var savedItem = await autoStore.SaveAsync(newItem);
 
-            var existingItemNetwork = await autoStore.FindByIDAsync(savedItem.ID);
-            var existingItemCache = await syncStore.FindByIDAsync(savedItem.ID);
+            var existingItemNetwork = await autoStore.FindByIDAsync(entityID: savedItem.ID, ct: default);
+            var existingItemCache = await syncStore.FindByIDAsync(entityID: savedItem.ID, ct: default);
 
             //Teardown
             await autoStore.RemoveAsync(savedItem.ID);
@@ -6001,8 +6001,8 @@ namespace Kinvey.Tests
             // Act
             var savedItem = await autoStore.SaveAsync(newItem);
 
-            var existingItemsCache = await syncStore.FindAsync();
-            var existingItemsNetwork = await networkStore.FindAsync();
+            var existingItemsCache = await syncStore.FindAsync(query: null, ct: default);
+            var existingItemsNetwork = await networkStore.FindAsync(query: null, ct: default);
             
             //Teardown
             await networkStore.RemoveAsync(savedItem.ID);
@@ -6059,7 +6059,7 @@ namespace Kinvey.Tests
             var savedItem = await autoStore.SaveAsync(newItem);
             SetRootUrlToKinveyClient(kinveyUrl);
 
-            var existingItemsCache = await syncStore.FindAsync();
+            var existingItemsCache = await syncStore.FindAsync(query: null, ct: default);
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
             //Teardown
@@ -6112,8 +6112,8 @@ namespace Kinvey.Tests
             // Act
             var savedItem = await autoStore.SaveAsync(newItem);
 
-            var existingItemsCache = await syncStore.FindAsync();
-            var existingItemsNetwork = await networkStore.FindAsync();
+            var existingItemsCache = await syncStore.FindAsync(query: null, ct: default);
+            var existingItemsNetwork = await networkStore.FindAsync(query: null, ct: default);
 
 
             //Teardown
@@ -6174,7 +6174,7 @@ namespace Kinvey.Tests
             var savedItem = await autoStore.SaveAsync(newItem);
             SetRootUrlToKinveyClient(kinveyUrl);
 
-            var existingItemsCache = await syncStore.FindAsync();
+            var existingItemsCache = await syncStore.FindAsync(query: null, ct: default);
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
             //Teardown
@@ -6228,8 +6228,8 @@ namespace Kinvey.Tests
             var savedToDos = await autoToDoStore.SaveAsync(toDos);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDosCache = await syncToDoStore.FindAsync();
-            var existingToDosNetwork = await networkToDoStore.FindAsync();
+            var existingToDosCache = await syncToDoStore.FindAsync(query: null, ct: default);
+            var existingToDosNetwork = await networkToDoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6286,7 +6286,7 @@ namespace Kinvey.Tests
             SetRootUrlToKinveyClient(kinveyUrl);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await syncToDoStore.FindAsync();
+            var existingToDos = await syncToDoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await syncToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6347,8 +6347,8 @@ namespace Kinvey.Tests
             var savedToDos = await autoToDoStore.SaveAsync(toDos);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDosCache = await syncToDoStore.FindAsync();
-            var existingToDosNetwork = await networkToDoStore.FindAsync();
+            var existingToDosCache = await syncToDoStore.FindAsync(query: null, ct: default);
+            var existingToDosNetwork = await networkToDoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6417,8 +6417,8 @@ namespace Kinvey.Tests
             var savedToDos = await autoToDoStore.SaveAsync(toDos);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDosLocal = await syncToDoStore.FindAsync();
-            var existingToDosNetwork = await networkToDoStore.FindAsync();
+            var existingToDosLocal = await syncToDoStore.FindAsync(query: null, ct: default);
+            var existingToDosNetwork = await networkToDoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6502,7 +6502,7 @@ namespace Kinvey.Tests
             SetRootUrlToKinveyClient(kinveyUrl);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await syncToDoStore.FindAsync();
+            var existingToDos = await syncToDoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await syncToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6614,7 +6614,7 @@ namespace Kinvey.Tests
 
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoSyncStore.FindAsync();
+            var existingToDos = await todoSyncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await todoSyncStore.RemoveAsync(todoSyncStore.Where(e => e.Name.StartsWith("Name")));
@@ -6666,7 +6666,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoStoreAuto.SaveAsync(toDos);
 
-            var existingToDos = await todoStoreAuto.FindAsync();
+            var existingToDos = await todoStoreAuto.FindAsync(query: null, ct: default);
 
             //Teardown
             await todoStoreAuto.RemoveAsync(todoStoreAuto.Where(e => e.Name.StartsWith("Name")));
@@ -6709,8 +6709,8 @@ namespace Kinvey.Tests
             var savedToDos = await todoStoreAuto.SaveAsync(toDos);
             SetRootUrlToKinveyClient(kinveyUrl);
 
-            var existingToDosSync = await todoStoreSync.FindAsync();
-            var existingToDosNetwork = await todoStoreNetwork.FindAsync();            
+            var existingToDosSync = await todoStoreSync.FindAsync(query: null, ct: default);
+            var existingToDosNetwork = await todoStoreNetwork.FindAsync(query: null, ct: default);            
 
             //Teardown
             await todoStoreSync.RemoveAsync(todoStoreAuto.Where(e => e.Name.StartsWith("Name")));
@@ -6819,8 +6819,8 @@ namespace Kinvey.Tests
                 var savedToDos = await autoToDoStore.SaveAsync(toDos);
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDosCache = await syncToDoStore.FindAsync();
-                var existingToDosNetwork = await networkToDoStore.FindAsync();
+                var existingToDosCache = await syncToDoStore.FindAsync(query: null, ct: default);
+                var existingToDosNetwork = await networkToDoStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await autoToDoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6879,7 +6879,7 @@ namespace Kinvey.Tests
                 var savedToDos = await toDoAutoStore.SaveAsync(toDos);
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDos = await syncToDoStore.FindAsync();
+                var existingToDos = await syncToDoStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await toDoAutoStore.RemoveAsync(savedToDos.Entities[1].ID);
@@ -6956,7 +6956,7 @@ namespace Kinvey.Tests
                 var savedToDos = await toDoAutoStore.SaveAsync(toDos);
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDos = await syncToDoStore.FindAsync();
+                var existingToDos = await syncToDoStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await toDoAutoStore.RemoveAsync(savedToDos.Entities[3].ID);
@@ -7060,8 +7060,8 @@ namespace Kinvey.Tests
             // Act
             var savedToDosToAdd = await todoAutoStore.SaveAsync(toDosToAdd);
 
-            var existingToDosNetwork = await todoNetworkStore.FindAsync();
-            var existingToDosSync = await todoSyncStore.FindAsync();
+            var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
+            var existingToDosSync = await todoSyncStore.FindAsync(query: null, ct: default);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
@@ -7170,8 +7170,8 @@ namespace Kinvey.Tests
                 // Act
                 var savedToDosToAdd = await todoAutoStore.SaveAsync(toDosToAdd);
 
-                var existingToDosNetwork = await todoNetworkStore.FindAsync();
-                var existingToDosSync = await todoSyncStore.FindAsync();
+                var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
+                var existingToDosSync = await todoSyncStore.FindAsync(query: null, ct: default);
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
@@ -7257,8 +7257,8 @@ namespace Kinvey.Tests
             // Act
             var savedToDosToAdd = await todoAutoStore.SaveAsync(toDosToAdd);
 
-            var existingToDosNetwork = await todoNetworkStore.FindAsync();
-            var existingToDosSync = await todoSyncStore.FindAsync();
+            var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
+            var existingToDosSync = await todoSyncStore.FindAsync(query: null, ct: default);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
@@ -7344,11 +7344,11 @@ namespace Kinvey.Tests
             var savedItem2 = await networkStore.SaveAsync(newItem2);
           
             // Act
-            var count1 = await autoStore.GetCountAsync();
+            var count1 = await autoStore.GetCountAsync(query: null, ct: default);
 
             var savedItem3 = await networkStore.SaveAsync(newItem3);
 
-            var count2 = await autoStore.GetCountAsync();
+            var count2 = await autoStore.GetCountAsync(query: null, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem1.ID);
@@ -7407,7 +7407,7 @@ namespace Kinvey.Tests
             var savedItem3 = await networkStore.SaveAsync(newItem3);
 
             // Act
-            var count = await autoStore.GetCountAsync(query);
+            var count = await autoStore.GetCountAsync(query: query, ct: default);
 
             // Teardown
             await networkStore.RemoveAsync(savedItem1.ID);
@@ -7457,7 +7457,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await autoStore.GetCountAsync(query);
+                await autoStore.GetCountAsync(query: query, ct: default);
             });
 
             // Teardown
@@ -7513,12 +7513,12 @@ namespace Kinvey.Tests
             var savedItem2 = await networkStore.SaveAsync(newItem2);
 
             // Act
-            var listAutoToDo = await autoStore.FindAsync();
+            var listAutoToDo = await autoStore.FindAsync(query: null, ct: default);
            
             var savedItem3 = await networkStore.SaveAsync(newItem3);
 
             SetRootUrlToKinveyClient(unreachableUrl);
-            var count = await autoStore.GetCountAsync();
+            var count = await autoStore.GetCountAsync(query: null, ct: default);
             SetRootUrlToKinveyClient(kinveyUrl);
             
             // Teardown
@@ -7552,7 +7552,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await autoStore.GetCountAsync();
+                await autoStore.GetCountAsync(query: null, ct: default);
             });
 
             // Assert
@@ -7604,7 +7604,7 @@ namespace Kinvey.Tests
             ToDo savedItem3 = await autoStore.SaveAsync(newItem3);
 
             // Act
-            var networkResult = await autoStore.GetCountAsync();
+            var networkResult = await autoStore.GetCountAsync(query: null, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(savedItem1.ID);
@@ -7661,7 +7661,7 @@ namespace Kinvey.Tests
             var savedItem3 = await syncStore.SaveAsync(newItem3);
 
             // Act
-            var networkResult = await autoStore.GetCountAsync();
+            var networkResult = await autoStore.GetCountAsync(query: null, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(savedItem1.ID);
@@ -7717,7 +7717,7 @@ namespace Kinvey.Tests
             var savedItem3 = await autoStore.SaveAsync(newItem3);
             
             // Act
-            var networkResult = await autoStore.GetCountAsync(query);
+            var networkResult = await autoStore.GetCountAsync(query: query, ct: default);
 
             // Teardown
             await autoStore.RemoveAsync(savedItem1.ID);
@@ -7776,7 +7776,7 @@ namespace Kinvey.Tests
             var savedItem3 = await syncStore.SaveAsync(newItem3);
             
             // Act
-            var networkResult = await autoStore.GetCountAsync(query);
+            var networkResult = await autoStore.GetCountAsync(query: query, ct: default);
 
             // Teardown
             await syncStore.RemoveAsync(savedItem1.ID);
@@ -7831,7 +7831,7 @@ namespace Kinvey.Tests
             // Act
             var pushedEntities = await autoStore.PushAsync();
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             var pendingWriteActionCount = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).Count(false);
 
@@ -7886,7 +7886,7 @@ namespace Kinvey.Tests
             await syncStore.SaveAsync(newItem1);
             await autoStore.PushAsync();
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             var pendingWriteActionCount = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).Count(false);
 
@@ -7956,7 +7956,7 @@ namespace Kinvey.Tests
             await syncStore.RemoveAsync(newItem2.ID);
             var pushedEntities = await autoStore.PushAsync();
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             var pendingWriteActionCount = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).Count(false);
 
@@ -8074,13 +8074,13 @@ namespace Kinvey.Tests
             newItem1.Details = "Details";
             newItem1 = await syncStore.SaveAsync(newItem1);
 
-            var networkEntities1 = await networkStore.FindAsync();
+            var networkEntities1 = await networkStore.FindAsync(query: null, ct: default);
             var idToBeRemoved = networkEntities1.FirstOrDefault(e => e.Name.Equals("todo1")).ID;
             await networkStore.RemoveAsync(idToBeRemoved);
 
             var pushedEntities2 = await autoStore.PushAsync();
 
-            var networkEntities2 = await networkStore.FindAsync();
+            var networkEntities2 = await networkStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(networkEntities2[0].ID);
@@ -8125,7 +8125,7 @@ namespace Kinvey.Tests
             var pushResponse = await autoToDoStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDosNetwork = await networkToDoStore.FindAsync();
+            var existingToDosNetwork = await networkToDoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkToDoStore.RemoveAsync(existingToDosNetwork[0].ID);
@@ -8190,7 +8190,7 @@ namespace Kinvey.Tests
             var pushResponse = await autoToDoStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDosNetwork = await networkToDoStore.FindAsync();
+            var existingToDosNetwork = await networkToDoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await networkToDoStore.RemoveAsync(pushResponse.PushEntities[0].ID);
@@ -8244,7 +8244,7 @@ namespace Kinvey.Tests
             var pushResponse = await todoSyncStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoSyncStore.FindAsync();
+            var existingToDos = await todoSyncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoSyncStore.RemoveAsync(todoNetworkStore.Where(e => e.Name.StartsWith("Name")));
@@ -8301,8 +8301,8 @@ namespace Kinvey.Tests
                 var pushResponse = await todoAutoStore.PushAsync();
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDosLocal = await todoSyncStore.FindAsync();
-                var existingToDosNetwork = await todoNetworkStore.FindAsync();
+                var existingToDosLocal = await todoSyncStore.FindAsync(query: null, ct: default);
+                var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await todoNetworkStore.RemoveAsync(pushResponse.PushEntities[0].ID);
@@ -8365,7 +8365,7 @@ namespace Kinvey.Tests
             var pushResponse = await todoAutoStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoNetworkStore.FindAsync();
+            var existingToDos = await todoNetworkStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoNetworkStore.RemoveAsync(existingToDos[0].ID);
@@ -8646,7 +8646,7 @@ namespace Kinvey.Tests
             // Act
             var pullEntities = await autoStore.PullAsync();
 
-            var localEntities = await syncStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(fc1.ID);
@@ -8756,7 +8756,7 @@ namespace Kinvey.Tests
             // Act
             var pullEntities = await autoStore.PullAsync(query);
 
-            var localEntities = await syncStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(fc1.ID);
@@ -8816,13 +8816,13 @@ namespace Kinvey.Tests
 
             // Act
             var pullEntities1 = await autoStore.PullAsync();
-            var localEntities1 = await syncStore.FindAsync();
+            var localEntities1 = await syncStore.FindAsync(query: null, ct: default);
 
             await networkStore.RemoveAsync(fc1.ID);
             await networkStore.RemoveAsync(fc2.ID);
 
             var pullEntities2 = await autoStore.PullAsync();
-            var localEntities2 = await syncStore.FindAsync();
+            var localEntities2 = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(fc3.ID);
@@ -8893,7 +8893,7 @@ namespace Kinvey.Tests
             fc2 = await networkStore.SaveAsync(fc2);
             
             var pullEntities2 = await autoStore.PullAsync();
-            var localEntities = await syncStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(fc1.ID);
@@ -9036,7 +9036,7 @@ namespace Kinvey.Tests
 
             var networkEntities2 = await autoStore.PullAsync();
 
-            var localEntities = await syncStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(fc1.ID);
@@ -9082,7 +9082,7 @@ namespace Kinvey.Tests
             var secondResponse = await store.PullAsync();
 
             //Teardown
-            var existingEntities = await store.FindAsync();
+            var existingEntities = await store.FindAsync(query: null, ct: default);
             if (existingEntities != null)
             {
                 await store.RemoveAsync(existingEntities.First().ID);
@@ -9139,7 +9139,7 @@ namespace Kinvey.Tests
             var thirdResponse = await store.PullAsync();
 
             //Teardown
-            var existingEntities = await store.FindAsync();
+            var existingEntities = await store.FindAsync(query: null, ct: default);
             if (existingEntities != null)
             {
                 foreach (var existingEntity in existingEntities)
@@ -9198,14 +9198,14 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
             //Teardown
-            var existingEntities = await store.FindAsync();
+            var existingEntities = await store.FindAsync(query: null, ct: default);
             if (existingEntities != null)
             {
                 foreach (var existingEntity in existingEntities)
@@ -9263,12 +9263,12 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             int networkDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             int networkCount = networkEntities.Count;
 
             //Teardown
@@ -9331,7 +9331,7 @@ namespace Kinvey.Tests
             var secondResponse = await store.PullAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -9389,7 +9389,7 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
@@ -9404,7 +9404,7 @@ namespace Kinvey.Tests
             var thirdResponse = await store.PullAsync(query3);
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -9463,14 +9463,14 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.Equals("What+?"));
             var secondResponse = await store.PullAsync(query2);
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -9534,7 +9534,7 @@ namespace Kinvey.Tests
             var thirdResponse = await store.PullAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -9595,14 +9595,14 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync();
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
             var secondResponse = await store.PullAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -9868,8 +9868,8 @@ namespace Kinvey.Tests
             // Act
             var syncedEntities = await autoStore.SyncAsync();
 
-            var localEntities = await syncStore.FindAsync();
-            var networkEntities = await networkStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             //Teardown
             foreach (var networkEntity in networkEntities)
@@ -9946,8 +9946,8 @@ namespace Kinvey.Tests
             // Act
             var syncedEntities = await autoStore.SyncAsync(query);
 
-            var localEntities = await syncStore.FindAsync(query);
-            var networkEntities = await networkStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: query, ct: default);
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             //Teardown
             foreach (var networkEntity in networkEntities)
@@ -10013,7 +10013,7 @@ namespace Kinvey.Tests
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.IsNotNull(exception);
@@ -10054,7 +10054,7 @@ namespace Kinvey.Tests
             var secondResponse = await store.SyncAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 await store.RemoveAsync(networkEntities.First().ID);
@@ -10110,7 +10110,7 @@ namespace Kinvey.Tests
             var thirdResponse = await store.SyncAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -10168,14 +10168,14 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -10232,12 +10232,12 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             int removedCount = (await networkStore.RemoveAsync(fc2.ID)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             int networkCount = networkEntities.Count;
 
             //Teardown
@@ -10299,7 +10299,7 @@ namespace Kinvey.Tests
             var secondResponse = await store.SyncAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -10356,7 +10356,7 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
@@ -10371,7 +10371,7 @@ namespace Kinvey.Tests
             var thirdResponse = await store.SyncAsync(query3);
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -10435,7 +10435,7 @@ namespace Kinvey.Tests
             var thirdResponse = await store.SyncAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -10495,14 +10495,14 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync();
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
             var secondResponse = await store.SyncAsync();
 
             //Teardown
-            var networkEntities = await store.FindAsync();
+            var networkEntities = await store.FindAsync(query: null, ct: default);
             if (networkEntities != null)
             {
                 foreach (var networkEntity in networkEntities)
@@ -10549,8 +10549,8 @@ namespace Kinvey.Tests
                 var syncResponse = await todoAutoStore.SyncAsync();
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDosNetwork = await todoNetworkStore.FindAsync();
-                var existingToDosLocal = await todoSyncStore.FindAsync();
+                var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
+                var existingToDosLocal = await todoSyncStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await todoNetworkStore.RemoveAsync(existingToDosNetwork[0].ID);
@@ -11215,7 +11215,7 @@ namespace Kinvey.Tests
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 
             //Teardown
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
             foreach (var networkEntity in networkEntities)
             {
                 await networkStore.RemoveAsync(networkEntity.ID);
@@ -11268,7 +11268,7 @@ namespace Kinvey.Tests
             // Act
             var clearResponse = autoStore.ClearCache();
 
-            var networkEntities = await networkStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -11326,8 +11326,8 @@ namespace Kinvey.Tests
             // Act
             var clearResponse = autoStore.ClearCache(query);
 
-            var networkEntities = await networkStore.FindAsync();
-            var localEntities = await syncStore.FindAsync();
+            var networkEntities = await networkStore.FindAsync(query: null, ct: default);
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await networkStore.RemoveAsync(newItem1.ID);
@@ -11447,7 +11447,7 @@ namespace Kinvey.Tests
             // Act
             var clearResponse = autoStore.ClearCache();
 
-            var localEntities = await syncStore.FindAsync();
+            var localEntities = await syncStore.FindAsync(query: null, ct: default);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreCacheIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreCacheIntegrationTests.cs
@@ -3559,7 +3559,7 @@ namespace Kinvey.Tests
             // Act
             var firstResponse = await store.PullAsync();
             var secondResponse = await store.PullAsync();
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 await store.RemoveAsync(localEntities.First().ID);
@@ -3617,7 +3617,7 @@ namespace Kinvey.Tests
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -3677,13 +3677,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -3742,12 +3742,12 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             int localCount = localEntities.Count;
             bool localCopy = false;
 
@@ -3818,7 +3818,7 @@ namespace Kinvey.Tests
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -3876,7 +3876,7 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
@@ -3890,7 +3890,7 @@ namespace Kinvey.Tests
             var query3 = store.Where(x => x.Question.StartsWith("Wh"));
             var thirdResponse = await store.PullAsync(query3);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -3943,13 +3943,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.Equals("What+?"));
             var secondResponse = await store.PullAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4008,14 +4008,14 @@ namespace Kinvey.Tests
             var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
-            var firstStoreCount = (await store.FindAsync()).Count;
+            var firstStoreCount = (await store.FindAsync(query: null, ct: default)).Count;
 
             var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
             var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4075,13 +4075,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync();
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: null, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
             var secondResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4140,7 +4140,7 @@ namespace Kinvey.Tests
             // Act
             var firstResponse = await store.SyncAsync();
             var secondResponse = await store.SyncAsync();
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 await store.RemoveAsync(localEntities.First().ID);
@@ -4195,7 +4195,7 @@ namespace Kinvey.Tests
             fc3 = await store.SaveAsync(fc3);
             var thirdResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4254,13 +4254,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4318,12 +4318,12 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             int localCount = localEntities.Count;
             bool localCopy = false;
 
@@ -4392,7 +4392,7 @@ namespace Kinvey.Tests
             fc3 = await store.SaveAsync(fc3);
             var secondResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4450,7 +4450,7 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
@@ -4464,7 +4464,7 @@ namespace Kinvey.Tests
             var query3 = store.Where(x => x.Question.StartsWith("Wh"));
             var thirdResponse = await store.SyncAsync(query3);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4523,13 +4523,13 @@ namespace Kinvey.Tests
 
             var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
             var secondResponse = await store.SyncAsync();
-            var firstStoreCount = (await store.FindAsync()).Count;
+            var firstStoreCount = (await store.FindAsync(query: null, ct: default)).Count;
 
             var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
             var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
             var thirdResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4589,13 +4589,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync();
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
             var secondResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -715,7 +715,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID:savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -724,7 +724,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -733,7 +733,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -797,7 +797,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -806,7 +806,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -815,7 +815,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -879,7 +879,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -888,7 +888,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -897,7 +897,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -962,7 +962,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -971,7 +971,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -980,7 +980,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1045,7 +1045,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1054,7 +1054,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1063,7 +1063,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1135,7 +1135,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1144,7 +1144,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1153,7 +1153,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1225,7 +1225,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1234,7 +1234,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1243,7 +1243,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1315,7 +1315,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1324,7 +1324,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1333,7 +1333,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1405,7 +1405,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1414,7 +1414,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1423,7 +1423,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1494,7 +1494,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1503,7 +1503,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1512,7 +1512,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1585,7 +1585,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1594,7 +1594,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1603,7 +1603,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1676,7 +1676,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1685,7 +1685,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1694,7 +1694,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1765,7 +1765,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1774,7 +1774,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1783,7 +1783,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1854,7 +1854,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1863,7 +1863,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1872,7 +1872,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1943,7 +1943,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1952,7 +1952,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1961,7 +1961,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2034,7 +2034,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2043,7 +2043,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2052,7 +2052,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2124,7 +2124,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2133,7 +2133,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2142,7 +2142,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2214,7 +2214,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2223,7 +2223,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2232,7 +2232,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2304,7 +2304,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2313,7 +2313,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2322,7 +2322,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2395,7 +2395,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2404,7 +2404,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2413,7 +2413,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2487,7 +2487,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2496,7 +2496,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2505,7 +2505,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2579,7 +2579,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2588,7 +2588,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2597,7 +2597,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2672,7 +2672,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2681,7 +2681,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2690,7 +2690,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2764,7 +2764,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2773,7 +2773,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2782,7 +2782,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -3273,7 +3273,7 @@ namespace Kinvey.Tests
 
             // Act
             var count = 0u;
-            count = await todoStore.GetCountAsync();
+            count = await todoStore.GetCountAsync(query: null, ct: default);
 
             // Assert
             Assert.AreEqual(2u, count);
@@ -3318,7 +3318,7 @@ namespace Kinvey.Tests
             // Act
             var count = 0u;
             var query = todoStore.Where(e => e.Details.Equals("details for 2+"));
-            count = await todoStore.GetCountAsync(query);
+            count = await todoStore.GetCountAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(t1.ID);
@@ -3353,7 +3353,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.GetCountAsync();
+                    await todoStore.GetCountAsync(query: null, ct:default);
                 });
 
                 // Assert
@@ -3384,7 +3384,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await todoStore.GetCountAsync();
+                await todoStore.GetCountAsync(query: null, ct: default);
             });
 
             // Assert
@@ -3413,7 +3413,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.GetCountAsync();
+                    await todoStore.GetCountAsync(query: null, ct: default);
                 });
 
                 // Assert
@@ -3443,7 +3443,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.GetCountAsync();
+                    await todoStore.GetCountAsync(query: null, ct: default);
                 });
 
                 // Assert
@@ -3473,7 +3473,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.GetCountAsync();
+                    await todoStore.GetCountAsync(query: null, ct: default);
                 });
 
                 // Assert
@@ -3503,7 +3503,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.GetCountAsync();
+                    await todoStore.GetCountAsync(query: null, ct: default);
                 });
 
                 // Assert
@@ -3552,7 +3552,7 @@ namespace Kinvey.Tests
             // Act
             List<ToDo> todoList = new List<ToDo>();
 
-            todoList = await todoStore.FindAsync();
+            todoList = await todoStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.IsNotNull(todoList);
@@ -3607,7 +3607,7 @@ namespace Kinvey.Tests
                 // Assert
                 Exception er = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate ()
                 {
-                    await store.FindAsync();
+                    await store.FindAsync(query: null, ct: default);
                 });
 
                 Assert.IsNotNull(er);
@@ -3641,7 +3641,7 @@ namespace Kinvey.Tests
 
 			// Act
 			ToDo entity = null;
-			entity = await todoStore.FindByIDAsync(t.ID);
+			entity = await todoStore.FindByIDAsync(entityID: t.ID, ct: default);
 
 			// Assert
 			Assert.IsNotNull(entity);
@@ -3806,7 +3806,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3861,7 +3861,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3912,7 +3912,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -3965,7 +3965,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -4026,7 +4026,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -4088,7 +4088,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -4150,7 +4150,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -4218,7 +4218,7 @@ namespace Kinvey.Tests
 
             var listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -4279,7 +4279,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -4342,7 +4342,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -4403,7 +4403,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -4464,7 +4464,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -4516,7 +4516,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -4569,7 +4569,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4623,7 +4623,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4677,7 +4677,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4736,7 +4736,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4788,7 +4788,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4840,7 +4840,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4892,7 +4892,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4944,7 +4944,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -4996,7 +4996,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -5048,7 +5048,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
             // Teardown
@@ -5102,7 +5102,7 @@ namespace Kinvey.Tests
 			// Act
             Exception e = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
 			{
-				listToDo = await todoStore.FindAsync(query);
+				listToDo = await todoStore.FindAsync(query: query, ct: default);
 			});
 
 			// Assert
@@ -5157,7 +5157,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -5199,7 +5199,7 @@ namespace Kinvey.Tests
             newItem2.DueDate = "2016-04-22T19:56:00.963Z";
 
             DataStore<ToDo> todoStore = DataStore<ToDo>.Collection(toDosCollection, DataStoreType.NETWORK);
-            foreach (var item in await todoStore.FindAsync())
+            foreach (var item in await todoStore.FindAsync(query: null, ct: default))
             {
                 await todoStore.RemoveAsync(item.ID);
             }
@@ -5214,7 +5214,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -5271,7 +5271,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -5330,7 +5330,7 @@ namespace Kinvey.Tests
 
             List<ToDo> listToDo = new List<ToDo>();
 
-            listToDo = await todoStore.FindAsync(query);
+            listToDo = await todoStore.FindAsync(query: query, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(newItem1.ID);
@@ -5387,7 +5387,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -5438,7 +5438,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -5490,7 +5490,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -5526,7 +5526,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.FindByIDAsync(TestSetup.id_for_400_error_response_fake);
+                    await todoStore.FindByIDAsync(entityID: TestSetup.id_for_400_error_response_fake, ct: default);
                 });
 
                 // Assert
@@ -5557,7 +5557,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await todoStore.FindByIDAsync(Guid.NewGuid().ToString());
+                await todoStore.FindByIDAsync(entityID: Guid.NewGuid().ToString(), ct: default);
             });
 
             // Assert
@@ -5586,7 +5586,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.FindByIDAsync(TestSetup.id_for_403_error_response_fake);
+                    await todoStore.FindByIDAsync(entityID: TestSetup.id_for_403_error_response_fake, ct: default);
                 });
 
                 // Assert
@@ -5617,7 +5617,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await todoStore.FindByIDAsync(Guid.NewGuid().ToString());
+                await todoStore.FindByIDAsync(entityID: Guid.NewGuid().ToString(), ct: default);
             });
 
             // Assert
@@ -5646,7 +5646,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.FindByIDAsync(TestSetup.id_for_409_error_response_fake);
+                    await todoStore.FindByIDAsync(entityID: TestSetup.id_for_409_error_response_fake, ct: default);
                 });
 
                 // Assert
@@ -5676,7 +5676,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await todoStore.FindByIDAsync(TestSetup.id_for_500_error_response_fake);
+                    await todoStore.FindByIDAsync(entityID: TestSetup.id_for_500_error_response_fake, ct: default);
                 });
 
                 // Assert
@@ -5738,7 +5738,7 @@ namespace Kinvey.Tests
 
             // Act
             int avg = 0;
-            List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "Age");
+            List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "Age", query: null, ct: default);
             foreach (var gar in arrGAR)
             {
                 avg = gar.Result;
@@ -5793,7 +5793,7 @@ namespace Kinvey.Tests
 
             // Act
             int max = 0;
-            List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MAX, "", "Age");
+            List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MAX, groupField: "", aggregateField: "Age", query: null, ct: default);
             foreach (var gar in arrGAR)
             {
                 max = gar.Result;
@@ -5847,7 +5847,8 @@ namespace Kinvey.Tests
 
 			// Act
 			int min = 0;
-			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MIN, "", "Age");
+			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MIN, groupField: "", aggregateField: "Age",
+                query: null, ct: default);
 			foreach (var gar in arrGAR)
 			{
 				min = gar.Result;
@@ -5903,7 +5904,7 @@ namespace Kinvey.Tests
 
             // Act
             int sum = 0;
-            List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_SUM, "LastName", "Age", query);
+            List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_SUM, groupField: "LastName", aggregateField: "Age", query: query, ct: default);
             foreach (var gar in arrGAR)
             {
                 if (gar.GroupField.Equals("Bluth"))
@@ -5946,7 +5947,8 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "Name");
+                    await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "Name",
+                        query: null, ct: default);
                 });
 
                 // Assert
@@ -5977,7 +5979,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await store.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "Name");
+                await store.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "Name", query: null,  ct: default);
             });
 
             // Assert
@@ -6006,7 +6008,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "FirstName");
+                    await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "FirstName", query: null, ct: default);
                 });
 
                 // Assert
@@ -6036,7 +6038,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "FirstName");
+                    await personStore.GroupAndAggregateAsync(reduceFunction:EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "FirstName", query: null, ct: default);
                 });
 
                 // Assert
@@ -6066,7 +6068,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "FirstName");
+                    await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "FirstName", query: null, ct: default);
                 });
 
                 // Assert
@@ -6096,7 +6098,7 @@ namespace Kinvey.Tests
                 // Act
                 var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
                 {
-                    await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "FirstName");
+                    await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "FirstName", query: null, ct: default);
                 });
 
                 // Assert
@@ -6175,7 +6177,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDo = await todoStore.SaveAsync(newItem);
 
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.ID);
@@ -6214,7 +6216,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDo = await todoStore.SaveAsync(newItem);
 
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.ID);
@@ -6253,7 +6255,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDo = await todoStore.SaveAsync(newItem);
 
-            var existingToDo = await todoStore.FindByIDAsync(savedToDo.ID);
+            var existingToDo = await todoStore.FindByIDAsync(entityID: savedToDo.ID, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.ID);
@@ -6291,7 +6293,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDo = await todoStore.SaveAsync(newItem);
 
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.ID);
@@ -6332,7 +6334,7 @@ namespace Kinvey.Tests
                 var savedToDo = await todoStore.SaveAsync(newItem);
             });
 
-            var toDosNetwork = await todoStore.FindAsync();
+            var toDosNetwork = await todoStore.FindAsync(query: null, ct: default);
 
             // Assert
             Assert.IsNotNull(toDosNetwork);
@@ -6561,7 +6563,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
 
-            var existingToDos = await todoStoreNetwork.FindAsync();
+            var existingToDos = await todoStoreNetwork.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6607,7 +6609,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
 
-            var existingToDos = await todoStoreNetwork.FindAsync();
+            var existingToDos = await todoStoreNetwork.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6665,7 +6667,7 @@ namespace Kinvey.Tests
             // Act
             var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
 
-            var existingToDos = await todoStoreNetwork.FindAsync();
+            var existingToDos = await todoStoreNetwork.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6722,7 +6724,7 @@ namespace Kinvey.Tests
                 // Act
                 var savedToDos = await todoStoreNetwork.SaveAsync(toDos);
 
-                var existingToDos = await todoStoreNetwork.FindAsync();
+                var existingToDos = await todoStoreNetwork.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await todoStoreNetwork.RemoveAsync(savedToDos.Entities[0].ID);
@@ -7793,7 +7795,7 @@ namespace Kinvey.Tests
             // Act
             var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
             {
-                await invalidToDoStore.FindByIDAsync(savedToDo.ID);
+                await invalidToDoStore.FindByIDAsync(entityID: savedToDo.ID, ct: default);
             });
                     
             // Teardown

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -152,7 +153,7 @@ namespace Kinvey.Tests
 			// Act
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync();
+			listToDo = await todoStore.FindAsync(query: null, ct: default);
 
 			// Assert
 			Assert.IsNotNull(listToDo);
@@ -187,7 +188,7 @@ namespace Kinvey.Tests
 			var savedEntity = await todoStore.SaveAsync(newItem);
 
 			// Act
-			var existingEntity = await todoStore.FindByIDAsync(savedEntity.ID);
+			var existingEntity = await todoStore.FindByIDAsync(entityID: savedEntity.ID, ct: default);
 
 			// Assert
 			Assert.IsNotNull(existingEntity);
@@ -222,7 +223,7 @@ namespace Kinvey.Tests
             ToDo existingEntity = null;
             try
             {
-                existingEntity = await todoStore.FindByIDAsync(savedEntity.ID);
+                existingEntity = await todoStore.FindByIDAsync(entityID: savedEntity.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -273,7 +274,7 @@ namespace Kinvey.Tests
             ToDo existingEntity = null;
             try
             {
-                existingEntity = await todoStore.FindByIDAsync(savedEntity.ID);
+                existingEntity = await todoStore.FindByIDAsync(entityID: savedEntity.ID, ct: default);
             }
             catch (KinveyException kinveyException)
             {
@@ -328,7 +329,7 @@ namespace Kinvey.Tests
 			List<ToDo> listToDo = new List<ToDo>();
 			var query = todoStore.Where(x => x.Details.StartsWith("det"));
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 
 			// Teardown
@@ -388,7 +389,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -397,7 +398,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -406,7 +407,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -470,7 +471,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -479,7 +480,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -488,7 +489,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -553,7 +554,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -562,7 +563,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -571,7 +572,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -636,7 +637,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -645,7 +646,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -654,7 +655,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -726,7 +727,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -735,7 +736,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -744,7 +745,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -817,7 +818,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -826,7 +827,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -835,7 +836,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -907,7 +908,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -916,7 +917,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -925,7 +926,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -997,7 +998,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1006,7 +1007,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1015,7 +1016,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1087,7 +1088,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1096,7 +1097,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1105,7 +1106,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1178,7 +1179,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1187,7 +1188,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1196,7 +1197,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1269,7 +1270,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1278,7 +1279,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1287,7 +1288,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1358,7 +1359,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1367,7 +1368,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1376,7 +1377,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1447,7 +1448,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1456,7 +1457,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1465,7 +1466,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1536,7 +1537,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1545,7 +1546,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1554,7 +1555,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1627,7 +1628,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1636,7 +1637,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1645,7 +1646,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1717,7 +1718,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1726,7 +1727,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1735,7 +1736,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1807,7 +1808,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1816,7 +1817,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1825,7 +1826,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1897,7 +1898,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1906,7 +1907,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1915,7 +1916,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1987,7 +1988,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -1996,7 +1997,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2005,7 +2006,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2078,7 +2079,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2087,7 +2088,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2096,7 +2097,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2169,7 +2170,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2178,7 +2179,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2187,7 +2188,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2260,7 +2261,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2269,7 +2270,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2278,7 +2279,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2352,7 +2353,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem1 = await todoStore.FindByIDAsync(savedItem1.ID);
+                existingItem1 = await todoStore.FindByIDAsync(entityID: savedItem1.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2361,7 +2362,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem2 = await todoStore.FindByIDAsync(savedItem2.ID);
+                existingItem2 = await todoStore.FindByIDAsync(entityID: savedItem2.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2370,7 +2371,7 @@ namespace Kinvey.Tests
 
             try
             {
-                existingItem3 = await todoStore.FindByIDAsync(savedItem3.ID);
+                existingItem3 = await todoStore.FindByIDAsync(entityID: savedItem3.ID, ct: default);
             }
             catch (Exception)
             {
@@ -2832,7 +2833,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -2895,7 +2896,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -2956,7 +2957,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3017,7 +3018,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3079,7 +3080,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3141,7 +3142,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3203,7 +3204,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3265,7 +3266,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -3309,7 +3310,7 @@ namespace Kinvey.Tests
 
 			// Act
 			var count = 0u;
-			count = await todoStore.GetCountAsync();
+			count = await todoStore.GetCountAsync(query: null, ct: default);
 
 			// Assert
 			//Assert.GreaterOrEqual(count, 0);
@@ -3357,7 +3358,7 @@ namespace Kinvey.Tests
 
 			// Act
 			int sum = 0;
-			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_SUM, "", "Age", query);
+			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_SUM, groupField: "", aggregateField: "Age", query: query, ct: default);
 			foreach (var gar in arrGAR)
 			{
 				sum = gar.Result;
@@ -3411,7 +3412,7 @@ namespace Kinvey.Tests
 
 			// Act
 			int min = 0;
-			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MIN, "", "Age", query);
+			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MIN, groupField: "", aggregateField: "Age", query: query, ct: default);
 			foreach (var gar in arrGAR)
 			{
 				min = gar.Result;
@@ -3462,7 +3463,7 @@ namespace Kinvey.Tests
 
 			// Act
 			int max = 0;
-			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_MAX, "LastName", "Age");
+			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_MAX, groupField: "LastName", aggregateField: "Age", query: null, ct: default);
 			foreach (var gar in arrGAR)
 			{
 				if (gar.GroupField.Equals("Funke"))
@@ -3522,7 +3523,7 @@ namespace Kinvey.Tests
 
 			// Act
 			int avg = 0;
-			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, "", "Age");
+			List<GroupAggregationResults> arrGAR = await personStore.GroupAndAggregateAsync(reduceFunction: EnumReduceFunction.REDUCE_FUNCTION_AVERAGE, groupField: "", aggregateField: "Age", query: null, ct: default);
 			foreach (var gar in arrGAR)
 			{
 				avg = gar.Result;
@@ -3668,7 +3669,7 @@ namespace Kinvey.Tests
 
 			// Act
 			PendingWriteAction pwa = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).Peek();
-			List<ToDo> t = await todoStore.FindAsync();
+			List<ToDo> t = await todoStore.FindAsync(query: null, ct: default);
 
 			// Assert
 			Assert.IsNotNull(pwa);
@@ -3767,7 +3768,7 @@ namespace Kinvey.Tests
 			// Teardown
 			List<ToDo> listRemoveToDo = new List<ToDo>();
 
-			listRemoveToDo = await todoStore.FindAsync();
+			listRemoveToDo = await todoStore.FindAsync(query: null, ct: default);
 
 			KinveyDeleteResponse kdr;
 			foreach (ToDo td in listRemoveToDo)
@@ -3868,7 +3869,7 @@ namespace Kinvey.Tests
 
             // Teardown
             List<ToDo> listRemoveToDo = new List<ToDo>();
-            listRemoveToDo = await todoStore.FindAsync();
+            listRemoveToDo = await todoStore.FindAsync(query: null, ct: default);
 
             foreach (ToDo td in listRemoveToDo)
             {
@@ -3876,7 +3877,7 @@ namespace Kinvey.Tests
             }
 
             List<FlashCard> listRemoveFlash = new List<FlashCard>();
-            listRemoveFlash = await flashCardStore.FindAsync();
+            listRemoveFlash = await flashCardStore.FindAsync(query: null, ct: default);
 
             foreach (FlashCard fc in listRemoveFlash)
             {
@@ -3928,7 +3929,7 @@ namespace Kinvey.Tests
 
 			// Teardown
 			List<ToDo> listRemoveToDo = new List<ToDo>();
-			listRemoveToDo = await todoStore.FindAsync();
+			listRemoveToDo = await todoStore.FindAsync(query: null, ct: default);
 
 			foreach (ToDo t in listRemoveToDo)
 			{
@@ -4026,7 +4027,7 @@ namespace Kinvey.Tests
 
             await syncStore.PullAsync();
 
-            var savedTasks = await syncStore.FindAsync();
+            var savedTasks = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             foreach (var todo in savedTasks)
@@ -4077,10 +4078,10 @@ namespace Kinvey.Tests
 
             var query = syncStore.Where(e => e.Details.Equals("Another test"));
             await syncStore.PullAsync(query);
-            var savedTasksWithQuery = await syncStore.FindAsync();
+            var savedTasksWithQuery = await syncStore.FindAsync(query: null, ct: default);
 
             await syncStore.PullAsync();
-            var savedTasksWithoutQuery = await syncStore.FindAsync();
+            var savedTasksWithoutQuery = await syncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             foreach (var todo in savedTasksWithoutQuery)
@@ -4139,7 +4140,7 @@ namespace Kinvey.Tests
 
                 //Act
                 await syncStore.PullAsync();
-                var savedTasks = await syncStore.FindAsync();
+                var savedTasks = await syncStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await syncStore.RemoveAsync(syncStore.Where(e => e.Details.Equals("A test")));
@@ -4312,7 +4313,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -4382,7 +4383,7 @@ namespace Kinvey.Tests
 
 			List<ToDo> listToDo = new List<ToDo>();
 
-			listToDo = await todoStore.FindAsync(query);
+			listToDo = await todoStore.FindAsync(query: query, ct: default);
 
 			// Teardown
 			await todoStore.RemoveAsync(newItem1.ID);
@@ -4686,7 +4687,7 @@ namespace Kinvey.Tests
             // Act
             var firstResponse = await store.PullAsync();
             var secondResponse = await store.PullAsync();
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 await store.RemoveAsync(localEntities.First().ID);
@@ -4744,7 +4745,7 @@ namespace Kinvey.Tests
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4804,13 +4805,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -4869,12 +4870,12 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.PullAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             int localCount = localEntities.Count;
             bool localCopy = false;
 
@@ -4945,7 +4946,7 @@ namespace Kinvey.Tests
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5003,7 +5004,7 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
@@ -5017,7 +5018,7 @@ namespace Kinvey.Tests
             var query3 = store.Where(x => x.Question.StartsWith("Wh"));
             var thirdResponse = await store.PullAsync(query3);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5077,14 +5078,14 @@ namespace Kinvey.Tests
             var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
             await store.PushAsync();
             var secondResponse = await store.PullAsync();
-            var firstStoreCount = (await store.FindAsync()).Count;
+            var firstStoreCount = (await store.FindAsync(query: null, ct: default)).Count;
 
             var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
             var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
             await store.PushAsync();
             var thirdResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5144,13 +5145,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.PullAsync();
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
             var secondResponse = await store.PullAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5210,7 +5211,7 @@ namespace Kinvey.Tests
             // Act
             var firstResponse = await store.SyncAsync();
             var secondResponse = await store.SyncAsync();
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 await store.RemoveAsync(localEntities.First().ID);
@@ -5265,7 +5266,7 @@ namespace Kinvey.Tests
             fc3 = await store.SaveAsync(fc3);
             var thirdResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5324,13 +5325,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5388,12 +5389,12 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             int localDeleteCount = (await networkStore.RemoveAsync(fc2.ID)).count;
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
             var secondResponse = await store.SyncAsync(query2);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             int localCount = localEntities.Count;
             bool localCopy = false;
 
@@ -5463,7 +5464,7 @@ namespace Kinvey.Tests
             fc3 = await store.SaveAsync(fc3);
             var secondResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5521,7 +5522,7 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync(query);
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var query2 = store.Where(x => x.Question.StartsWith("Wh"));
@@ -5535,7 +5536,7 @@ namespace Kinvey.Tests
             var query3 = store.Where(x => x.Question.StartsWith("Wh"));
             var thirdResponse = await store.SyncAsync(query3);
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5594,13 +5595,13 @@ namespace Kinvey.Tests
 
             var firstDeleteResponse = await store.RemoveAsync(fc1.ID);
             var secondResponse = await store.SyncAsync();
-            var firstStoreCount = (await store.FindAsync()).Count;
+            var firstStoreCount = (await store.FindAsync(query: null, ct: default)).Count;
 
             var secondDeleteResponse = await store.RemoveAsync(fc2.ID);
             var thirdDeleteResponse = await store.RemoveAsync(fc3.ID);
             var thirdResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5660,13 +5661,13 @@ namespace Kinvey.Tests
             var firstResponse = await store.SyncAsync();
 
             var fc2Query = store.Where(y => y.Answer.Equals("8"));
-            fc2 = (await store.FindAsync(fc2Query)).First();
+            fc2 = (await store.FindAsync(query: fc2Query, ct: default)).First();
             fc2.Answer = "14";
             fc2 = await networkStore.SaveAsync(fc2);
             var deleteResponse = await networkStore.RemoveAsync(fc3.ID);
             var secondResponse = await store.SyncAsync();
 
-            var localEntities = await store.FindAsync();
+            var localEntities = await store.FindAsync(query: null, ct: default);
             if (localEntities != null)
             {
                 foreach (var localEntity in localEntities)
@@ -5723,7 +5724,7 @@ namespace Kinvey.Tests
             var savedToDo = await todoStore.SaveAsync(newItem);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.ID);
@@ -5816,7 +5817,7 @@ namespace Kinvey.Tests
             var savedToDo = await todoStore.SaveAsync(newItem);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDo.ID);
@@ -5864,7 +5865,7 @@ namespace Kinvey.Tests
             var savedToDos = await todoStore.SaveAsync(toDos);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -5921,7 +5922,7 @@ namespace Kinvey.Tests
             var savedToDos = await todoStore.SaveAsync(toDos);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -5990,7 +5991,7 @@ namespace Kinvey.Tests
             var savedToDos = await todoStore.SaveAsync(toDos);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDos.Entities[0].ID);
@@ -6125,7 +6126,7 @@ namespace Kinvey.Tests
             var savedToDos = await todoStore.SaveAsync(toDos);
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoStore.FindAsync();
+            var existingToDos = await todoStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoStore.RemoveAsync(savedToDos.Entities[1].ID);
@@ -6216,7 +6217,7 @@ namespace Kinvey.Tests
             var pushResponse = await todoSyncStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoSyncStore.FindAsync();
+            var existingToDos = await todoSyncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoNetworkStore.RemoveAsync(pushResponse.PushEntities[0].ID);
@@ -6265,8 +6266,8 @@ namespace Kinvey.Tests
             var pushResponse = await todoSyncStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDosSync = await todoSyncStore.FindAsync();
-            var existingToDosNetwork = await todoNetworkStore.FindAsync();
+            var existingToDosSync = await todoSyncStore.FindAsync(query: null, ct: default);
+            var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoNetworkStore.RemoveAsync(pushResponse.PushEntities[0].ID);
@@ -6324,7 +6325,7 @@ namespace Kinvey.Tests
             var pushResponse = await todoSyncStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoSyncStore.FindAsync();
+            var existingToDos = await todoSyncStore.FindAsync(query: null, ct: default);
 
             //Teardown
             await todoSyncStore.RemoveAsync(todoSyncStore.Where(e=>e.Name.StartsWith("Name")));
@@ -6377,7 +6378,7 @@ namespace Kinvey.Tests
                 var pushResponse = await todoSyncStore.PushAsync();
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDos = await todoSyncStore.FindAsync();
+                var existingToDos = await todoSyncStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await todoSyncStore.RemoveAsync(savedToDos.Entities[2].ID);
@@ -6433,7 +6434,7 @@ namespace Kinvey.Tests
             var pushResponse = await todoSyncStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDos = await todoSyncStore.FindAsync();
+            var existingToDos = await todoSyncStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoNetworkStore.RemoveAsync(pushResponse.PushEntities[0].ID);
@@ -6481,8 +6482,8 @@ namespace Kinvey.Tests
                 var syncResponse = await todoSyncStore.SyncAsync();
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDosNetwork = await todoNetworkStore.FindAsync();
-                var existingToDosLocal = await todoSyncStore.FindAsync();
+                var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
+                var existingToDosLocal = await todoSyncStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await todoNetworkStore.RemoveAsync(existingToDosNetwork[0].ID);
@@ -6579,8 +6580,8 @@ namespace Kinvey.Tests
             var pushResponse = await todoSyncStore.PushAsync();
 
             var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-            var existingToDosSync = await todoSyncStore.FindAsync();
-            var existingToDosNetwork = await todoNetworkStore.FindAsync();
+            var existingToDosSync = await todoSyncStore.FindAsync(query: null, ct: default);
+            var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
 
             // Teardown
             await todoNetworkStore.RemoveAsync(todoSyncStore.Where(e=> e.Name.StartsWith("Name")));
@@ -6687,8 +6688,8 @@ namespace Kinvey.Tests
                 var pushResponse = await todoSyncStore.PushAsync();
 
                 var pendingWriteActions = kinveyClient.CacheManager.GetSyncQueue(toDosCollection).GetAll();
-                var existingToDosSync = await todoSyncStore.FindAsync();
-                var existingToDosNetwork = await todoNetworkStore.FindAsync();
+                var existingToDosSync = await todoSyncStore.FindAsync(query: null, ct: default);
+                var existingToDosNetwork = await todoNetworkStore.FindAsync(query: null, ct: default);
 
                 // Teardown
                 await todoNetworkStore.RemoveAsync(todoSyncStore.Where(e => e.Name.StartsWith("Name")));

--- a/Kinvey.Tests/UserTests/UserIntegrationTests.cs
+++ b/Kinvey.Tests/UserTests/UserIntegrationTests.cs
@@ -489,7 +489,7 @@ namespace Kinvey.Tests
             // Act
             await User.LoginWithMIC("test3", "test3", null, kinveyClient);
             var savedToDo = await todoStore.SaveAsync(todo);
-            var existingToDo = await todoStore.FindByIDAsync(savedToDo.ID);
+            var existingToDo = await todoStore.FindByIDAsync(entityID: savedToDo.ID, ct: default);
 
             //Teardown
             await todoStore.RemoveAsync(savedToDo.ID);
@@ -780,7 +780,7 @@ namespace Kinvey.Tests
             // Check that all state is cleared out properly in logout by verifying that re-login works correctly
             await User.LoginAsync(TestSetup.user, TestSetup.pass, kinveyClient);
             DataStore<ToDo> todoStoreRelogin = DataStore<ToDo>.Collection(collectionName, DataStoreType.SYNC, kinveyClient);
-            await todoStoreRelogin.FindAsync();
+            await todoStoreRelogin.FindAsync(query: null, ct: default);
         }
 
         [TestMethod]


### PR DESCRIPTION
#### Description
Removal of dead and not needed code by deprecating.

DataStore.cs
```
GetCustomRequestProperties()
SetCustomRequestProperties (JObject customheaders)
SetCustomRequestProperty (string key, JObject value)
FindAsync(IQueryable<object> query = null, KinveyDelegate<List<T>> cacheResults = null, CancellationToken ct = default(CancellationToken))
FindByIDAsync(string entityID, KinveyDelegate<T> cacheResult = null, CancellationToken ct = default(CancellationToken))
GetCountAsync(IQueryable<object> query = null, KinveyDelegate<uint> cacheCount = null, CancellationToken ct = default(CancellationToken))
GroupAndAggregateAsync(EnumReduceFunction reduceFunction, string groupField = "", string aggregateField = "", IQueryable<object> query = null, KinveyDelegate<List<GroupAggregationResults>> cacheDelegate = null, CancellationToken ct = default(CancellationToken))
```
ReadPolicy.cs 
`BOTH `

ReadRequest.cs
`RetrieveDeltaSet(List<T> cacheItems, List<DeltaSetFetchInfo> networkItems, string mongoQuery)`

#### Changes
No changes

#### Tests
No changes
