### PR TITLE
KDEV-803: Return all errors when saving multiple entities

### DIFF
--- a/Kinvey.Shared/Store/MultiInsertRequest.cs
+++ b/Kinvey.Shared/Store/MultiInsertRequest.cs
@@ -80,14 +80,11 @@ namespace Kinvey
                         }
                     }
 
-                    ThrowExceptionIfOnlyErrors(kinveyDataStoreResponse, EnumErrorCategory.ERROR_DATASTORE_CACHE, EnumErrorCode.ERROR_DATASTORE_CACHE_MULTIPLE_SAVE);
-
                     break;
 
                 case WritePolicy.FORCE_NETWORK:
                     // network
                     kinveyDataStoreResponse = await HandleNetworkRequestAsync(entities).ConfigureAwait(false);
-                    ThrowExceptionIfOnlyErrors(kinveyDataStoreResponse, EnumErrorCategory.ERROR_BACKEND, EnumErrorCode.ERROR_JSON_RESPONSE);
                     break;
 
                 case WritePolicy.LOCAL_THEN_NETWORK:
@@ -117,8 +114,6 @@ namespace Kinvey
                             kinveyDataStoreResponse.Errors.Add(error);
                         }
                     }
-
-                    ThrowExceptionIfOnlyErrors(kinveyDataStoreResponse, EnumErrorCategory.ERROR_DATASTORE_CACHE, EnumErrorCode.ERROR_DATASTORE_CACHE_MULTIPLE_SAVE);
 
                     KinveyException kinveyException = null;
                     Exception exception = null;
@@ -184,8 +179,6 @@ namespace Kinvey
 
                         kinveyDataStoreResponse = kinveyDataStoreNetworkResponse;                        
                     }
-
-                    ThrowExceptionIfOnlyErrors(kinveyDataStoreResponse, EnumErrorCategory.ERROR_BACKEND, EnumErrorCode.ERROR_JSON_RESPONSE);
 
                     break;
 
@@ -386,14 +379,6 @@ namespace Kinvey
             }
 
             return response;
-        }
-
-        private void ThrowExceptionIfOnlyErrors(KinveyMultiInsertResponse<T> kinveyDataStoreResponse, EnumErrorCategory errorCategory, EnumErrorCode errorCode)
-        {
-            if (kinveyDataStoreResponse.Entities.All(e => e == null) && kinveyDataStoreResponse.Errors.Count > 0)
-            {
-                throw new KinveyException(errorCategory, errorCode, kinveyDataStoreResponse.Errors[0].Errmsg);
-            }
         }
     }
 }

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -575,7 +575,7 @@ namespace Kinvey.Tests
                     {
                         ["index"] = index,
                         ["code"] = 1,
-                        ["errmsg"] = jObjects[index]["name"].ToString()
+                        ["error"] = jObjects[index]["name"].ToString()
                     };
 
                     jObjectErrors.Add(jObjectError);
@@ -591,7 +591,7 @@ namespace Kinvey.Tests
                     {
                         ["index"] = index,
                         ["code"] = 1,
-                        ["errmsg"] = "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90"
+                        ["error"] = "Geolocation points must be in the form [longitude, latitude] with long between -180 and 180, lat between -90 and 90"
                     };
 
                     jObjectErrors.Add(jObjectError);

--- a/Kinvey.Tests/BaseTestClass.cs
+++ b/Kinvey.Tests/BaseTestClass.cs
@@ -557,9 +557,17 @@ namespace Kinvey.Tests
                 return;
             }
 
+            var testSetupErrors = new[] {
+                TestSetup.entity_name_for_400_response_error,
+                TestSetup.entity_name_for_403_response_error,
+                TestSetup.entity_name_for_404_response_error,
+                TestSetup.entity_name_for_409_response_error,
+                TestSetup.entity_name_for_500_response_error,
+            };
+
             for(var index = 0; index < jObjects.Count; index ++)
             {
-                if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_name_for_400_response_error))
+                if (jObjects[index]["name"] != null && testSetupErrors.Any(err => err == jObjects[index]["name"].ToString()))
                 {
                     jObjectsToSave.Add(null);
 
@@ -567,73 +575,13 @@ namespace Kinvey.Tests
                     {
                         ["index"] = index,
                         ["code"] = 1,
-                        ["errmsg"] = "Error"
+                        ["errmsg"] = jObjects[index]["name"].ToString()
                     };
 
                     jObjectErrors.Add(jObjectError);
 
                     continue;
 
-                }
-                else if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_name_for_403_response_error))
-                {
-                    jObjectsToSave.Add(null);
-
-                    var jObjectError = new JObject
-                    {
-                        ["index"] = index,
-                        ["code"] = 1,
-                        ["errmsg"] = "Error"
-                    };
-
-                    jObjectErrors.Add(jObjectError);
-
-                    continue;
-                }
-                else if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_name_for_404_response_error))
-                {
-                    jObjectsToSave.Add(null);
-
-                    var jObjectError = new JObject
-                    {
-                        ["index"] = index,
-                        ["code"] = 1,
-                        ["errmsg"] = "Error"
-                    };
-
-                    jObjectErrors.Add(jObjectError);
-
-                    continue;
-                }
-                else if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_name_for_409_response_error))
-                {
-                    jObjectsToSave.Add(null);
-
-                    var jObjectError = new JObject
-                    {
-                        ["index"] = index,
-                        ["code"] = 1,
-                        ["errmsg"] = "Error"
-                    };
-
-                    jObjectErrors.Add(jObjectError);
-
-                    continue;
-                }
-                else if (jObjects[index]["name"] != null && jObjects[index]["name"].ToString().Equals(TestSetup.entity_name_for_500_response_error))
-                {
-                    jObjectsToSave.Add(null);
-
-                    var jObjectError = new JObject
-                    {
-                        ["index"] = index,
-                        ["code"] = 1,
-                        ["errmsg"] = "Error"
-                    };
-
-                    jObjectErrors.Add(jObjectError);
-
-                    continue;
                 }
                 else if (jObjects[index]["_geoloc"] != null && !IsValidGeolocation(jObjects[index]["_geoloc"].ToString()))
                 {
@@ -656,12 +604,6 @@ namespace Kinvey.Tests
                     items.Add(jObjects[index]);
                     jObjectsToSave.Add(jObjects[index]);
                 }
-            }
-
-            if(!jObjectsToSave.Any(j=> j != null) && jObjectErrors.Count > 0)
-            {
-                MockInternal(context);
-                return;
             }
 
             var multiInsertResultJsonObject = new JObject

--- a/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreAutoIntegrationTests.cs
@@ -6758,7 +6758,7 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowingNetworkExceptionAsync()
+        public async Task TestSaveMultiInsertNetworkStoreWithErrorsAsync()
         {
             if (MockData)
             {
@@ -6779,16 +6779,13 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual(response.Errors[0].Errmsg, TestSetup.entity_name_for_400_response_error);
             }
         }
 
@@ -6988,7 +6985,7 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowingLocalExceptionAsync()
+        public async Task TestSaveMultiInsertAutoStoreWithErrorsAsync()
         {
             // Setup
             kinveyClient = BuildClient("5");
@@ -7009,16 +7006,13 @@ namespace Kinvey.Tests
             };
 
             // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStore.SaveAsync(toDos);
-            });
+            var response = await todoStore.SaveAsync(toDos);
 
             // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_CACHE, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_CACHE_MULTIPLE_SAVE, kinveyException.ErrorCode);
+            Assert.AreEqual(toDos.Count, response.Entities.Count);
+            Assert.IsTrue(response.Entities.All(e => e == null));
+            Assert.AreEqual(toDos.Count, response.Errors.Count);
+            Assert.AreEqual("Value cannot be null. (Parameter 'o')", response.Errors[0].Errmsg);
         }
 
         [TestMethod]

--- a/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreNetworkIntegrationTests.cs
@@ -7217,16 +7217,13 @@ namespace Kinvey.Tests
             };
 
             // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStoreNetwork.SaveAsync(toDos);
-            });
+            var response = await todoStoreNetwork.SaveAsync(toDos);
 
             // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+            Assert.AreEqual(toDos.Count, response.Entities.Count);
+            Assert.IsTrue(response.Entities.All(e => e == null));
+            Assert.AreEqual(toDos.Count, response.Errors.Count);
+            Assert.AreEqual("Response status code does not indicate success: 401 (Unauthorized).", response.Errors[0].Errmsg);
         }
 
         [TestMethod]
@@ -7265,7 +7262,7 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing400ErrorResponseInMultiInsertAsync()
+        public async Task TestSaveMultiInsertWith400ErrorResponseInMultiInsertAsync()
         {
             if (MockData)
             {
@@ -7286,21 +7283,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual(TestSetup.entity_name_for_400_response_error, response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing400ErrorResponseInUpdateAsync()
+        public async Task TestSaveMultiInsertWith400ErrorResponseInUpdateAsync()
         {
             if (MockData)
             {
@@ -7321,21 +7315,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual("Response status code does not indicate success: 400 (Bad Request).", response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing403ErrorResponseInMultiInsertAsync()
+        public async Task TestSaveMultiInsertWith403ErrorResponseInMultiInsertAsync()
         {
             if (MockData)
             {
@@ -7356,21 +7347,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual(TestSetup.entity_name_for_403_response_error, response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing403ErrorResponseInUpdateAsync()
+        public async Task TestSaveMultiInsertWith403ErrorResponseInUpdateAsync()
         {
             if (MockData)
             {
@@ -7390,21 +7378,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual("Response status code does not indicate success: 403 (Forbidden).", response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing404ErrorResponseInMultiInsertAsync()
+        public async Task TestSaveMultiInsertWith404ErrorResponseInMultiInsertAsync()
         {
             if (MockData)
             {
@@ -7425,21 +7410,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual(TestSetup.entity_name_for_404_response_error, response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing404ErrorResponseInUpdateAsync()
+        public async Task TestSaveMultiInsertWith404ErrorResponseInUpdateAsync()
         {
             if (MockData)
             {
@@ -7459,21 +7441,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual("Response status code does not indicate success: 404 (Not Found).", response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing409ErrorResponseInMultiInsertAsync()
+        public async Task TestSaveMultiInsertWith409ErrorResponseInMultiInsertAsync()
         {
             if (MockData)
             {
@@ -7494,21 +7473,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual(TestSetup.entity_name_for_409_response_error, response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing409ErrorResponseInUpdateAsync()
+        public async Task TestSaveMultiInsertWith409ErrorResponseInUpdateAsync()
         {
             if (MockData)
             {
@@ -7528,21 +7504,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual("Response status code does not indicate success: 409 (Conflict).", response.Errors[0].Errmsg);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing500ErrorResponseInMultiInsertAsync()
+        public async Task TestSaveMultiInsertWith500ErrorResponseInMultiInsertAsync()
         {
             if (MockData)
             {
@@ -7563,21 +7536,18 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual(response.Errors[0].Errmsg, TestSetup.entity_name_for_500_response_error);
             }
         }
 
         [TestMethod]
-        public async Task TestSaveMultiInsertThrowing500ErrorResponseInUpdateAsync()
+        public async Task TestSaveMultiInsertWith500ErrorAsync()
         {
             if (MockData)
             {
@@ -7597,16 +7567,13 @@ namespace Kinvey.Tests
                 };
 
                 // Act
-                var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-                {
-                    await todoStoreNetwork.SaveAsync(toDos);
-                });
+                var response = await todoStoreNetwork.SaveAsync(toDos);
 
                 // Assert
-                Assert.AreEqual(typeof(KinveyException), exception.GetType());
-                var kinveyException = exception as KinveyException;
-                Assert.AreEqual(EnumErrorCategory.ERROR_BACKEND, kinveyException.ErrorCategory);
-                Assert.AreEqual(EnumErrorCode.ERROR_JSON_RESPONSE, kinveyException.ErrorCode);
+                Assert.AreEqual(toDos.Count, response.Entities.Count);
+                Assert.IsTrue(response.Entities.All(e => e == null));
+                Assert.AreEqual(toDos.Count, response.Errors.Count);
+                Assert.AreEqual("Response status code does not indicate success: 500 (Internal Server Error).", response.Errors[0].Errmsg);
             }
         }
 

--- a/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
+++ b/Kinvey.Tests/DataStoreTests/DataStoreSyncIntegrationTests.cs
@@ -6149,7 +6149,7 @@ namespace Kinvey.Tests
         }
 
         [TestMethod]
-        public async Task TestSyncStoreSaveMultiInsertThrowingExceptionAsync()
+        public async Task TestSyncStoreSaveMultiInsertWithErrorAsync()
         {
             // Setup
             kinveyClient = BuildClient("5");
@@ -6170,16 +6170,13 @@ namespace Kinvey.Tests
             };
 
             // Act
-            var exception = await Assert.ThrowsExceptionAsync<KinveyException>(async delegate
-            {
-                await todoStore.SaveAsync(toDos);
-            });
+            var response = await todoStore.SaveAsync(toDos);
 
             // Assert
-            Assert.AreEqual(typeof(KinveyException), exception.GetType());
-            var kinveyException = exception as KinveyException;
-            Assert.AreEqual(EnumErrorCategory.ERROR_DATASTORE_CACHE, kinveyException.ErrorCategory);
-            Assert.AreEqual(EnumErrorCode.ERROR_DATASTORE_CACHE_MULTIPLE_SAVE, kinveyException.ErrorCode);
+            Assert.AreEqual(toDos.Count, response.Entities.Count);
+            Assert.IsTrue(response.Entities.All(e => e == null));
+            Assert.AreEqual(toDos.Count, response.Errors.Count);
+            Assert.AreEqual("Value cannot be null. (Parameter 'o')", response.Errors[0].Errmsg);
         }
 
         #endregion Save


### PR DESCRIPTION
## Breaking Changes:
* Always return all errors when making a save of multiple entities. Previously we checked if there were only errors in the response and threw an Exception. Now the request will return a response which contain only errors.