### PR TITLE
KDEV-722: Fix missing info in KinveyException

### DIFF
--- a/Kinvey.Shared/Auth/KinveyAuthRequest.cs
+++ b/Kinvey.Shared/Auth/KinveyAuthRequest.cs
@@ -239,7 +239,7 @@ namespace Kinvey
 			}
             try
             {
-                response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCodeWithoutDispose();
             }
             catch (Exception ex)
             {

--- a/Kinvey.Shared/Core/AbstractKinveyClientRequest.cs
+++ b/Kinvey.Shared/Core/AbstractKinveyClientRequest.cs
@@ -411,7 +411,7 @@ namespace Kinvey
 
 			try
             {
-                response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCodeWithoutDispose();
             }
             catch (Exception ex)
             {
@@ -543,7 +543,7 @@ namespace Kinvey
 
             try
             {
-                response.EnsureSuccessStatusCode();
+                response.EnsureSuccessStatusCodeWithoutDispose();
             }
             catch (Exception ex)
             {
@@ -649,7 +649,7 @@ namespace Kinvey
 				// produce a successsful outcome.
                 try
                 {
-                    response.EnsureSuccessStatusCode();
+                    response.EnsureSuccessStatusCodeWithoutDispose();
                 }
                 catch (Exception ex)
                 {
@@ -672,7 +672,7 @@ namespace Kinvey
 				// indicates that there is an issue with what was being requested
                 try
                 {
-                    response.EnsureSuccessStatusCode();
+                    response.EnsureSuccessStatusCodeWithoutDispose();
                 }
                 catch (Exception ex)
                 {
@@ -690,7 +690,7 @@ namespace Kinvey
 			{
 				try
                 {
-                    response.EnsureSuccessStatusCode();
+                    response.EnsureSuccessStatusCodeWithoutDispose();
                 }
                 catch (Exception ex)
                 {
@@ -818,5 +818,22 @@ namespace Kinvey
 				return String.Join("&", dict.Select(kvp => String.Concat(Uri.EscapeDataString(kvp.Key), "=", Uri.EscapeDataString(kvp.Value.ToString()))));
 			}
 		}
+    }
+
+    public static class HttpResponseMessageExtensions
+    {
+        public static HttpResponseMessage EnsureSuccessStatusCodeWithoutDispose(this HttpResponseMessage response)
+        {
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException(string.Format(
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    "Response status code does not indicate success: {0} ({1}).",
+                    (int)response.StatusCode,
+                    response.ReasonPhrase));
+            }
+
+            return response;
+        }
     }
 }

--- a/Kinvey.Shared/File/KinveyFileRequest.cs
+++ b/Kinvey.Shared/File/KinveyFileRequest.cs
@@ -63,7 +63,7 @@ namespace Kinvey
 			}
 
 			var response = await httpClient.PutAsync(requestURI, input).ConfigureAwait(false);
-			response.EnsureSuccessStatusCode();
+			response.EnsureSuccessStatusCodeWithoutDispose();
 			return response;
 		}
 

--- a/Kinvey.Shared/Troubleshooting/KinveyException.cs
+++ b/Kinvey.Shared/Troubleshooting/KinveyException.cs
@@ -180,12 +180,11 @@ namespace Kinvey
 			{
 				KinveyJsonError errorJSON = KinveyJsonError.parse(response);
 				this.error = errorJSON.Error ?? errorInfo.Item1;
-				this.debug = errorJSON.Debug ?? errorInfo.Item2;
+				this.debug = errorJSON.Debug != null ? errorJSON.Debug.ToString() : errorInfo.Item2;
 				this.description = errorJSON.Description ?? errorInfo.Item3;
 				this.requestID = HelperMethods.getRequestID(response);
-
 			}
-			catch (Exception) { 
+			catch (Exception) {
 				//Catch any exceptions thrown while parsing an unknown responseJSON
 			}
 		}

--- a/Kinvey.Shared/Troubleshooting/KinveyJsonError.cs
+++ b/Kinvey.Shared/Troubleshooting/KinveyJsonError.cs
@@ -13,6 +13,7 @@
 
 using System.Net.Http;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace Kinvey
 {
@@ -48,7 +49,7 @@ namespace Kinvey
 		/// </summary>
 		/// <value>The debug.</value>
         [JsonProperty]
-        public string Debug {get; set;}
+        public JToken Debug {get; set;}
 
         /// <summary>
         /// Parses the specified response into an error.

--- a/Kinvey.TestApp.Shared/Pages/ContractsPage.xaml
+++ b/Kinvey.TestApp.Shared/Pages/ContractsPage.xaml
@@ -5,33 +5,40 @@
             x:Class="Kinvey.TestApp.Shared.Pages.ContractsPage"
             Appearing="ContractsPage_OnAppearing">  
     <pages:BasePage.Content>
-        <StackLayout>
-            <Label x:Name="UserLabel" Text="Hello!" 
-               HorizontalOptions="Center"/>
-
-            <Label Text="Contracts" Margin="0, 20, 0, 0"
-                   HorizontalOptions="Center"/>
-
-            <ListView x:Name="ContractsList">
-                <ListView.ItemTemplate>
-                    <DataTemplate>
-                        <TextCell Text="{Binding Title}" Detail="{Binding Number}"></TextCell>
-                    </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
-
-            <Picker x:Name="Platforms" Title="Platforms" SelectedIndex="0" HorizontalOptions="FillAndExpand">
-              <Picker.Items>
-                <x:String>Android</x:String>
-                <x:String>IOS</x:String>
-              </Picker.Items>
-            </Picker>
-
-            <Button Text="Add contract" Clicked="AddContractButton_OnClicked"/>
-            <Button Text="Subscribe Live Service" Clicked="SubscribeLiveService_OnClicked"/>
-            <Button Text="Unsubscribe Live Service" Clicked="UnsubscribeLiveService_OnClicked"/>
-            <Button Text="Register push" Clicked="RegisterPush_OnClickedAsync"/>
-            <Button Text="Unregister push" Clicked="UnregisterPush_OnClickedAsync"/>
+        <StackLayout Spacing="20" Padding="10">
+            <Label x:Name="UserLabel" Text="Hello!" HorizontalOptions="Center" Margin="0,50,0,0" />
+            <StackLayout>
+                <Label Text="Live Service" HorizontalOptions="Center"/>
+                <Button Text="Subscribe Live Service" Clicked="SubscribeLiveService_OnClicked"/>
+                <Button Text="Unsubscribe Live Service" Clicked="UnsubscribeLiveService_OnClicked"/>
+            </StackLayout>
+            <StackLayout>
+                <Label Text="Push Notifications" HorizontalOptions="Center"/>
+                <Picker x:Name="Platforms" SelectedIndex="0" HorizontalOptions="FillAndExpand" VerticalOptions="End">
+                    <Picker.Items>
+                    <x:String>FCMService</x:String>
+                    <x:String>IOSPushService</x:String>
+                    </Picker.Items>
+                </Picker>
+                <Button Text="Register push" Clicked="RegisterPush_OnClickedAsync"/>
+                <Button Text="Unregister push" Clicked="UnregisterPush_OnClickedAsync"/>
+            </StackLayout>
+            <StackLayout>
+                <Label Text="Custom Endpoints" HorizontalOptions="Center"/>
+                <Button Text="Call CustomEndpoint Test -> Hello" Clicked="CustomEndpointTestHello_OnClickedAsync"/>
+                <Button Text="Call CustomEndpoint Test -> Error" Clicked="CustomEndpointTestError_OnClickedAsync"/>
+            </StackLayout>
+            <StackLayout HeightRequest="200">
+                <Label Text="Contracts Collection" HorizontalOptions="Center"/>
+                <Button Text="Add New Record" Clicked="AddContractButton_OnClicked"/>
+                <ListView x:Name="ContractsList">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <TextCell Text="{Binding Title}" Detail="{Binding Number}"></TextCell>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+            </StackLayout>
         </StackLayout>
     </pages:BasePage.Content>
 </pages:BasePage>

--- a/Kinvey.TestApp.Shared/Pages/ContractsPage.xaml.cs
+++ b/Kinvey.TestApp.Shared/Pages/ContractsPage.xaml.cs
@@ -6,6 +6,7 @@ using Plugin.Connectivity;
 using System.Linq;
 using Kinvey.TestApp.Shared.Interfaces;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
 
 namespace Kinvey.TestApp.Shared.Pages
 {
@@ -180,6 +181,40 @@ namespace Kinvey.TestApp.Shared.Pages
                     break;
                 default:
                     throw new Exception("Wrong index.");
+            }
+        }
+
+        private async void CustomEndpointTestHello_OnClickedAsync(object sender, EventArgs e)
+        {
+            var requestBody = new JObject();
+            var customEndpoint = Client.SharedClient.CustomEndpoint<JObject, JObject>();
+
+            try
+            {
+                var result = await customEndpoint.ExecuteCustomEndpoint("test", requestBody);
+
+                await DisplayMessage("Response", result.ToString());
+            }
+            catch (KinveyException ex)
+            {
+                await DisplayMessage("Exception", ex.Message);
+            }
+        }
+
+        private async void CustomEndpointTestError_OnClickedAsync(object sender, EventArgs e)
+        {
+            var requestBody = new JObject();
+            var customEndpoint = Client.SharedClient.CustomEndpoint<JObject, JObject>();
+
+            try
+            {
+                var result = await customEndpoint.ExecuteCustomEndpoint("test_error", requestBody);
+
+                await DisplayMessage("Response", result.ToString());
+            }
+            catch (KinveyException ex)
+            {
+                await DisplayMessage("Exception", ex.Message);
             }
         }
     }


### PR DESCRIPTION
Prior dotnet core `3.0` the `EnsureSuccessStatusCode` disposes the content:
https://github.com/dotnet/corefx/blob/release/2.2/src/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs#L164

The new implementation simply throws:
https://github.com/dotnet/corefx/blob/release/3.0/src/System.Net.Http/src/System/Net/Http/HttpResponseMessage.cs#L172

Since the SDK raises KinveyException after a failed status code check the response is already disposed and the error info cannot be obtained.

Changes:
* Use an extension method which resembles the dotnet core 3+ implementation of `EnsureSuccessStatusCode`.
* Update TestApp for CustomEndpoint tests