### PR TITLE
MLIBZ-3161: Cleanup: Kinvey.Shared/Offline project (To next-v5)

### DIFF
--- a/Kinvey.Shared/Offline/PendingWriteAction.cs
+++ b/Kinvey.Shared/Offline/PendingWriteAction.cs
@@ -13,6 +13,7 @@
 
 using SQLite;
 using Newtonsoft.Json;
+using System;
 
 namespace Kinvey
 {
@@ -82,7 +83,8 @@ namespace Kinvey
 			return newAction;
 		}
 
-		public NetworkRequest<T> toNetworkRequest <T>(AbstractClient client){
+        [Obsolete("This method has been deprecated.")]
+        public NetworkRequest<T> toNetworkRequest <T>(AbstractClient client){
 			return null;
 		}
 	}

--- a/Kinvey.Shared/Offline/SQLTemplates.cs
+++ b/Kinvey.Shared/Offline/SQLTemplates.cs
@@ -17,15 +17,17 @@ using Newtonsoft.Json.Linq;
 
 namespace Kinvey
 {
-	/// <summary>
-	/// These are the structures stored in the database, one for each table
-	/// </summary>
-	public class SQLTemplates{
+    /// <summary>
+    /// These are the structures stored in the database, one for each table
+    /// </summary>
+    [Obsolete("This class has been deprecated.")]
+    public class SQLTemplates{
 
-		/// <summary>
-		/// This maintains the collection names
-		/// </summary>
-		public class TableItem{
+        /// <summary>
+        /// This maintains the collection names
+        /// </summary>
+        [Obsolete("This class has been deprecated.")]
+        public class TableItem{
             /// <summary>
             /// Name.
             /// </summary>
@@ -33,10 +35,11 @@ namespace Kinvey
             public string name { get; set;}
 		}
 
-		/// <summary>
-		/// This maintains the entities themselves.
-		/// </summary>
-		public class OfflineEntity{
+        /// <summary>
+        /// This maintains the entities themselves.
+        /// </summary>
+        [Obsolete("This class has been deprecated.")]
+        public class OfflineEntity{
             /// <summary>
             /// Identifier.
             /// </summary>
@@ -57,10 +60,11 @@ namespace Kinvey
 			public string collection { get; set; }
 		}
 
-		/// <summary>
-		/// This maintains a queue of pending requests.
-		/// </summary>
-		public class QueueItem{
+        /// <summary>
+        /// This maintains a queue of pending requests.
+        /// </summary>
+        [Obsolete("This class has been deprecated.")]
+        public class QueueItem{
             /// <summary>
             /// Key.
             /// </summary>
@@ -87,10 +91,11 @@ namespace Kinvey
             public string action { get; set; }
 		}
 
-		/// <summary>
-		/// This maintains a query and it's responses.
-		/// </summary>
-		public class QueryItem{
+        /// <summary>
+        /// This maintains a query and it's responses.
+        /// </summary>
+        [Obsolete("This class has been deprecated.")]
+        public class QueryItem{
             /// <summary>
             /// Key.
             /// </summary>
@@ -118,10 +123,11 @@ namespace Kinvey
 				
 		}
 
-		/// <summary>
-		/// This maintains the custom request parameters, client app verison, and _id of a queued request
-		/// </summary>
-		public class OfflineMetaData{
+        /// <summary>
+        /// This maintains the custom request parameters, client app verison, and _id of a queued request
+        /// </summary>
+        [Obsolete("This class has been deprecated.")]
+        public class OfflineMetaData{
             /// <summary>
             /// Identifier.
             /// </summary>

--- a/Kinvey.Shared/Offline/SQLiteCache.cs
+++ b/Kinvey.Shared/Offline/SQLiteCache.cs
@@ -531,7 +531,8 @@ namespace Kinvey
 			return localAggregateResults;
 		}
 
-		public async Task<List<T>> GetAsync(string query)
+        [Obsolete("This method has been deprecated.")]
+        public async Task<List<T>> GetAsync(string query)
 		{
 			// TODO implement
 			return default(List<T>);

--- a/Kinvey.Shared/Offline/SQLiteCacheManager.cs
+++ b/Kinvey.Shared/Offline/SQLiteCacheManager.cs
@@ -159,11 +159,12 @@ namespace Kinvey
             }
 		}
 
-		/// <summary>
-		/// Gets the collection tables.
-		/// </summary>
-		/// <returns>The collection tables.</returns>
-		public List<string> getCollectionTables()
+        /// <summary>
+        /// Gets the collection tables.
+        /// </summary>
+        /// <returns>The collection tables.</returns>
+        [Obsolete("This method has been deprecated.")]
+        public List<string> getCollectionTables()
 		{
             lock (DBConnectionSync)
             {
@@ -179,11 +180,12 @@ namespace Kinvey
             }
 		}
 
-		/// <summary>
-		/// Gets the collection tables asynchronously.
-		/// </summary>
-		/// <returns>The collection tables.</returns>
-		public async Task<List<string>> getCollectionTablesAsync ()
+        /// <summary>
+        /// Gets the collection tables asynchronously.
+        /// </summary>
+        /// <returns>The collection tables.</returns>
+        [Obsolete("This method has been deprecated.")]
+        public async Task<List<string>> getCollectionTablesAsync ()
 		{
 			List<SQLTemplates.TableItem> result = await dbConnectionAsync.Table<SQLTemplates.TableItem> ().OrderByDescending (t => t.name).ToListAsync ();
 			List<string> collections = new List<string> ();


### PR DESCRIPTION
#### Description
Deprecating of not being used code.
1. The "toNetworkRequest()" method in the "PendingWriteAction" class.
2. The "GetAsync(string query)" method in the "SQLiteCache" class.
3. The "getCollectionTables()" method in the "SQLiteCacheManager" class.
4. The "getCollectionTablesAsync()" method in the "SQLiteCacheManager" class.
5. The "SQLTemplates" class, the "SQLTemplates.TableItem" class, the "SQLTemplates.OfflineEntity" class, the "SQLTemplates.QueueItem" class, the "SQLTemplates.QueryItem" class, the "SQLTemplates.OfflineMetaData" class.

#### Changes
No changes

#### Tests
No tests
