### PR TITLE
[WIP]Adding possibility to set environment variables in Travis CI settings.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ matrix:
       mono: none
       dotnet: 3.0
       dist: xenial
+      before_install:
+        - export KINVEY_APP_KEY="_kid_"
+        - export KINVEY_APP_SECRET="appSecret"
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"
@@ -16,8 +19,8 @@ matrix:
         - brew update
         - brew cask install dotnet-sdk
         - export PATH="$PATH:/usr/local/share/dotnet"
-        - export KINVEY_APP_KEY="kid_HkEDqv45B"
-        - export KINVEY_APP_SECRET="06fa3d06463f473d8c6ecdd26b306f67"
+        - export KINVEY_APP_KEY="_kid_"
+        - export KINVEY_APP_SECRET="appSecret"
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F macOS
     # - name: "Mono"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
         - brew update
         - brew cask install dotnet-sdk
         - export PATH="$PATH:/usr/local/share/dotnet"
+        - export KINVEY_APP_KEY="kid_HkEDqv45B"
+        - export KINVEY_APP_SECRET="06fa3d06463f473d8c6ecdd26b306f67"
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F macOS
     # - name: "Mono"
@@ -46,8 +48,6 @@ matrix:
 install:
   - dotnet tool install --global coverlet.console
   - export PATH="$PATH:/home/travis/.dotnet/tools"
-  - export KINVEY_APP_KEY="kid_HkEDqv45B"
-  - export KINVEY_APP_SECRET="06fa3d06463f473d8c6ecdd26b306f67"
 script:
   - cd Kinvey.Tests; dotnet build
   - dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
       dotnet: 3.0
       dist: xenial
       before_install:
-        - export KINVEY_APP_KEY="kid_HkEDqv45B"
-        - export KINVEY_APP_SECRET="06fa3d06463f473d8c6ecdd26b306f67"
+        - export KINVEY_APP_KEY="_kid_"
+        - export KINVEY_APP_SECRET="appSecret"
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ matrix:
 install:
   - dotnet tool install --global coverlet.console
   - export PATH="$PATH:/home/travis/.dotnet/tools"
+  - export KINVEY_APP_KEY="kid_HkEDqv45B"
+  - export KINVEY_APP_SECRET="06fa3d06463f473d8c6ecdd26b306f67"
 script:
   - cd Kinvey.Tests; dotnet build
   - dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=opencover

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ matrix:
       dotnet: 3.0
       dist: xenial
       before_install:
-        - export KINVEY_APP_KEY="_kid_"
-        - export KINVEY_APP_SECRET="appSecret"
+        - export KINVEY_APP_KEY="kid_HkEDqv45B"
+        - export KINVEY_APP_SECRET="06fa3d06463f473d8c6ecdd26b306f67"
       after_success:
         - bash <(curl -s https://codecov.io/bash) -F Linux
     - name: "macOS"

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -11461,5 +11461,14 @@ namespace Kinvey.Tests
         }
 
         #endregion Clear cache       
-    }
+
+        [TestMethod]
+        public async Task TestIntegration()
+        {
+            if (!MockData)
+            {
+                Assert.Fail("Test integration");
+            }
+        }
+        }
 }

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -11462,13 +11462,5 @@ namespace Kinvey.Tests
 
         #endregion Clear cache       
 
-        [TestMethod]
-        public async Task TestIntegration()
-        {
-            if (!MockData)
-            {
-                Assert.Fail("Test integration");
-            }
-        }
-        }
+    }
 }


### PR DESCRIPTION
#### Description
These are default settings:
KINVEY_APP_KEY: 'kid'
KINVEY_APP_SECRET: 'appSecret'

They imply that CI will run the unit tests. If a user changes them, CI will run the integration tests.

#### Changes
<!-- List the changes to the SDK made by this pull request. -->

#### Tests
<!-- Describe the tests that were performed on the changes. -->
